### PR TITLE
Kernel S1: runtime, identity Context, operation_lookup, alignment_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ AUTHENTICATION_BACKENDS = (
 ```
 
 Import concrete models from ``trusts.zero.models``. Kernel APIs stay
-``trusts.context``, ``trusts.trustee``, and ``trusts.path``. This
-package does not ship ``trusts/zero``.
+``trusts.context``, ``trusts.trustee``, ``trusts.path``, ``trusts.runtime``,
+and ``trusts.query``. This package does not ship ``trusts/zero``.
 
 API and compatibility notes for this modernization are in [migrates.md](migrates.md).
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -20,6 +20,10 @@ installable `trusts/` package:
 - `tests/core/test_gh_vocab.py` — issue #43 GH-shaped private proof
   (`Account` / `Organization` / `Team` / `PermissionBundle` / `Policy` /
   `Repository`; `account.teams` membership vs organization containment)
+- `tests/core/test_s1_kernel.py` — issue #47 S1 runtime / queryset /
+  identity Context / `operation_lookup` / `alignment_paths` / `compose_scope`
+  (isolated registries; object≡list; one-query; cross-org and NULL
+  alignment deny; registration traps)
 - `tests/core/test_zero_path.py` — issue #43 Step 2 Zero consumer of compose
   (`ContentQuerySet.permitted` / `TrustModelBackend`; same-PK fail-closed)
 - `tests/core/test_kernel_split.py` — issue #43 Step 3 kernel/Zero AppConfig,
@@ -28,7 +32,8 @@ installable `trusts/` package:
 - `python -m tests.runtests` — discovers the core and regression modules
   by explicit labels (`tests.core.test_core`, `tests.core.test_context`,
   `tests.core.test_trustee`, `tests.core.test_path`,
-  `tests.core.test_gh_vocab`, `tests.core.test_zero_path`,
+  `tests.core.test_gh_vocab`, `tests.core.test_s1_kernel`,
+  `tests.core.test_zero_path`,
   `tests.core.test_kernel_split`, `tests.core.test_wheel_install`,
   `tests.regressions.test_issue_*`)
 - `python -m tests.runtests_custom` — isolated custom-user suite

--- a/migrates.md
+++ b/migrates.md
@@ -1978,8 +1978,9 @@ argument order.
 Object decisions and authorized querysets compile from the same frozen
 `AuthorizationPath.grant_q`. String operations compile as
 `operation_path__lookup` inside that `Exists` when
-`Trustee.operation_lookup` is set. There is no preliminary
-`Operation.objects.get()`.
+`Trustee.operation_lookup` is set. Strings are prepared through that
+field; an unpreparable value is an always-false predicate. There is no
+preliminary `Operation.objects.get()`.
 
 `alignment_paths` are grant-row equalities, AND-ed into that adapter's
 `Exists` with `F()` and non-NULL on both sides. They are not
@@ -2012,10 +2013,10 @@ NULL or mismatched identities deny at read time.
 | | |
 | --- | --- |
 | Previous | `grant_q` required an operation-model *instance*. |
-| New | `Trustee.configure(..., operation_lookup='code')` (unique scalar on `operation_model`). Strings compile as `{operation_path__lookup: value}` inside the same `Exists`. Unknown codes deny (match nothing). Missing lookup + string is `AuthorizationConfigError` on direct APIs. |
+| New | `Trustee.configure(..., operation_lookup='code')` (unique scalar on `operation_model`, including non-text fields such as `id`). Strings are prepared through the lookup field (no `get()`) and compile as `{operation_path__lookup: prepared}` inside the same `Exists`. Unknown codes and values the field cannot accept (for example `operation_lookup='id'` plus `'missing'`) deny via an always-false predicate. Missing lookup + string is `AuthorizationConfigError` on direct APIs. |
 | Replacement | Prefer instances, or configure a unique lookup. Zero does not have to use this (`auth.Permission.codename` is not unique alone). |
 | Affected | New kernel consumers that want `'read'`-style operations. |
-| Authorization | One SQL statement for supported object/list decisions. No preliminary `get()`. |
+| Authorization | One SQL statement for supported object/list decisions. Unpreparable string data is ordinary denial, not `ValueError` / `FieldError`. No preliminary `get()`. |
 
 ### 41. Trustee `alignment_paths` (new, optional)
 

--- a/migrates.md
+++ b/migrates.md
@@ -1946,3 +1946,140 @@ Already-applied 0001+0002: `migrate --plan` for `trusts` is empty.
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #43 from this PR.
 
+# Issue #47 S1: runtime, queryset, identity, alignment (1.0.0.dev0)
+
+This record covers the first kernel execution slice. Version remains
+**1.0.0.dev0**. This PR does **not** close
+[#47](https://github.com/django-trusts/django-trusts/issues/47); review
+owns that. It implements accepted **framework-execution-r1+r2+r3**
+kernel S1 only. It does **not** modify `django-trusts-zero`, start
+gh-permissions#1, resume #17, or implement S2 backend / S3 decorators /
+S4 UI.
+
+## Decision
+
+```text
+trusts.context: register_direct / register_related / register_identity
+trusts.trustee: configure(..., operation_lookup=) / register(..., alignment_paths=)
+trusts.path: compose / compose_scope
+trusts.runtime:
+  AuthorizationDenied, AuthorizationConfigError
+  is_authorized / require_authorized / filter_authorized / authorized_q
+  is_scope_authorized / require_scope_authorized / filter_authorized_scope / authorized_scope_q
+  (no configure_runtime, no all_authorized, no public scope_from_row)
+trusts.query: AuthorizedQuerySet.authorized / AuthorizedManager
+```
+
+The queryset class name is **`AuthorizedQuerySet`** (not
+`AuthorizationQuerySet`). That is the r1/r2 name: `authorized` is the
+neutral verb, and Zero keeps `permitted` with its Django-permission
+argument order.
+
+Object decisions and authorized querysets compile from the same frozen
+`AuthorizationPath.grant_q`. String operations compile as
+`operation_path__lookup` inside that `Exists` when
+`Trustee.operation_lookup` is set. There is no preliminary
+`Operation.objects.get()`.
+
+`alignment_paths` are grant-row equalities, AND-ed into that adapter's
+`Exists` with `F()` and non-NULL on both sides. They are not
+`constraint_paths` (those still terminate at the operation model).
+NULL or mismatched identities deny at read time.
+
+## No change to these public call sites
+
+- `Context.register_direct` / `register_related`
+- `Trustee.register` without `alignment_paths` (default `()`)
+- `Trustee.configure` without `operation_lookup` (default unset)
+- `AuthorizationPath.compose` / `filter_granted` / `row_is_granted`
+- Zero `ContentQuerySet.permitted`, `TrustModelBackend`, decorators,
+  admin, views, historical migrations, app label `trusts`
+
+## Changes
+
+### 39. `Context.register_identity` (new)
+
+| | |
+| --- | --- |
+| Previous | Resource→scope required `register_direct` (a real field) or `register_related`. |
+| New | `register_identity(model)` registers a resource that *is* its policy scope. Kind `identity`. Compiled `scope_path` is the empty string. |
+| Replacement | Use identity when the row is the scope (for example a repository that is also the grant scope). Do not fake a field on `register_direct`. |
+| Affected | New kernel consumers. Zero still uses `register_direct` / `register_related`. |
+| Authorization | Identity `compose(Model, op)` uses grant `scope_path` → row `pk`. Same predicate as list/`exists`. |
+
+### 40. Trustee `operation_lookup` (new, optional)
+
+| | |
+| --- | --- |
+| Previous | `grant_q` required an operation-model *instance*. |
+| New | `Trustee.configure(..., operation_lookup='code')` (unique scalar on `operation_model`). Strings compile as `{operation_path__lookup: value}` inside the same `Exists`. Unknown codes deny (match nothing). Missing lookup + string is `AuthorizationConfigError` on direct APIs. |
+| Replacement | Prefer instances, or configure a unique lookup. Zero does not have to use this (`auth.Permission.codename` is not unique alone). |
+| Affected | New kernel consumers that want `'read'`-style operations. |
+| Authorization | One SQL statement for supported object/list decisions. No preliminary `get()`. |
+
+### 41. Trustee `alignment_paths` (new, optional)
+
+| | |
+| --- | --- |
+| Previous | Extra grant constraints had to be operation-terminal `constraint_paths` or write-time integrity. |
+| New | `register(..., alignment_paths=(('team__organization', 'repository__organization'),))`. Each pair is grant-origin, single-valued, compatible FK or scalar identity. AND-ed with `F()` + `__isnull=False`. Default `()`. Copied onto `AuthorizationBranch`. `equivalent` / `revalidate` / `trusts.E007` include it. |
+| Replacement | Do **not** overload `constraint_paths`. Those still walk grant → operation model. |
+| Affected | Any consumer that must refuse malformed/cross-terminal grant rows at read time. |
+| Authorization | Cross-org or NULL-org grant rows deny even when membership, operation, and bundle ceiling hold. Adapters still OR only as complete paths. Read-time alignment is the security boundary. |
+
+### 42. `AuthorizationPath.compose_scope` (new)
+
+| | |
+| --- | --- |
+| Previous | `compose()` always required a Context resource hop. Scope-is-row was an empty-string back-channel. |
+| New | `compose_scope(scope_model, operation, ...)` when the queryset/row *is* `Trustee.scope_model()`. No Context adapter. No public `scope_from_row`. |
+| Replacement | Resource listings: `compose` / `filter_authorized`. Scope listings: `compose_scope` / `filter_authorized_scope`. |
+| Affected | Create-under-scope listings. Zero `trust_grant_q` can wrap `authorized_scope_q` later. |
+| Authorization | Same grant `Exists` as resource-origin, including `alignment_paths`. |
+
+### 43. `trusts.runtime` and `trusts.query` (new)
+
+| | |
+| --- | --- |
+| Previous | Consumers wrote their own exists/list helpers on top of `compose`. |
+| New | `is_authorized` / `require_authorized` / `filter_authorized` / `authorized_q` and scope-origin siblings. `AuthorizedQuerySet.authorized` / `AuthorizedManager`. |
+| Replacement | Call these instead of copying `grant_q`. Isolated tests pass `context=` / `trustee=`. |
+| Affected | New kernel consumers. Zero wrappers are a later follow-up. |
+| Authorization | Unusable principal / unknown operation *data* deny. Unregistered resource, no adapters, raw PK, wrong concrete model, mixed/stale terminals, reserved slot, incomplete `operation_lookup` raise `AuthorizationConfigError`. `require_*` raises `AuthorizationDenied` only for ordinary denials. Equivalence: `is_authorized(p, op, obj)` == `exists()` of the same `Q` as `filter_authorized`. One query each. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m tests.runtests
+```
+
+No Trusts schema migration. Test-only `trusts_tests.0007_s1_kernel` adds
+isolated S1 models.
+
+## Upgrade of a representative legacy database
+
+Unchanged. `scripts/verify-legacy-upgrade.py` still expects
+`{0001_initial, 0002_trustgroup}` on label `trusts`.
+
+## Out of scope (unchanged)
+
+- S2 `ObjectAuthorizationBackend` / S3 decorators / S4 admin/CBV/templates
+- Generic `register_row_condition`
+- `RecursiveEdge` / `OrderedContribution`
+- django-trusts-zero wrappers or pin bump
+- gh-permissions#1
+- Closing #17 or #47
+
+## Migration-bot summary (issue #47 S1)
+
+- [ ] Register identity resources with `Context.register_identity`.
+- [ ] Configure `Trustee.operation_lookup` if you pass operation strings.
+- [ ] Declare org/identity equalities as `alignment_paths`, not `constraint_paths`.
+- [ ] Use `compose_scope` / `filter_authorized_scope` when the row is the scope.
+- [ ] Catch `AuthorizationConfigError` only at security boundaries.
+- [ ] Attach `AuthorizedManager` (class name `AuthorizedQuerySet`) if you want `.authorized()`.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_s1_kernel`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #47 from this PR.
+

--- a/migrates.md
+++ b/migrates.md
@@ -2045,7 +2045,7 @@ NULL or mismatched identities deny at read time.
 | New | `is_authorized` / `require_authorized` / `filter_authorized` / `authorized_q` and scope-origin siblings. `AuthorizedQuerySet.authorized` / `AuthorizedManager`. |
 | Replacement | Call these instead of copying `grant_q`. Isolated tests pass `context=` / `trustee=`. |
 | Affected | New kernel consumers. Zero wrappers are a later follow-up. |
-| Authorization | Unusable principal / unknown operation *data* deny. Unregistered resource, no adapters, raw PK, wrong concrete model, mixed/stale terminals, reserved slot, incomplete `operation_lookup` raise `AuthorizationConfigError`. `require_*` raises `AuthorizationDenied` only for ordinary denials. Equivalence: `is_authorized(p, op, obj)` == `exists()` of the same `Q` as `filter_authorized`. One query each. |
+| Authorization | Explicitly unusable principal (`is_anonymous is True`, `is_authenticated is False`, or `is_active is False`, including Django `AnonymousUser`) and unknown operation *data* deny. Unusable flags are checked **before** requester-model identity so `AnonymousUser` is an ordinary denial, not `AuthorizationConfigError`. Unregistered resource, no adapters, raw PK, *usable* wrong concrete model, mixed/stale terminals, reserved slot, incomplete `operation_lookup` raise `AuthorizationConfigError`. `require_*` raises `AuthorizationDenied` only for ordinary denials. Equivalence: `is_authorized(p, op, obj)` == `exists()` of the same `Q` as `filter_authorized`. One query each. |
 
 ## Fresh database
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -25,6 +25,7 @@ from trusts.checks import (
 )
 from trusts.context import (
     KIND_DIRECT,
+    KIND_IDENTITY,
     KIND_RELATED,
     Context,
     ContextAdapter,
@@ -74,6 +75,7 @@ class ContextReusableLayerTest(TestCase):
         self.assertIs(Imported, Context)
         self.assertIs(PublicJunction, Junction)
         self.assertTrue(issubclass(TestGroupJunction, Junction))
+        self.assertEqual(Context.KIND_IDENTITY, KIND_IDENTITY)
 
 
 class ContextRegistryContractTest(TestCase):

--- a/tests/core/test_path.py
+++ b/tests/core/test_path.py
@@ -20,6 +20,7 @@ from trusts.path import (
     OrderedContribution,
     RecursiveEdge,
     compose,
+    compose_scope,
     empty_grant_q,
     filter_granted,
     row_is_granted,
@@ -71,6 +72,7 @@ class AuthorizationPathReusableLayerTest(TestCase):
         self.assertIs(Imported, AuthorizationPath)
         self.assertIs(ImportedBranch, AuthorizationBranch)
         self.assertTrue(callable(compose))
+        self.assertTrue(callable(compose_scope))
         self.assertTrue(callable(row_is_granted))
         self.assertTrue(callable(filter_granted))
 

--- a/tests/core/test_s1_kernel.py
+++ b/tests/core/test_s1_kernel.py
@@ -6,6 +6,7 @@ registries only. Does not close #47. Does not implement S2–S4.
 """
 
 import inspect
+import re
 from pathlib import Path
 
 from django.core.checks import Error
@@ -120,7 +121,12 @@ class S1ReusableLayerTest(TestCase):
         for module in (runtime, query):
             source = Path(inspect.getfile(module)).read_text()
             for noun in ('Trust', 'Content', 'Junction', 'GitHub'):
-                self.assertNotIn(noun, source)
+                self.assertIsNone(
+                    re.search(r'\b%s\b' % noun, source),
+                    '%r appears as a product noun in %s' % (
+                        noun, module.__name__,
+                    ),
+                )
 
     def test_authorized_queryset_name_is_the_r1_choice(self):
         self.assertEqual(AuthorizedQuerySet.__name__, 'AuthorizedQuerySet')

--- a/tests/core/test_s1_kernel.py
+++ b/tests/core/test_s1_kernel.py
@@ -9,6 +9,7 @@ import inspect
 import re
 from pathlib import Path
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.checks import Error
 from django.db import models
 from django.db.models import UniqueConstraint
@@ -29,6 +30,7 @@ from trusts.path import (
     AuthorizationPathError,
     compose,
     compose_scope,
+    empty_grant_q,
 )
 from trusts.query import AuthorizedManager, AuthorizedQuerySet
 from trusts.runtime import (
@@ -681,6 +683,52 @@ class S1RuntimeConfigTest(TransactionTestCase):
     def test_missing_flags_are_usable(self):
         self.assertTrue(principal_is_usable(self.account))
 
+    def test_anonymous_user_takes_ordinary_denial_path(self):
+        principal = AnonymousUser()
+        self.assertFalse(principal_is_usable(principal))
+
+        with self.assertNumQueries(0):
+            self.assertFalse(
+                is_authorized(principal, 'read', self.repo, **self.runtime)
+            )
+            self.assertFalse(
+                is_scope_authorized(
+                    principal, 'read', self.repo, trustee=self.trustee,
+                )
+            )
+
+        with self.assertNumQueries(0):
+            filtered = filter_authorized(
+                S1Repository.objects.all(), principal, 'read', **self.runtime,
+            )
+            self.assertTrue(filtered.query.is_empty())
+            self.assertEqual(list(filtered), [])
+            scoped = filter_authorized_scope(
+                S1Repository.objects.all(), principal, 'read',
+                trustee=self.trustee,
+            )
+            self.assertTrue(scoped.query.is_empty())
+            self.assertEqual(list(scoped), [])
+
+        with self.assertNumQueries(0):
+            with self.assertRaises(AuthorizationDenied):
+                require_authorized(
+                    principal, 'read', self.repo, **self.runtime,
+                )
+            with self.assertRaises(AuthorizationDenied):
+                require_scope_authorized(
+                    principal, 'read', self.repo, trustee=self.trustee,
+                )
+
+        empty = authorized_q(
+            S1Repository, principal, 'read', **self.runtime,
+        )
+        empty_scope = authorized_scope_q(
+            S1Repository, principal, 'read', trustee=self.trustee,
+        )
+        self.assertEqual(str(empty), str(empty_grant_q()))
+        self.assertEqual(str(empty_scope), str(empty_grant_q()))
+
     def test_wrong_model_and_raw_pk_are_config_errors(self):
         with self.assertRaises(AuthorizationConfigError):
             is_authorized(self.repo, 'read', self.repo, **self.runtime)
@@ -691,6 +739,14 @@ class S1RuntimeConfigTest(TransactionTestCase):
         with self.assertRaises(AuthorizationConfigError):
             filter_authorized(
                 S1Repository.objects.all(), self.repo, 'read', **self.runtime,
+            )
+        with self.assertRaises(AuthorizationConfigError):
+            is_scope_authorized(
+                self.repo, 'read', self.repo, trustee=self.trustee,
+            )
+        with self.assertRaises(AuthorizationConfigError):
+            is_scope_authorized(
+                self.account.pk, 'read', self.repo, trustee=self.trustee,
             )
 
     def test_unregistered_resource_and_wrong_queryset_raise(self):

--- a/tests/core/test_s1_kernel.py
+++ b/tests/core/test_s1_kernel.py
@@ -1,0 +1,767 @@
+"""Isolated kernel tests for #47 S1 (framework-execution-r1+r2+r3).
+
+Covers identity Context, Trustee operation_lookup / alignment_paths,
+compose_scope, trusts.runtime, and AuthorizedQuerySet. Isolated
+registries only. Does not close #47. Does not implement S2–S4.
+"""
+
+import inspect
+from pathlib import Path
+
+from django.core.checks import Error
+from django.db import models
+from django.db.models import UniqueConstraint
+from django.test import TestCase, TransactionTestCase
+
+from trusts.checks import CHECK_ID_INVALID_TRUSTEE, check_trustee_registry
+from trusts.context import (
+    KIND_IDENTITY,
+    Context,
+    ContextRegistrationError,
+    ContextRegistry,
+    ContextRegistryFrozen,
+    check_registration as check_context_registration,
+)
+from trusts.path import (
+    AuthorizationBranch,
+    AuthorizationPath,
+    AuthorizationPathError,
+    compose,
+    compose_scope,
+)
+from trusts.query import AuthorizedManager, AuthorizedQuerySet
+from trusts.runtime import (
+    AuthorizationConfigError,
+    AuthorizationDenied,
+    authorized_q,
+    authorized_scope_q,
+    filter_authorized,
+    filter_authorized_scope,
+    is_authorized,
+    is_scope_authorized,
+    principal_is_usable,
+    require_authorized,
+    require_scope_authorized,
+)
+from trusts.trustee import (
+    KIND_GRANT,
+    Trustee,
+    TrusteeAdapter,
+    TrusteeRegistrationError,
+    TrusteeRegistry,
+    TrusteeRegistryFrozen,
+    check_registration as check_trustee_registration,
+)
+from tests.models import (
+    S1Account,
+    S1Bundle,
+    S1DirectGrant,
+    S1Issue,
+    S1Operation,
+    S1Organization,
+    S1Repository,
+    S1Team,
+    S1TeamGrant,
+    S1TrapGrant,
+    S1UnregisteredNote,
+    TrusteeOperation,
+    TrusteeRequester,
+    TrusteeScope,
+)
+
+
+S1_TEAM = 'team'
+S1_DIRECT = 'direct'
+
+
+def _s1_maps(grant_model=None, include_direct=True, alignment=True):
+    """Isolated identity + alignment registries. Never touch process-wide maps."""
+    if grant_model is None:
+        grant_model = S1TeamGrant
+    context = ContextRegistry()
+    context.register_identity(S1Repository)
+    trustee = TrusteeRegistry(
+        requester_model=S1Account,
+        scope_model=S1Repository,
+        operation_model=S1Operation,
+        operation_lookup='code',
+    )
+    alignment_paths = (
+        (('team__organization', 'repository__organization'),)
+        if alignment else ()
+    )
+    trustee.register(
+        name=S1_TEAM,
+        trustee_model=S1Team,
+        grant_model=grant_model,
+        trustee_path='team',
+        scope_path='repository',
+        operation_path='operation',
+        membership_path='members',
+        constraint_paths=('team__bundles__operations',),
+        alignment_paths=alignment_paths,
+    )
+    if include_direct:
+        trustee.register(
+            name=S1_DIRECT,
+            trustee_model=S1Account,
+            grant_model=S1DirectGrant,
+            trustee_path='account',
+            scope_path='repository',
+            operation_path='operation',
+            membership_path='',
+        )
+    return context, trustee
+
+
+class S1ReusableLayerTest(TestCase):
+    def test_runtime_and_query_have_no_product_nouns(self):
+        from trusts import query, runtime
+        for module in (runtime, query):
+            source = Path(inspect.getfile(module)).read_text()
+            for noun in ('Trust', 'Content', 'Junction', 'GitHub'):
+                self.assertNotIn(noun, source)
+
+    def test_authorized_queryset_name_is_the_r1_choice(self):
+        self.assertEqual(AuthorizedQuerySet.__name__, 'AuthorizedQuerySet')
+        self.assertTrue(issubclass(AuthorizedManager, type(S1Repository.objects)))
+        self.assertIsInstance(S1Repository.objects.all(), AuthorizedQuerySet)
+        self.assertTrue(callable(S1Repository.objects.all().authorized))
+
+
+class S1IdentityContextTest(TestCase):
+    def test_register_identity_paths_and_idempotence(self):
+        registry = ContextRegistry()
+        adapter = registry.register_identity(S1Repository)
+        self.assertEqual(adapter.kind, KIND_IDENTITY)
+        self.assertEqual(adapter.scope_path(), '')
+        self.assertEqual(adapter.resource_path(), '')
+        self.assertIs(adapter.scope_model(), S1Repository)
+        self.assertIs(adapter.terminal_model(), S1Repository)
+        again = registry.register_identity(S1Repository)
+        self.assertTrue(again.equivalent(adapter))
+        self.assertIsNone(
+            check_context_registration(S1Repository, KIND_IDENTITY, '')
+        )
+
+    def test_identity_related_joins_without_trailing_separator(self):
+        registry = ContextRegistry()
+        registry.register_identity(S1Repository)
+        registry.register_related(S1Issue, through='repository')
+        self.assertEqual(registry.scope_path(S1Issue), 'repository')
+        self.assertEqual(registry.resource_path(S1Issue), 'issues')
+
+    def test_identity_conflicts_with_direct(self):
+        registry = ContextRegistry()
+        registry.register_identity(S1Repository)
+        with self.assertRaises(ContextRegistrationError):
+            registry.register_direct(S1Repository, scope_field='organization')
+
+    def test_identity_freeze_rejects_late_registration(self):
+        registry = ContextRegistry()
+        registry.register_identity(S1Repository)
+        registry.freeze()
+        with self.assertRaises(ContextRegistryFrozen):
+            registry.register_identity(S1Issue)
+        self.assertFalse(registry.is_registered(S1Issue))
+
+    def test_process_wide_map_does_not_register_s1_identity(self):
+        self.assertFalse(Context.is_registered(S1Repository))
+
+
+class S1OperationLookupTest(TestCase):
+    def test_unique_lookup_configures_and_is_idempotent(self):
+        registry = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        )
+        registry.configure(operation_lookup='code')
+        self.assertEqual(registry.operation_lookup(), 'code')
+        registry.configure(operation_lookup='code')
+        self.assertEqual(registry.operation_lookup(), 'code')
+
+    def test_non_unique_and_relation_lookups_fail(self):
+        class RelOp(models.Model):
+            owner = models.ForeignKey(
+                S1Account, on_delete=models.CASCADE, related_name='+',
+            )
+            label = models.CharField(max_length=16)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        rel = TrusteeRegistry(
+            requester_model=S1Account,
+            operation_model=RelOp,
+        )
+        with self.assertRaises(TrusteeRegistrationError) as ctx:
+            rel.configure(operation_lookup='owner')
+        self.assertIn('unique scalar', str(ctx.exception).lower())
+
+        class NonUniqueOp(models.Model):
+            label = models.CharField(max_length=16)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        bad = TrusteeRegistry(
+            requester_model=S1Account,
+            operation_model=NonUniqueOp,
+        )
+        with self.assertRaises(TrusteeRegistrationError):
+            bad.configure(operation_lookup='label')
+
+    def test_frozen_registry_rejects_lookup_change(self):
+        registry = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='code',
+        )
+        registry.freeze()
+        registry.configure(operation_lookup='code')
+        with self.assertRaises(TrusteeRegistryFrozen):
+            registry.configure(operation_lookup='id')
+
+    def test_unique_constraint_lookup_is_accepted(self):
+        class ConstrainedOp(models.Model):
+            slug = models.CharField(max_length=16)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+                constraints = [
+                    UniqueConstraint(fields=('slug',), name='s1_op_slug'),
+                ]
+
+        registry = TrusteeRegistry(
+            requester_model=S1Account,
+            operation_model=ConstrainedOp,
+            operation_lookup='slug',
+        )
+        self.assertEqual(registry.operation_lookup(), 'slug')
+
+    def test_string_without_lookup_is_config_error_at_compose(self):
+        context, trustee = _s1_maps()
+        trustee._operation_lookup = None
+        with self.assertRaises(AuthorizationPathError):
+            compose(S1Repository, 'read', context=context, trustee=trustee)
+
+
+class S1AlignmentRegistrationTest(TestCase):
+    def test_valid_pair_freezes_on_adapter_and_branch(self):
+        context, trustee = _s1_maps()
+        adapter = trustee.get(S1_TEAM)
+        expected = (('team__organization', 'repository__organization'),)
+        self.assertEqual(adapter.alignment_paths, expected)
+        path = compose(S1Repository, None, context=context, trustee=trustee)
+        team_branch = [b for b in path.branches if b.name == S1_TEAM][0]
+        self.assertIsInstance(team_branch, AuthorizationBranch)
+        self.assertEqual(team_branch.alignment_paths, expected)
+        self.assertIsInstance(team_branch.alignment_paths, tuple)
+        self.assertIsInstance(team_branch.alignment_paths[0], tuple)
+        direct = [b for b in path.branches if b.name == S1_DIRECT][0]
+        self.assertEqual(direct.alignment_paths, ())
+
+    def test_default_empty_alignment_matches_today(self):
+        registry = TrusteeRegistry(
+            requester_model=TrusteeRequester,
+            scope_model=TrusteeScope,
+            operation_model=TrusteeOperation,
+        )
+        from tests.models import TrusteeDirectGrant
+        adapter = registry.register(
+            name='direct',
+            trustee_model=TrusteeRequester,
+            grant_model=TrusteeDirectGrant,
+            trustee_path='requester',
+            scope_path='scope',
+            operation_path='operation',
+        )
+        self.assertEqual(adapter.alignment_paths, ())
+        self.assertTrue(adapter.equivalent(adapter))
+
+    def test_registration_traps(self):
+        registry = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        )
+        base = dict(
+            name=S1_TEAM,
+            trustee_model=S1Team,
+            grant_model=S1TeamGrant,
+            trustee_path='team',
+            scope_path='repository',
+            operation_path='operation',
+            membership_path='members',
+        )
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(**base, alignment_paths=lambda: ())
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(**base, alignment_paths=('team__organization',))
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(**base, alignment_paths=(('team__organization',),))
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(**base, alignment_paths=(('', 'repository__organization'),))
+        with self.assertRaises(TrusteeRegistrationError) as ctx:
+            registry.register(
+                **base,
+                alignment_paths=(('team__name__foo', 'repository__title'),),
+            )
+        self.assertIn('scalar', str(ctx.exception).lower())
+        with self.assertRaises(TrusteeRegistrationError) as ctx:
+            registry.register(
+                **base,
+                alignment_paths=(('team__members', 'repository__organization'),),
+            )
+        self.assertIn('many-valued', str(ctx.exception).lower())
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(
+                **base,
+                alignment_paths=(('missing', 'repository__organization'),),
+            )
+        with self.assertRaises(TrusteeRegistrationError) as ctx:
+            registry.register(
+                **base,
+                alignment_paths=(('team__organization', 'id'),),
+            )
+        self.assertIn('compatible', str(ctx.exception).lower())
+        with self.assertRaises(TrusteeRegistrationError):
+            registry.register(
+                **base,
+                alignment_paths=(('team__organization', 'team'),),
+            )
+        self.assertIsNotNone(check_trustee_registration(
+            S1_TEAM, S1Team, S1TeamGrant, 'team', 'repository', 'operation',
+            membership_path='members',
+            alignment_paths=(('team__organization', 'id'),),
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        ))
+
+    def test_revalidate_and_e007_report_stale_alignment(self):
+        _context, trustee = _s1_maps()
+        saved = trustee.get(S1_TEAM)
+        trustee._adapters[S1_TEAM] = TrusteeAdapter(
+            KIND_GRANT, S1_TEAM, saved.trustee_model, saved.membership_path,
+            saved.grant_model, saved.trustee_path, saved.scope_path,
+            saved.operation_path, saved.constraint_paths, trustee,
+            alignment_paths=(('not_a_field', 'repository__organization'),),
+        )
+        try:
+            with self.assertRaises(TrusteeRegistrationError) as ctx:
+                trustee.revalidate(trustee.get(S1_TEAM))
+            self.assertIn('not a field', str(ctx.exception))
+        finally:
+            trustee._adapters[S1_TEAM] = saved
+
+        from trusts.zero.models import DIRECT_TRUSTEE, TrustUserPermission
+        from trusts.zero.models import prepare_trustee_registry
+        prepare_trustee_registry()
+        process = Trustee.registry
+        process_saved = process._adapters[DIRECT_TRUSTEE]
+        process._adapters[DIRECT_TRUSTEE] = TrusteeAdapter(
+            KIND_GRANT, DIRECT_TRUSTEE, process_saved.trustee_model,
+            process_saved.membership_path, TrustUserPermission,
+            process_saved.trustee_path, process_saved.scope_path,
+            'not_a_field', process_saved.constraint_paths, process,
+            alignment_paths=(('not_a_field', 'trust'),),
+        )
+        try:
+            messages = check_trustee_registry(None)
+            e007 = [m for m in messages if m.id == CHECK_ID_INVALID_TRUSTEE]
+            self.assertTrue(e007)
+            self.assertIsInstance(e007[0], Error)
+            self.assertIn('not a field', e007[0].msg)
+        finally:
+            process._adapters[DIRECT_TRUSTEE] = process_saved
+
+
+class S1ComposeScopeTest(TestCase):
+    def test_compose_scope_needs_no_context_adapter(self):
+        _context, trustee = _s1_maps()
+        path = compose_scope(S1Repository, None, trustee=trustee)
+        self.assertIsInstance(path, AuthorizationPath)
+        self.assertTrue(path.scope_origin)
+        self.assertEqual(path.resource_to_scope, '')
+        self.assertIs(path.scope_model, S1Repository)
+        self.assertIs(path.resource_model, S1Repository)
+        self.assertIsNone(path._context_adapter)
+
+    def test_compose_scope_rejects_wrong_scope_model(self):
+        _context, trustee = _s1_maps()
+        with self.assertRaises(AuthorizationPathError):
+            compose_scope(S1Team, None, trustee=trustee)
+
+    def test_resource_compose_of_unregistered_scope_model_fails(self):
+        _context, trustee = _s1_maps()
+        bare = ContextRegistry()
+        with self.assertRaises(AuthorizationPathError):
+            compose(S1Organization, None, context=bare, trustee=trustee)
+
+
+class S1EvaluationTest(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        super(S1EvaluationTest, self).setUp()
+        self.org_a = S1Organization.objects.create(name='acme')
+        self.org_b = S1Organization.objects.create(name='other')
+        self.team = S1Team.objects.create(organization=self.org_a, name='writers')
+        self.other_team = S1Team.objects.create(
+            organization=self.org_b, name='outsiders',
+        )
+        self.member = S1Account.objects.create(name='member')
+        self.stranger = S1Account.objects.create(name='stranger')
+        self.team.members.add(self.member)
+        self.read = S1Operation.objects.create(code='read')
+        self.write = S1Operation.objects.create(code='write')
+        self.bundle = S1Bundle.objects.create(team=self.team, name='reader')
+        self.bundle.operations.add(self.read)
+        self.repo_a = S1Repository.objects.create(
+            organization=self.org_a, title='repo-a',
+        )
+        self.repo_b = S1Repository.objects.create(
+            organization=self.org_a, title='repo-b',
+        )
+        self.cross_repo = S1Repository.objects.create(
+            organization=self.org_b, title='cross',
+        )
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.read,
+        )
+        self.context, self.trustee = _s1_maps()
+        self.path = compose(
+            S1Repository, self.read, context=self.context, trustee=self.trustee,
+        )
+        self.runtime = dict(context=self.context, trustee=self.trustee)
+
+    def _assert_object_list_equiv(self, principal, operation, obj, expected):
+        with self.assertNumQueries(1):
+            via_obj = is_authorized(principal, operation, obj, **self.runtime)
+        with self.assertNumQueries(1):
+            via_exists = type(obj).objects.filter(pk=obj.pk).filter(
+                authorized_q(type(obj), principal, operation, **self.runtime)
+            ).exists()
+        with self.assertNumQueries(1):
+            via_list = obj in list(
+                filter_authorized(
+                    type(obj).objects.filter(pk=obj.pk), principal, operation,
+                    **self.runtime,
+                )
+            )
+        self.assertEqual(via_obj, expected)
+        self.assertEqual(via_exists, expected)
+        self.assertEqual(via_list, expected)
+
+    def test_same_org_team_grant_object_equals_list_one_query(self):
+        self._assert_object_list_equiv(self.member, self.read, self.repo_a, True)
+        self._assert_object_list_equiv(self.member, self.read, self.repo_b, False)
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized(
+                    S1Repository.objects.all(), self.member, self.read,
+                    **self.runtime,
+                ).order_by('pk').values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk])
+
+    def test_string_operation_compiles_without_preliminary_get(self):
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_authorized(self.member, 'read', self.repo_a, **self.runtime)
+            )
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized(
+                    S1Repository.objects.all(), self.member, 'read',
+                    **self.runtime,
+                ).values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk])
+        exists_sql = str(
+            S1Repository.objects.filter(pk=self.repo_a.pk).filter(
+                authorized_q(S1Repository, self.member, 'read', **self.runtime)
+            ).query
+        )
+        self.assertIn('code', exists_sql.lower())
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                is_authorized(self.member, 'missing', self.repo_a, **self.runtime)
+            )
+
+    def test_cross_org_malformed_grant_denies(self):
+        other_bundle = S1Bundle.objects.create(team=self.team, name='cross-bundle')
+        other_bundle.operations.add(self.read)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.cross_repo, operation=self.read,
+        )
+        self._assert_object_list_equiv(
+            self.member, self.read, self.cross_repo, False,
+        )
+
+    def test_null_alignment_denies(self):
+        null_team = S1Team.objects.create(organization=None, name='null-team')
+        null_team.members.add(self.member)
+        null_bundle = S1Bundle.objects.create(team=null_team, name='null-bundle')
+        null_bundle.operations.add(self.read)
+        null_repo = S1Repository.objects.create(
+            organization=self.org_a, title='null-team-repo',
+        )
+        S1TeamGrant.objects.create(
+            team=null_team, repository=null_repo, operation=self.read,
+        )
+        self._assert_object_list_equiv(self.member, self.read, null_repo, False)
+
+        null_org_repo = S1Repository.objects.create(
+            organization=None, title='null-org-repo',
+        )
+        S1TeamGrant.objects.create(
+            team=self.team, repository=null_org_repo, operation=self.read,
+        )
+        self._assert_object_list_equiv(
+            self.member, self.read, null_org_repo, False,
+        )
+
+    def test_membership_grant_and_bundle_each_required(self):
+        self._assert_object_list_equiv(
+            self.stranger, self.read, self.repo_a, False,
+        )
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.write,
+        )
+        self._assert_object_list_equiv(
+            self.member, self.write, self.repo_a, False,
+        )
+        self.bundle.operations.add(self.write)
+        self._assert_object_list_equiv(
+            self.member, self.write, self.repo_a, True,
+        )
+
+    def test_direct_grant_is_independent_of_cross_org_team_row(self):
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.cross_repo, operation=self.read,
+        )
+        S1DirectGrant.objects.create(
+            account=self.member, repository=self.repo_b, operation=self.read,
+        )
+        self._assert_object_list_equiv(self.member, self.read, self.repo_b, True)
+        self._assert_object_list_equiv(
+            self.member, self.read, self.cross_repo, False,
+        )
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized(
+                    S1Repository.objects.all(), self.member, self.read,
+                    **self.runtime,
+                ).order_by('pk').values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk, self.repo_b.pk])
+
+    def test_compose_scope_listings_apply_alignment(self):
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.cross_repo, operation=self.read,
+        )
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized_scope(
+                    S1Repository.objects.all(), self.member, 'read',
+                    trustee=self.trustee,
+                ).order_by('pk').values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk])
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_scope_authorized(
+                    self.member, 'read', self.repo_a, trustee=self.trustee,
+                )
+            )
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                is_scope_authorized(
+                    self.member, 'read', self.cross_repo, trustee=self.trustee,
+                )
+            )
+
+    def test_getters_are_not_executed(self):
+        grant = S1TrapGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.read,
+        )
+        context, trustee = _s1_maps(grant_model=S1TrapGrant, include_direct=False)
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_authorized(
+                    self.member, 'read', self.repo_a,
+                    context=context, trustee=trustee,
+                )
+            )
+        with self.assertRaises(AssertionError):
+            grant.forbidden
+        with self.assertRaises(AssertionError):
+            grant.get_team()
+
+    def test_authorized_queryset_manager(self):
+        with self.assertNumQueries(1):
+            listed = list(
+                S1Repository.objects.authorized(
+                    self.member, 'read', **self.runtime,
+                ).order_by('pk').values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk])
+
+    def test_require_helpers(self):
+        self.assertIs(
+            require_authorized(self.member, 'read', self.repo_a, **self.runtime),
+            self.repo_a,
+        )
+        with self.assertRaises(AuthorizationDenied):
+            require_authorized(self.member, 'read', self.repo_b, **self.runtime)
+        self.assertIs(
+            require_scope_authorized(
+                self.member, 'read', self.repo_a, trustee=self.trustee,
+            ),
+            self.repo_a,
+        )
+        with self.assertRaises(AuthorizationDenied):
+            require_scope_authorized(
+                self.member, 'read', self.repo_b, trustee=self.trustee,
+            )
+
+
+class S1RuntimeConfigTest(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        super(S1RuntimeConfigTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+        self.context, self.trustee = _s1_maps()
+        self.runtime = dict(context=self.context, trustee=self.trustee)
+
+    def test_unusable_principal_denies(self):
+        self.account.is_anonymous = True
+        self.assertFalse(principal_is_usable(self.account))
+        self.assertFalse(
+            is_authorized(self.account, 'read', self.repo, **self.runtime)
+        )
+        self.assertEqual(
+            list(filter_authorized(
+                S1Repository.objects.all(), self.account, 'read', **self.runtime,
+            )),
+            [],
+        )
+        del self.account.is_anonymous
+        self.account.is_authenticated = False
+        self.assertFalse(
+            is_authorized(self.account, 'read', self.repo, **self.runtime)
+        )
+        del self.account.is_authenticated
+        self.account.is_active = False
+        self.assertFalse(
+            is_authorized(self.account, 'read', self.repo, **self.runtime)
+        )
+        with self.assertRaises(AuthorizationDenied):
+            require_authorized(self.account, 'read', self.repo, **self.runtime)
+
+    def test_missing_flags_are_usable(self):
+        self.assertTrue(principal_is_usable(self.account))
+
+    def test_wrong_model_and_raw_pk_are_config_errors(self):
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(self.repo, 'read', self.repo, **self.runtime)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(self.account.pk, 'read', self.repo, **self.runtime)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(self.account, self.read.pk, self.repo, **self.runtime)
+        with self.assertRaises(AuthorizationConfigError):
+            filter_authorized(
+                S1Repository.objects.all(), self.repo, 'read', **self.runtime,
+            )
+
+    def test_unregistered_resource_and_wrong_queryset_raise(self):
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo, text='nope',
+        )
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(self.account, 'read', note, **self.runtime)
+        with self.assertRaises(AuthorizationConfigError):
+            filter_authorized(
+                S1UnregisteredNote.objects.all(), self.account, 'read',
+                **self.runtime,
+            )
+        with self.assertRaises(AuthorizationConfigError):
+            filter_authorized(
+                S1Team.objects.all(), self.account, 'read', **self.runtime,
+            )
+        with self.assertRaises(AuthorizationConfigError):
+            filter_authorized_scope(
+                S1Team.objects.all(), self.account, 'read',
+                trustee=self.trustee,
+            )
+
+    def test_string_without_lookup_raises_on_direct_api(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        )
+        trustee.register(
+            name=S1_DIRECT,
+            trustee_model=S1Account,
+            grant_model=S1DirectGrant,
+            trustee_path='account',
+            scope_path='repository',
+            operation_path='operation',
+        )
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.account, 'read', self.repo,
+                context=context, trustee=trustee,
+            )
+
+    def test_empty_adapters_raise(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='code',
+        )
+        with self.assertRaises(AuthorizationConfigError):
+            filter_authorized(
+                S1Repository.objects.all(), self.account, 'read',
+                context=context, trustee=trustee,
+            )
+
+    def test_scope_q_siblings(self):
+        S1DirectGrant.objects.create(
+            account=self.account, repository=self.repo, operation=self.read,
+        )
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_scope_authorized(
+                    self.account, 'read', self.repo, trustee=self.trustee,
+                )
+            )
+        with self.assertNumQueries(1):
+            listed = list(
+                S1Repository.objects.filter(
+                    authorized_scope_q(
+                        S1Repository, self.account, 'read',
+                        trustee=self.trustee,
+                    )
+                ).values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo.pk])

--- a/tests/core/test_s1_kernel.py
+++ b/tests/core/test_s1_kernel.py
@@ -77,7 +77,10 @@ S1_TEAM = 'team'
 S1_DIRECT = 'direct'
 
 
-def _s1_maps(grant_model=None, include_direct=True, alignment=True):
+def _s1_maps(
+    grant_model=None, include_direct=True, alignment=True,
+    operation_lookup='code',
+):
     """Isolated identity + alignment registries. Never touch process-wide maps."""
     if grant_model is None:
         grant_model = S1TeamGrant
@@ -87,7 +90,7 @@ def _s1_maps(grant_model=None, include_direct=True, alignment=True):
         requester_model=S1Account,
         scope_model=S1Repository,
         operation_model=S1Operation,
-        operation_lookup='code',
+        operation_lookup=operation_lookup,
     )
     alignment_paths = (
         (('team__organization', 'repository__organization'),)
@@ -178,6 +181,15 @@ class S1IdentityContextTest(TestCase):
 
 
 class S1OperationLookupTest(TestCase):
+    def test_integer_pk_lookup_is_accepted(self):
+        registry = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='id',
+        )
+        self.assertEqual(registry.operation_lookup(), 'id')
+
     def test_unique_lookup_configures_and_is_idempotent(self):
         registry = TrusteeRegistry(
             requester_model=S1Account,
@@ -502,6 +514,69 @@ class S1EvaluationTest(TransactionTestCase):
             self.assertFalse(
                 is_authorized(self.member, 'missing', self.repo_a, **self.runtime)
             )
+
+    def test_non_text_lookup_unknown_string_denies_without_exception(self):
+        context, trustee = _s1_maps(operation_lookup='id')
+        runtime = dict(context=context, trustee=trustee)
+        supported = str(self.read.pk)
+
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_authorized(self.member, supported, self.repo_a, **runtime)
+            )
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized(
+                    S1Repository.objects.all(), self.member, supported,
+                    **runtime,
+                ).order_by('pk').values_list('pk', flat=True)
+            )
+        self.assertEqual(listed, [self.repo_a.pk])
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                is_scope_authorized(
+                    self.member, supported, self.repo_a, trustee=trustee,
+                )
+            )
+
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                is_authorized(self.member, 'missing', self.repo_a, **runtime)
+            )
+        with self.assertNumQueries(1):
+            listed = list(
+                filter_authorized(
+                    S1Repository.objects.all(), self.member, 'missing',
+                    **runtime,
+                )
+            )
+        self.assertEqual(listed, [])
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                is_scope_authorized(
+                    self.member, 'missing', self.repo_a, trustee=trustee,
+                )
+            )
+        with self.assertNumQueries(1):
+            scoped = list(
+                filter_authorized_scope(
+                    S1Repository.objects.all(), self.member, 'missing',
+                    trustee=trustee,
+                )
+            )
+        self.assertEqual(scoped, [])
+        with self.assertRaises(AuthorizationDenied):
+            require_authorized(
+                self.member, 'missing', self.repo_a, **runtime,
+            )
+        with self.assertRaises(AuthorizationDenied):
+            require_scope_authorized(
+                self.member, 'missing', self.repo_a, trustee=trustee,
+            )
+        authorized_q(S1Repository, self.member, 'missing', **runtime)
+        authorized_scope_q(
+            S1Repository, self.member, 'missing', trustee=trustee,
+        )
 
     def test_cross_org_malformed_grant_denies(self):
         other_bundle = S1Bundle.objects.create(team=self.team, name='cross-bundle')

--- a/tests/migrations/0007_s1_kernel.py
+++ b/tests/migrations/0007_s1_kernel.py
@@ -1,0 +1,108 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trusts_tests', '0006_trustee_team'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='S1Account',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Organization',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Operation',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('code', models.CharField(max_length=40, unique=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Team',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+                ('members', models.ManyToManyField(blank=True, related_name='teams', to='trusts_tests.s1account')),
+                ('organization', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='teams', to='trusts_tests.s1organization')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Bundle',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+                ('operations', models.ManyToManyField(blank=True, related_name='bundles', to='trusts_tests.s1operation')),
+                ('team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='bundles', to='trusts_tests.s1team')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Repository',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=40)),
+                ('organization', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='repositories', to='trusts_tests.s1organization')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1Issue',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=40)),
+                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='issues', to='trusts_tests.s1repository')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1TeamGrant',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('operation', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='team_grants', to='trusts_tests.s1operation')),
+                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='team_grants', to='trusts_tests.s1repository')),
+                ('team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='repo_grants', to='trusts_tests.s1team')),
+            ],
+            options={
+                'unique_together': {('team', 'repository', 'operation')},
+            },
+        ),
+        migrations.CreateModel(
+            name='S1DirectGrant',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='repo_grants', to='trusts_tests.s1account')),
+                ('operation', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='direct_grants', to='trusts_tests.s1operation')),
+                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='direct_grants', to='trusts_tests.s1repository')),
+            ],
+            options={
+                'unique_together': {('account', 'repository', 'operation')},
+            },
+        ),
+        migrations.CreateModel(
+            name='S1TrapGrant',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('operation', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='trap_grants', to='trusts_tests.s1operation')),
+                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='trap_grants', to='trusts_tests.s1repository')),
+                ('team', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='trap_grants', to='trusts_tests.s1team')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='S1UnregisteredNote',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('text', models.CharField(default='', max_length=80)),
+                ('repository', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='notes', to='trusts_tests.s1repository')),
+            ],
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group, User
 
 from trusts.conditions import condition_refs
 from trusts.context import Context
+from trusts.query import AuthorizedManager
 from trusts.zero.models import Content, Junction
 from trusts.trustee import Trustee, TrusteeMixin
 
@@ -457,3 +458,164 @@ def sync_test_team_trustee_adapter():
 
 
 Trustee.add_finalizer(sync_test_team_trustee_adapter)
+
+
+class S1Account(models.Model):
+    """S1 requester. No Django auth flags (attribute protocol ignores missing)."""
+
+    name = models.CharField(max_length=40, null=False, blank=False)
+
+    def __str__(self):
+        return self.name
+
+
+class S1Organization(models.Model):
+    """S1 alignment terminal. Not a requester."""
+
+    name = models.CharField(max_length=40, null=False, blank=False)
+
+    def __str__(self):
+        return self.name
+
+
+class S1Team(models.Model):
+    """S1 collective. ``organization`` is nullable so NULL alignment can deny."""
+
+    organization = models.ForeignKey(
+        S1Organization, related_name='teams', null=True, blank=True,
+        on_delete=models.CASCADE,
+    )
+    name = models.CharField(max_length=40, null=False, blank=False)
+    members = models.ManyToManyField(
+        S1Account, related_name='teams', blank=True,
+    )
+
+    def __str__(self):
+        return self.name
+
+
+class S1Operation(models.Model):
+    """S1 operation with unique ``code`` for ``operation_lookup``."""
+
+    code = models.CharField(max_length=40, null=False, blank=False, unique=True)
+
+    def __str__(self):
+        return self.code
+
+
+class S1Bundle(models.Model):
+    """Operation ceiling. Constraints never create a grant."""
+
+    team = models.ForeignKey(
+        S1Team, related_name='bundles', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    name = models.CharField(max_length=40, null=False, blank=False)
+    operations = models.ManyToManyField(
+        S1Operation, related_name='bundles', blank=True,
+    )
+
+    def __str__(self):
+        return self.name
+
+
+class S1Repository(models.Model):
+    """Identity resource and Trustee scope. ``organization`` may be NULL."""
+
+    organization = models.ForeignKey(
+        S1Organization, related_name='repositories', null=True, blank=True,
+        on_delete=models.CASCADE,
+    )
+    title = models.CharField(max_length=40, null=False, blank=False)
+
+    objects = AuthorizedManager()
+
+    def __str__(self):
+        return self.title
+
+
+class S1Issue(models.Model):
+    """Related Context resource through an identity-registered repository."""
+
+    repository = models.ForeignKey(
+        S1Repository, related_name='issues', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    title = models.CharField(max_length=40, null=False, blank=False)
+
+    def __str__(self):
+        return self.title
+
+
+class S1TeamGrant(models.Model):
+    """Team → repository grant. Alignment compares team and repository orgs."""
+
+    team = models.ForeignKey(
+        S1Team, related_name='repo_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    repository = models.ForeignKey(
+        S1Repository, related_name='team_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    operation = models.ForeignKey(
+        S1Operation, related_name='team_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+
+    class Meta:
+        unique_together = ('team', 'repository', 'operation')
+
+
+class S1DirectGrant(models.Model):
+    """Direct account → repository grant. No alignment_paths."""
+
+    account = models.ForeignKey(
+        S1Account, related_name='repo_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    repository = models.ForeignKey(
+        S1Repository, related_name='direct_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    operation = models.ForeignKey(
+        S1Operation, related_name='direct_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+
+    class Meta:
+        unique_together = ('account', 'repository', 'operation')
+
+
+class S1TrapGrant(models.Model):
+    """Grant whose Python getters must never run during S1 resolution."""
+
+    team = models.ForeignKey(
+        S1Team, related_name='trap_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    repository = models.ForeignKey(
+        S1Repository, related_name='trap_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    operation = models.ForeignKey(
+        S1Operation, related_name='trap_grants', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+
+    @property
+    def forbidden(self):
+        raise AssertionError('S1 kernel must not execute properties')
+
+    def get_team(self):
+        raise AssertionError('S1 kernel must not execute getters')
+
+
+class S1UnregisteredNote(models.Model):
+    """Must stay unregistered so missing compose fails closed."""
+
+    repository = models.ForeignKey(
+        S1Repository, related_name='notes', null=False, blank=False,
+        on_delete=models.CASCADE,
+    )
+    text = models.CharField(max_length=80, null=False, blank=False, default='')

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -30,6 +30,7 @@ NORMAL_SUITE = [
     'tests.core.test_trustee',
     'tests.core.test_path',
     'tests.core.test_gh_vocab',
+    'tests.core.test_s1_kernel',
     'tests.core.test_zero_path',
     'tests.core.test_kernel_split',
     'tests.core.test_wheel_install',

--- a/trusts/checks.py
+++ b/trusts/checks.py
@@ -35,7 +35,8 @@ def check_context_registry(app_configs, **kwargs):
     """Re-validate the frozen Context registry after models are loaded.
 
     Missing, cyclic, ambiguous, scalar, many-valued, and wrong-terminal
-    paths are rejected at ``register_direct`` / ``register_related``.
+    paths are rejected at ``register_direct`` / ``register_related`` /
+    ``register_identity``.
     This check re-walks every installed adapter so ``manage.py check``
     reports ``trusts.E006`` if the map is stale. ``app_configs`` is
     ignored so ``manage.py check trusts_kernel`` still sees the full

--- a/trusts/context.py
+++ b/trusts/context.py
@@ -5,13 +5,15 @@ The reusable question:
     Starting from this resource model, what validated relational path
     resolves its authorization scope?
 
-Two registration forms:
+Three registration forms:
 
-* **Direct** — the resource owns a single-valued relationship to its
-  policy scope (``register_direct(model, scope_field=...)``).
-* **Related** — the resource reaches an already registered resource
-  through a validated, single-valued relational path and therefore
-  resolves the same scope (``register_related(model, through=...)``).
+    * **Direct** — the resource owns a single-valued relationship to its
+      policy scope (``register_direct(model, scope_field=...)``).
+    * **Related** — the resource reaches an already registered resource
+      through a validated, single-valued relational path and therefore
+      resolves the same scope (``register_related(model, through=...)``).
+    * **Identity** — the resource *is* its policy scope
+      (``register_identity(model)``). The compiled scope path is empty.
 
 Registration is static during application loading and frozen before
 authorization queries. Validation uses Django ``_meta`` only: no
@@ -30,6 +32,7 @@ from django.db.models.constants import LOOKUP_SEP
 
 KIND_DIRECT = 'direct'
 KIND_RELATED = 'related'
+KIND_IDENTITY = 'identity'
 
 
 class ContextRegistrationError(ValueError):
@@ -312,6 +315,8 @@ class ContextAdapter(object):
 
     def scope_model(self):
         """Terminal policy-scope model this adapter resolves to."""
+        if self.kind == KIND_IDENTITY:
+            return self.model
         if self.kind == KIND_DIRECT:
             field = _get_field(self.model, self.decl, self.decl)
             return _resolve_related_model(field)
@@ -319,21 +324,31 @@ class ContextAdapter(object):
         return self.registry.get(terminal).scope_model()
 
     def terminal_model(self):
-        """Direct: the resource itself. Related: the registered parent."""
-        if self.kind == KIND_DIRECT:
+        """Identity/direct: the resource itself. Related: the registered parent."""
+        if self.kind in (KIND_IDENTITY, KIND_DIRECT):
             return self.model
         terminal, _hops = _walk(self.model, self.decl)
         return terminal
 
     def scope_path(self):
-        """Resource → scope ORM lookup shared by exists and list filters."""
+        """Resource → scope ORM lookup shared by exists and list filters.
+
+        Identity: the empty string. The filtered row *is* the scope.
+        """
+        if self.kind == KIND_IDENTITY:
+            return ''
         if self.kind == KIND_DIRECT:
             return self.decl
         parent = self.registry.get(self.terminal_model())
-        return '%s__%s' % (self.decl, parent.scope_path())
+        parent_path = parent.scope_path()
+        if not parent_path:
+            return self.decl
+        return '%s__%s' % (self.decl, parent_path)
 
     def resource_path(self):
         """Scope → resource ORM lookup (the inverse of ``scope_path``)."""
+        if self.kind == KIND_IDENTITY:
+            return ''
         if self.kind == KIND_DIRECT:
             _target, reverse = _invert_hop(self.model, self.decl, self.decl)
             return reverse
@@ -344,7 +359,11 @@ class ContextAdapter(object):
             current, reverse = _invert_hop(current, name, self.decl)
             inverted.append(reverse)
         inverted.reverse()
-        return '%s__%s' % (parent.resource_path(), '__'.join(inverted))
+        parent_path = parent.resource_path()
+        child_path = '__'.join(inverted)
+        if not parent_path:
+            return child_path
+        return '%s__%s' % (parent_path, child_path)
 
     def equivalent(self, other):
         return (
@@ -454,8 +473,13 @@ class ContextRegistry(object):
         """``Q`` matching rows whose registered path resolves to ``scope``.
 
         Instance and queryset/list ``scope`` values use the same lookup.
+        Identity adapters match the row primary key.
         """
         path = self.scope_path(model)
+        if not path:
+            if hasattr(scope, 'pk') and not hasattr(scope, 'model'):
+                return Q(pk=scope.pk)
+            return Q(pk__in=scope)
         if hasattr(scope, 'pk') and not hasattr(scope, 'model'):
             return Q(**{path: scope})
         return Q(**{'%s__in' % path: scope})
@@ -498,6 +522,19 @@ class ContextRegistry(object):
         adapter = ContextAdapter(KIND_RELATED, model, through, self)
         return self._commit(adapter)
 
+    def register_identity(self, model):
+        """Register a resource that is its own policy scope.
+
+        Identity is not ``register_direct`` with a fake field. The compiled
+        scope path is empty: the filtered row *is* the scope.
+        """
+        if not isinstance(model, type) or not hasattr(model, '_meta'):
+            raise ContextRegistrationError(
+                'register_identity requires a model class, not %r.' % (model,)
+            )
+        adapter = ContextAdapter(KIND_IDENTITY, model, '', self)
+        return self._commit(adapter)
+
     def _commit(self, adapter):
         key = _model_key(adapter.model)
         existing = self._adapters.get(key)
@@ -522,6 +559,16 @@ class ContextRegistry(object):
 
     def revalidate(self, adapter):
         """Re-walk a stored adapter. Raise ``ContextRegistrationError`` if stale."""
+        if adapter.kind == KIND_IDENTITY:
+            if not isinstance(adapter.model, type) or not hasattr(adapter.model, '_meta'):
+                raise ContextRegistrationError(
+                    'Identity Context %s is no longer a model class.' % (
+                        _model_label(adapter.model),
+                    )
+                )
+            adapter.scope_path()
+            adapter.resource_path()
+            return
         if adapter.kind == KIND_DIRECT:
             parts = _split_path(adapter.decl, 'scope_field')
             if len(parts) != 1:
@@ -558,7 +605,12 @@ def check_registration(model, kind, path, registry=None):
     """
     registry = registry if registry is not None else ContextRegistry()
     try:
-        if kind == KIND_DIRECT:
+        if kind == KIND_IDENTITY:
+            if not isinstance(model, type) or not hasattr(model, '_meta'):
+                raise ContextRegistrationError(
+                    'register_identity requires a model class, not %r.' % (model,)
+                )
+        elif kind == KIND_DIRECT:
             parts = _split_path(path, 'scope_field')
             if len(parts) != 1:
                 raise ContextRegistrationError(
@@ -596,6 +648,7 @@ class Context(object):
 
     KIND_DIRECT = KIND_DIRECT
     KIND_RELATED = KIND_RELATED
+    KIND_IDENTITY = KIND_IDENTITY
 
     @classmethod
     def register_direct(cls, model, scope_field):
@@ -604,6 +657,10 @@ class Context(object):
     @classmethod
     def register_related(cls, model, through):
         return cls.registry.register_related(model, through)
+
+    @classmethod
+    def register_identity(cls, model):
+        return cls.registry.register_identity(model)
 
     @classmethod
     def add_finalizer(cls, func):
@@ -661,6 +718,7 @@ class Context(object):
 __all__ = [
     'KIND_DIRECT',
     'KIND_RELATED',
+    'KIND_IDENTITY',
     'Context',
     'ContextAdapter',
     'ContextNotRegistered',

--- a/trusts/path.py
+++ b/trusts/path.py
@@ -23,11 +23,14 @@ Kernel positions are requester / subject / resource / scope / grant /
 operation. This module must not name a concrete authorization product's
 resource, scope, principal, collective, bundle, or grant tables.
 
-Public construction is ``compose`` only. Direct ``AuthorizationPath(...)``
-is rejected. Adapter-specific data is always a tuple of immutable
-``AuthorizationBranch`` records. Evaluation requires requester and
-operation *instances* whose concrete model matches the composed
-terminals; raw primary keys are not accepted.
+Public construction is ``compose`` (resource-origin, Context hop) or
+``compose_scope`` (the filtered row *is* the frozen Trustee scope).
+Direct ``AuthorizationPath(...)`` is rejected. Adapter-specific data is
+always a tuple of immutable ``AuthorizationBranch`` records. Evaluation
+requires a requester instance of the composed terminal. Operation may be
+an operation-model instance or, when ``Trustee.operation_lookup`` is
+set, a string compiled into the grant predicate. Raw primary keys are
+not accepted.
 
 Recursive and ordered remaining-bits helpers are reserved slots only.
 They are not compiled in this slice. An instance that carries a
@@ -190,6 +193,7 @@ def _branch_from_adapter(adapter):
         grant_to_scope=adapter.scope_path,
         grant_to_operation=adapter.operation_path,
         constraint_paths=adapter.constraint_paths,
+        alignment_paths=adapter.alignment_paths,
     )
 
 
@@ -250,12 +254,13 @@ class AuthorizationBranch(object):
         'grant_to_scope',
         'grant_to_operation',
         'constraint_paths',
+        'alignment_paths',
     )
 
     def __init__(
         self, name, subject_model, subject_from_grant, membership_path,
         requester_from_grant, grant_model, grant_to_scope,
-        grant_to_operation, constraint_paths,
+        grant_to_operation, constraint_paths, alignment_paths=(),
     ):
         object.__setattr__(self, 'name', name)
         object.__setattr__(self, 'subject_model', subject_model)
@@ -266,6 +271,9 @@ class AuthorizationBranch(object):
         object.__setattr__(self, 'grant_to_scope', grant_to_scope)
         object.__setattr__(self, 'grant_to_operation', grant_to_operation)
         object.__setattr__(self, 'constraint_paths', tuple(constraint_paths))
+        object.__setattr__(self, 'alignment_paths', tuple(
+            tuple(pair) for pair in alignment_paths
+        ))
 
     def __setattr__(self, name, value):
         raise AttributeError('AuthorizationBranch is immutable.')
@@ -302,6 +310,7 @@ class AuthorizationPath(object):
         '_trustee_adapters',
         '_context_registry',
         '_trustee_registry',
+        '_scope_origin',
     )
 
     def __init__(self, *args, **kwargs):
@@ -328,6 +337,10 @@ class AuthorizationPath(object):
         return tuple(branch.name for branch in self._branches)
 
     @property
+    def scope_origin(self):
+        return self._scope_origin
+
+    @property
     def condition(self):
         return self._condition
 
@@ -342,7 +355,7 @@ class AuthorizationPath(object):
     @classmethod
     def _from_validated(
         cls, context_adapter, trustee_adapters, context_registry,
-        trustee_registry,
+        trustee_registry, scope_origin=False, scope_model=None,
     ):
         """Install a validated, frozen join. Reserved slots are always None."""
         inst = object.__new__(cls)
@@ -350,9 +363,15 @@ class AuthorizationPath(object):
         object.__setattr__(inst, '_trustee_adapters', tuple(trustee_adapters))
         object.__setattr__(inst, '_context_registry', context_registry)
         object.__setattr__(inst, '_trustee_registry', trustee_registry)
-        object.__setattr__(inst, 'resource_model', context_adapter.model)
-        object.__setattr__(inst, 'resource_to_scope', context_adapter.scope_path())
-        object.__setattr__(inst, 'scope_model', context_adapter.scope_model())
+        object.__setattr__(inst, '_scope_origin', bool(scope_origin))
+        if scope_origin:
+            object.__setattr__(inst, 'resource_model', scope_model)
+            object.__setattr__(inst, 'resource_to_scope', '')
+            object.__setattr__(inst, 'scope_model', scope_model)
+        else:
+            object.__setattr__(inst, 'resource_model', context_adapter.model)
+            object.__setattr__(inst, 'resource_to_scope', context_adapter.scope_path())
+            object.__setattr__(inst, 'scope_model', context_adapter.scope_model())
         object.__setattr__(inst, 'requester_model', trustee_registry.requester_model())
         object.__setattr__(
             inst, 'operation_model', trustee_adapters[0].operation_model(),
@@ -403,12 +422,108 @@ class AuthorizationPath(object):
             )
 
         operation_cls = None
-        if operation is not None:
+        if isinstance(operation, str):
+            if not trustee_registry.operation_lookup():
+                raise AuthorizationPathError(
+                    'String operations require operation_lookup on the '
+                    'Trustee registry.'
+                )
+        elif operation is not None:
             operation_cls = _as_model(operation, 'operation')
 
         _assert_adapter_terminals(context_adapter, adapters, operation_cls)
         return cls._from_validated(
             context_adapter, adapters, context_registry, trustee_registry,
+        )
+
+    @classmethod
+    def compose_scope(
+        cls, scope_model, operation, trustee=None, names=None,
+        condition=None, recursive_edge=None, ordered_contribution=None,
+    ):
+        """Compose a path whose filtered row *is* the frozen Trustee scope.
+
+        No Context adapter is required. The compiled grant predicate uses
+        identity scope (grant ``scope_path`` → row ``pk``). ``scope_from_row``
+        is not a public argument.
+        """
+        _reject_reserved(condition, recursive_edge, ordered_contribution)
+
+        scope_model = _as_model(scope_model, 'scope_model')
+        trustee_registry = _as_trustee_registry(trustee)
+        trustee_registry.ensure_frozen()
+
+        try:
+            configured_scope = trustee_registry.scope_model()
+        except TrusteeRegistrationError as exc:
+            raise AuthorizationPathError(str(exc))
+
+        if not _same_model(scope_model, configured_scope):
+            raise AuthorizationPathError(
+                'Scope %s is not the configured Trustee scope %s.' % (
+                    _model_label(scope_model),
+                    _model_label(configured_scope),
+                )
+            )
+
+        try:
+            adapters = _enabled_adapters(trustee_registry, names)
+        except TrusteeNotRegistered as exc:
+            raise AuthorizationPathError(str(exc))
+
+        if not adapters:
+            raise AuthorizationPathError(
+                'No grant adapters are enabled for scope %s.' % (
+                    _model_label(scope_model),
+                )
+            )
+
+        operation_cls = None
+        if isinstance(operation, str):
+            if not trustee_registry.operation_lookup():
+                raise AuthorizationPathError(
+                    'String operations require operation_lookup on the '
+                    'Trustee registry.'
+                )
+        elif operation is not None:
+            operation_cls = _as_model(operation, 'operation')
+
+        for adapter in adapters:
+            grant_scope = adapter.scope_model()
+            if not _same_model(grant_scope, scope_model):
+                raise AuthorizationPathError(
+                    'Scope %s does not match grant adapter %r scope %s.' % (
+                        _model_label(scope_model),
+                        adapter.name,
+                        _model_label(grant_scope),
+                    )
+                )
+            grant_operation = adapter.operation_model()
+            if operation_cls is not None and not _same_model(
+                operation_cls, grant_operation,
+            ):
+                raise AuthorizationPathError(
+                    'Operation %s does not match grant adapter %r '
+                    'operation %s.' % (
+                        _model_label(operation_cls),
+                        adapter.name,
+                        _model_label(grant_operation),
+                    )
+                )
+            if not _same_model(adapter.scope_model(), adapters[0].scope_model()):
+                raise AuthorizationPathError(
+                    'Grant adapters mix scope terminals; refusing to compose.'
+                )
+            if not _same_model(
+                adapter.operation_model(), adapters[0].operation_model(),
+            ):
+                raise AuthorizationPathError(
+                    'Grant adapters mix operation terminals; refusing to compose.'
+                )
+
+        return cls._from_validated(
+            None, adapters, None, trustee_registry,
+            scope_origin=True, scope_model=scope_model,
         )
 
     def _assert_evaluable(self, requester, operation):
@@ -423,7 +538,14 @@ class AuthorizationPath(object):
                 'slot and cannot evaluate.'
             )
         _require_instance(requester, self.requester_model, 'requester')
-        _require_instance(operation, self.operation_model, 'operation')
+        if isinstance(operation, str):
+            if not self._trustee_registry.operation_lookup():
+                raise AuthorizationPathError(
+                    'String operations require operation_lookup on the '
+                    'Trustee registry.'
+                )
+        else:
+            _require_instance(operation, self.operation_model, 'operation')
 
     def grant_q(self, requester, operation):
         """Compiled grant predicate for this resource's scope path."""
@@ -438,11 +560,14 @@ class AuthorizationPath(object):
     def filter_granted(self, queryset, requester, operation):
         """SQL-filter ``queryset`` with the composed predicate (one query)."""
         self._assert_evaluable(requester, operation)
-        if not _same_model(queryset.model, self.resource_model):
+        expected = self.scope_model if self._scope_origin else self.resource_model
+        what = 'scope' if self._scope_origin else 'path resource'
+        if not _same_model(queryset.model, expected):
             raise AuthorizationPathError(
-                'Queryset model %s is not this path resource %s.' % (
+                'Queryset model %s is not this %s %s.' % (
                     _model_label(queryset.model),
-                    _model_label(self.resource_model),
+                    what,
+                    _model_label(expected),
                 )
             )
         return self._trustee_registry.filter_granted(
@@ -456,7 +581,10 @@ class AuthorizationPath(object):
     def row_is_granted(self, obj, requester, operation):
         """One-query exists check using the same predicate as ``filter_granted``."""
         self._assert_evaluable(requester, operation)
-        _require_instance(obj, self.resource_model, 'resource')
+        if self._scope_origin:
+            _require_instance(obj, self.scope_model, 'scope')
+        else:
+            _require_instance(obj, self.resource_model, 'resource')
         return self._trustee_registry.row_is_granted(
             obj,
             requester,
@@ -478,6 +606,22 @@ def compose(
         resource_model,
         operation,
         context=context,
+        trustee=trustee,
+        names=names,
+        condition=condition,
+        recursive_edge=recursive_edge,
+        ordered_contribution=ordered_contribution,
+    )
+
+
+def compose_scope(
+    scope_model, operation, trustee=None, names=None,
+    condition=None, recursive_edge=None, ordered_contribution=None,
+):
+    """Freeze the Trustee map and return a scope-origin ``AuthorizationPath``."""
+    return AuthorizationPath.compose_scope(
+        scope_model,
+        operation,
         trustee=trustee,
         names=names,
         condition=condition,
@@ -534,6 +678,7 @@ __all__ = [
     'OrderedContribution',
     'RecursiveEdge',
     'compose',
+    'compose_scope',
     'empty_grant_q',
     'filter_granted',
     'row_is_granted',

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -1,0 +1,33 @@
+"""Authorized queryset / manager surface (issue #47 S1).
+
+The class name is ``AuthorizedQuerySet`` (not ``AuthorizationQuerySet``).
+That matches accepted framework-execution-r1/r2: ``authorized`` is the
+neutral verb, and Zero keeps ``permitted`` with its Django-permission
+argument order. The manager is ``AuthorizedManager``.
+"""
+
+from django.db import models
+
+from trusts.runtime import filter_authorized
+
+
+class AuthorizedQuerySet(models.QuerySet):
+    """QuerySet that filters rows through the composed grant predicate."""
+
+    def authorized(self, principal, operation, **kwargs):
+        """SQL-filter this queryset with ``filter_authorized``.
+
+        ``kwargs`` are the isolated-registry / adapter-name options of
+        ``filter_authorized`` (``context``, ``trustee``, ``names``).
+        """
+        return filter_authorized(self, principal, operation, **kwargs)
+
+
+class AuthorizedManager(models.Manager.from_queryset(AuthorizedQuerySet)):
+    """Default manager that exposes ``QuerySet.authorized``."""
+
+
+__all__ = [
+    'AuthorizedManager',
+    'AuthorizedQuerySet',
+]

--- a/trusts/runtime.py
+++ b/trusts/runtime.py
@@ -1,0 +1,346 @@
+"""Object and scope authorization execution (issue #47 S1).
+
+``is_authorized`` / ``filter_authorized`` and the scope-origin siblings
+compile through ``AuthorizationPath.compose`` / ``compose_scope``. Object
+and list share one ``grant_q``. There is no preliminary operation
+``get()`` and no public ``scope_from_row``.
+
+Denial versus configuration:
+
+* Unusable principal (attribute protocol) and unknown operation *data*
+  deny (``False``, empty queryset, ``AuthorizationDenied``).
+* Wrong-model / raw-PK terminals, unregistered resources, missing
+  adapters, mixed/stale terminals, reserved slots, and incomplete
+  ``operation_lookup`` raise ``AuthorizationConfigError``. Direct APIs
+  never hide a broken install behind ``.none()``.
+"""
+
+from django.core.exceptions import PermissionDenied
+
+from trusts.context import Context, ContextRegistry
+from trusts.path import (
+    AuthorizationPathError,
+    compose,
+    compose_scope,
+    empty_grant_q,
+)
+from trusts.trustee import (
+    Trustee,
+    TrusteeRegistrationError,
+    TrusteeRegistry,
+)
+
+
+class AuthorizationDenied(PermissionDenied):
+    """Ordinary authorization denial. Not a configuration error."""
+
+
+class AuthorizationConfigError(ValueError):
+    """Missing, malformed, or incomplete authorization configuration.
+
+    Security boundaries (backend / decorator / admin; S2+) may catch this
+    and deny. Direct runtime APIs raise so a broken install cannot look
+    like an empty result set.
+    """
+
+
+def _as_context_registry(value):
+    if value is None or value is Context:
+        return Context.registry
+    if isinstance(value, ContextRegistry):
+        return value
+    raise AuthorizationConfigError(
+        'context must be a ContextRegistry, not %r.' % (value,)
+    )
+
+
+def _as_trustee_registry(value):
+    if value is None or value is Trustee:
+        return Trustee.registry
+    if isinstance(value, TrusteeRegistry):
+        return value
+    raise AuthorizationConfigError(
+        'trustee must be a TrusteeRegistry, not %r.' % (value,)
+    )
+
+
+def _model_label(model):
+    meta = getattr(model, '_meta', None)
+    if meta is not None:
+        return meta.label
+    return repr(model)
+
+
+def _same_model(left, right):
+    if not isinstance(left, type):
+        left = left.__class__
+    if not isinstance(right, type):
+        right = right.__class__
+    return left._meta.concrete_model is right._meta.concrete_model
+
+
+def _require_instance(value, expected_model, what):
+    if isinstance(value, type):
+        raise AuthorizationConfigError(
+            '%s must be a %s instance, not a model class.' % (
+                what, _model_label(expected_model),
+            )
+        )
+    meta = getattr(value, '_meta', None)
+    if meta is None:
+        raise AuthorizationConfigError(
+            '%s must be a %s instance, not %r. Raw primary keys are '
+            'not accepted.' % (what, _model_label(expected_model), value)
+        )
+    if not _same_model(value, expected_model):
+        raise AuthorizationConfigError(
+            '%s is %s, which is not the configured %s %s.' % (
+                what, _model_label(value.__class__),
+                what, _model_label(expected_model),
+            )
+        )
+    return value
+
+
+def principal_is_usable(principal):
+    """Attribute protocol. Missing attributes are ignored.
+
+    ``is_anonymous is True``, ``is_authenticated is False``, or
+    ``is_active is False`` makes the principal unusable. A model with
+    none of those attributes (for example a custom account) is usable.
+    """
+    if getattr(principal, 'is_anonymous', None) is True:
+        return False
+    if getattr(principal, 'is_authenticated', None) is False:
+        return False
+    if getattr(principal, 'is_active', None) is False:
+        return False
+    return True
+
+
+def _wrap_path_error(exc):
+    if isinstance(exc, AuthorizationConfigError):
+        raise exc
+    raise AuthorizationConfigError(str(exc)) from exc
+
+
+def _prepare_resource(resource, context, trustee, names):
+    context_registry = _as_context_registry(context)
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(resource, resource.__class__, 'resource')
+    try:
+        path = compose(
+            resource.__class__, None, context=context_registry,
+            trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    return path, trustee_registry, requester_model
+
+
+def _prepare_scope(scope_obj, trustee, names):
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+        scope_model = trustee_registry.scope_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(scope_obj, scope_model, 'scope')
+    try:
+        path = compose_scope(
+            scope_obj.__class__, None, trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    return path, trustee_registry, requester_model
+
+
+def _prepare_operation(operation, trustee_registry):
+    if isinstance(operation, str):
+        if not trustee_registry.operation_lookup():
+            raise AuthorizationConfigError(
+                'String operations require operation_lookup on the '
+                'Trustee registry.'
+            )
+        return operation
+    try:
+        operation_model = trustee_registry.operation_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    return _require_instance(operation, operation_model, 'operation')
+
+
+def _deny_empty(queryset):
+    return queryset.none()
+
+
+def is_authorized(principal, operation, resource, context=None, trustee=None, names=None):
+    """True when ``principal`` may perform ``operation`` on ``resource``."""
+    path, trustee_registry, requester_model = _prepare_resource(
+        resource, context, trustee, names,
+    )
+    _require_instance(principal, requester_model, 'requester')
+    if not principal_is_usable(principal):
+        return False
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.row_is_granted(resource, principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+def require_authorized(principal, operation, resource, context=None, trustee=None, names=None):
+    """Return ``resource`` or raise ``AuthorizationDenied``."""
+    if not is_authorized(
+        principal, operation, resource,
+        context=context, trustee=trustee, names=names,
+    ):
+        raise AuthorizationDenied(
+            'Not authorized to perform this operation on %s.' % (
+                _model_label(resource.__class__),
+            )
+        )
+    return resource
+
+
+def filter_authorized(queryset, principal, operation, context=None, trustee=None, names=None):
+    """SQL-filter ``queryset`` with the composed resource-origin predicate."""
+    context_registry = _as_context_registry(context)
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(principal, requester_model, 'requester')
+    try:
+        path = compose(
+            queryset.model, None, context=context_registry,
+            trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    if not principal_is_usable(principal):
+        return _deny_empty(queryset)
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.filter_granted(queryset, principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+def authorized_q(resource_model, principal, operation, context=None, trustee=None, names=None):
+    """Shared ``Q`` for resource-origin exists and list filters."""
+    context_registry = _as_context_registry(context)
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(principal, requester_model, 'requester')
+    try:
+        path = compose(
+            resource_model, None, context=context_registry,
+            trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    if not principal_is_usable(principal):
+        return empty_grant_q()
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.grant_q(principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+def is_scope_authorized(principal, operation, scope_obj, trustee=None, names=None):
+    """True when ``principal`` may perform ``operation`` on the scope row."""
+    path, trustee_registry, requester_model = _prepare_scope(
+        scope_obj, trustee, names,
+    )
+    _require_instance(principal, requester_model, 'requester')
+    if not principal_is_usable(principal):
+        return False
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.row_is_granted(scope_obj, principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+def require_scope_authorized(principal, operation, scope_obj, trustee=None, names=None):
+    """Return ``scope_obj`` or raise ``AuthorizationDenied``."""
+    if not is_scope_authorized(
+        principal, operation, scope_obj, trustee=trustee, names=names,
+    ):
+        raise AuthorizationDenied(
+            'Not authorized to perform this operation on %s.' % (
+                _model_label(scope_obj.__class__),
+            )
+        )
+    return scope_obj
+
+
+def filter_authorized_scope(queryset, principal, operation, trustee=None, names=None):
+    """SQL-filter a queryset whose model *is* the frozen Trustee scope."""
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(principal, requester_model, 'requester')
+    try:
+        path = compose_scope(
+            queryset.model, None, trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    if not principal_is_usable(principal):
+        return _deny_empty(queryset)
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.filter_granted(queryset, principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+def authorized_scope_q(scope_model, principal, operation, trustee=None, names=None):
+    """Shared ``Q`` for scope-origin exists and list filters."""
+    trustee_registry = _as_trustee_registry(trustee)
+    try:
+        requester_model = trustee_registry.requester_model()
+    except TrusteeRegistrationError as exc:
+        _wrap_path_error(exc)
+    _require_instance(principal, requester_model, 'requester')
+    try:
+        path = compose_scope(
+            scope_model, None, trustee=trustee_registry, names=names,
+        )
+    except AuthorizationPathError as exc:
+        _wrap_path_error(exc)
+    if not principal_is_usable(principal):
+        return empty_grant_q()
+    operation = _prepare_operation(operation, trustee_registry)
+    try:
+        return path.grant_q(principal, operation)
+    except (AuthorizationPathError, TrusteeRegistrationError) as exc:
+        _wrap_path_error(exc)
+
+
+__all__ = [
+    'AuthorizationConfigError',
+    'AuthorizationDenied',
+    'authorized_q',
+    'authorized_scope_q',
+    'filter_authorized',
+    'filter_authorized_scope',
+    'is_authorized',
+    'is_scope_authorized',
+    'principal_is_usable',
+    'require_authorized',
+    'require_scope_authorized',
+]

--- a/trusts/runtime.py
+++ b/trusts/runtime.py
@@ -13,7 +13,9 @@ Denial versus configuration:
   ``is_active is False``. Django's ``AnonymousUser`` therefore denies
   instead of raising a wrong-model config error.
 * Unknown operation *data* also denies (``False``, empty queryset,
-  ``AuthorizationDenied``).
+  ``AuthorizationDenied``), including a string the configured
+  ``operation_lookup`` field cannot prepare (for example
+  ``operation_lookup='id'`` plus ``'missing'``).
 * Usable principals that are the wrong requester model, raw PKs,
   unregistered resources, missing adapters, mixed/stale terminals,
   reserved slots, and incomplete ``operation_lookup`` raise

--- a/trusts/runtime.py
+++ b/trusts/runtime.py
@@ -7,12 +7,18 @@ and list share one ``grant_q``. There is no preliminary operation
 
 Denial versus configuration:
 
-* Unusable principal (attribute protocol) and unknown operation *data*
-  deny (``False``, empty queryset, ``AuthorizationDenied``).
-* Wrong-model / raw-PK terminals, unregistered resources, missing
-  adapters, mixed/stale terminals, reserved slots, and incomplete
-  ``operation_lookup`` raise ``AuthorizationConfigError``. Direct APIs
-  never hide a broken install behind ``.none()``.
+* Explicitly unusable principals are ordinary denials, checked **before**
+  requester-model identity. A principal is explicitly unusable when any of
+  ``is_anonymous is True``, ``is_authenticated is False``, or
+  ``is_active is False``. Django's ``AnonymousUser`` therefore denies
+  instead of raising a wrong-model config error.
+* Unknown operation *data* also denies (``False``, empty queryset,
+  ``AuthorizationDenied``).
+* Usable principals that are the wrong requester model, raw PKs,
+  unregistered resources, missing adapters, mixed/stale terminals,
+  reserved slots, and incomplete ``operation_lookup`` raise
+  ``AuthorizationConfigError``. Direct APIs never hide a broken install
+  behind ``.none()`` for a *usable* principal.
 """
 
 from django.core.exceptions import PermissionDenied
@@ -106,8 +112,13 @@ def principal_is_usable(principal):
     """Attribute protocol. Missing attributes are ignored.
 
     ``is_anonymous is True``, ``is_authenticated is False``, or
-    ``is_active is False`` makes the principal unusable. A model with
-    none of those attributes (for example a custom account) is usable.
+    ``is_active is False`` makes the principal unusable. Runtime entry
+    points check this **before** requester-model identity so Django's
+    ``AnonymousUser`` (and any other explicitly unusable object) takes
+    the ordinary denial path. A model with none of those attributes
+    (for example a custom account) is usable. ``None`` and raw PKs have
+    no flags and are still configuration errors via
+    :func:`_require_instance`.
     """
     if getattr(principal, 'is_anonymous', None) is True:
         return False
@@ -180,12 +191,12 @@ def _deny_empty(queryset):
 
 def is_authorized(principal, operation, resource, context=None, trustee=None, names=None):
     """True when ``principal`` may perform ``operation`` on ``resource``."""
+    if not principal_is_usable(principal):
+        return False
     path, trustee_registry, requester_model = _prepare_resource(
         resource, context, trustee, names,
     )
     _require_instance(principal, requester_model, 'requester')
-    if not principal_is_usable(principal):
-        return False
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.row_is_granted(resource, principal, operation)
@@ -209,6 +220,8 @@ def require_authorized(principal, operation, resource, context=None, trustee=Non
 
 def filter_authorized(queryset, principal, operation, context=None, trustee=None, names=None):
     """SQL-filter ``queryset`` with the composed resource-origin predicate."""
+    if not principal_is_usable(principal):
+        return _deny_empty(queryset)
     context_registry = _as_context_registry(context)
     trustee_registry = _as_trustee_registry(trustee)
     try:
@@ -223,8 +236,6 @@ def filter_authorized(queryset, principal, operation, context=None, trustee=None
         )
     except AuthorizationPathError as exc:
         _wrap_path_error(exc)
-    if not principal_is_usable(principal):
-        return _deny_empty(queryset)
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.filter_granted(queryset, principal, operation)
@@ -234,6 +245,8 @@ def filter_authorized(queryset, principal, operation, context=None, trustee=None
 
 def authorized_q(resource_model, principal, operation, context=None, trustee=None, names=None):
     """Shared ``Q`` for resource-origin exists and list filters."""
+    if not principal_is_usable(principal):
+        return empty_grant_q()
     context_registry = _as_context_registry(context)
     trustee_registry = _as_trustee_registry(trustee)
     try:
@@ -248,8 +261,6 @@ def authorized_q(resource_model, principal, operation, context=None, trustee=Non
         )
     except AuthorizationPathError as exc:
         _wrap_path_error(exc)
-    if not principal_is_usable(principal):
-        return empty_grant_q()
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.grant_q(principal, operation)
@@ -259,12 +270,12 @@ def authorized_q(resource_model, principal, operation, context=None, trustee=Non
 
 def is_scope_authorized(principal, operation, scope_obj, trustee=None, names=None):
     """True when ``principal`` may perform ``operation`` on the scope row."""
+    if not principal_is_usable(principal):
+        return False
     path, trustee_registry, requester_model = _prepare_scope(
         scope_obj, trustee, names,
     )
     _require_instance(principal, requester_model, 'requester')
-    if not principal_is_usable(principal):
-        return False
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.row_is_granted(scope_obj, principal, operation)
@@ -287,6 +298,8 @@ def require_scope_authorized(principal, operation, scope_obj, trustee=None, name
 
 def filter_authorized_scope(queryset, principal, operation, trustee=None, names=None):
     """SQL-filter a queryset whose model *is* the frozen Trustee scope."""
+    if not principal_is_usable(principal):
+        return _deny_empty(queryset)
     trustee_registry = _as_trustee_registry(trustee)
     try:
         requester_model = trustee_registry.requester_model()
@@ -299,8 +312,6 @@ def filter_authorized_scope(queryset, principal, operation, trustee=None, names=
         )
     except AuthorizationPathError as exc:
         _wrap_path_error(exc)
-    if not principal_is_usable(principal):
-        return _deny_empty(queryset)
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.filter_granted(queryset, principal, operation)
@@ -310,6 +321,8 @@ def filter_authorized_scope(queryset, principal, operation, trustee=None, names=
 
 def authorized_scope_q(scope_model, principal, operation, trustee=None, names=None):
     """Shared ``Q`` for scope-origin exists and list filters."""
+    if not principal_is_usable(principal):
+        return empty_grant_q()
     trustee_registry = _as_trustee_registry(trustee)
     try:
         requester_model = trustee_registry.requester_model()
@@ -322,8 +335,6 @@ def authorized_scope_q(scope_model, principal, operation, trustee=None, names=No
         )
     except AuthorizationPathError as exc:
         _wrap_path_error(exc)
-    if not principal_is_usable(principal):
-        return empty_grant_q()
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.grant_q(principal, operation)

--- a/trusts/trustee.py
+++ b/trusts/trustee.py
@@ -20,7 +20,12 @@ tables.
 """
 
 from django.apps import apps
-from django.core.exceptions import AppRegistryNotReady, FieldDoesNotExist
+from django.core.exceptions import (
+    AppRegistryNotReady,
+    FieldDoesNotExist,
+    FieldError,
+    ValidationError,
+)
 from django.db import models
 from django.db.models import (
     Exists,
@@ -46,6 +51,10 @@ from django.db.models.fields import GenericIPAddressField
 
 
 KIND_GRANT = 'grant'
+
+# Sentinel: a string operation that the configured lookup field cannot accept.
+# Compiles to an always-false grant predicate (ordinary denial, no SQL raise).
+_UNPREPARABLE_LOOKUP = object()
 
 
 class TrusteeRegistrationError(ValueError):
@@ -341,6 +350,18 @@ def _scalar_types_for_field(field):
     return ()
 
 
+def _prepare_lookup_value(field, value):
+    """Coerce ``value`` through ``field`` without a database lookup.
+
+    Returns the prepared value, or ``_UNPREPARABLE_LOOKUP`` when the
+    field cannot accept the value (unknown / wrong-type operation *data*).
+    """
+    try:
+        return field.get_prep_value(field.to_python(value))
+    except (TypeError, ValueError, OverflowError, ValidationError, FieldError):
+        return _UNPREPARABLE_LOOKUP
+
+
 def _field_is_unique_scalar(model, field_name):
     """True when ``field_name`` is a unique non-relation scalar on ``model``."""
     field = _get_field(model, field_name, field_name)
@@ -550,22 +571,36 @@ class TrusteeAdapter(object):
             and self.alignment_paths == other.alignment_paths
         )
 
+    def _string_operation_lookup(self, operation):
+        """Prepare a string operation through the configured lookup field.
+
+        Returns ``(lookup, prepared)``. ``prepared`` is
+        ``_UNPREPARABLE_LOOKUP`` when the field cannot accept the value.
+        There is no preliminary ``get()``.
+        """
+        lookup = None
+        if self.registry is not None:
+            lookup = getattr(self.registry, '_operation_lookup', None)
+        if not lookup:
+            raise TrusteeRegistrationError(
+                'String operations require operation_lookup on the '
+                'Trustee registry.'
+            )
+        field = _get_field(self.operation_model(), lookup, lookup)
+        return lookup, _prepare_lookup_value(field, operation)
+
     def _operation_filters(self, operation):
         """Compile an operation instance or lookup string into grant filters.
 
-        Strings become ``{operation_path__lookup: value}`` when the registry
-        has ``operation_lookup``. There is no preliminary ``get()``.
+        Strings become ``{operation_path__lookup: prepared}`` when the
+        registry has ``operation_lookup``. Unpreparable strings compile
+        to an always-false filter. There is no preliminary ``get()``.
         """
         if isinstance(operation, str):
-            lookup = None
-            if self.registry is not None:
-                lookup = getattr(self.registry, '_operation_lookup', None)
-            if not lookup:
-                raise TrusteeRegistrationError(
-                    'String operations require operation_lookup on the '
-                    'Trustee registry.'
-                )
-            return {'%s__%s' % (self.operation_path, lookup): operation}
+            lookup, prepared = self._string_operation_lookup(operation)
+            if prepared is _UNPREPARABLE_LOOKUP:
+                return {'pk__in': []}
+            return {'%s__%s' % (self.operation_path, lookup): prepared}
         return {self.operation_path: operation}
 
     def _apply_alignments(self, qs):
@@ -579,10 +614,21 @@ class TrusteeAdapter(object):
         return qs
 
     def _base_grant_qs(self, requester, operation, extra=None):
+        if isinstance(operation, str):
+            lookup, prepared = self._string_operation_lookup(operation)
+            if prepared is _UNPREPARABLE_LOOKUP:
+                return self.grant_model._default_manager.none()
+            operation_filters = {
+                '%s__%s' % (self.operation_path, lookup): prepared,
+            }
+        else:
+            lookup = None
+            prepared = None
+            operation_filters = {self.operation_path: operation}
         filters = {
             self.requester_from_grant_path(): requester,
         }
-        filters.update(self._operation_filters(operation))
+        filters.update(operation_filters)
         if extra:
             filters.update(extra)
         qs = self.grant_model._default_manager.filter(**filters)
@@ -590,8 +636,7 @@ class TrusteeAdapter(object):
             constraint = Q()
             for path in self.constraint_paths:
                 if isinstance(operation, str):
-                    lookup = getattr(self.registry, '_operation_lookup', None)
-                    constraint |= Q(**{'%s__%s' % (path, lookup): operation})
+                    constraint |= Q(**{'%s__%s' % (path, lookup): prepared})
                 else:
                     constraint |= Q(**{path: operation})
             qs = qs.filter(constraint)
@@ -744,8 +789,10 @@ class TrusteeRegistry(object):
         """Set requester / scope / operation terminals and optional lookup.
 
         ``operation_lookup`` is a unique scalar on ``operation_model``.
-        String operations compile as ``operation_path__lookup`` inside
-        the grant ``Exists``; there is no preliminary ``get()``.
+        String operations are prepared through that field and compile as
+        ``operation_path__lookup`` inside the grant ``Exists``; there is
+        no preliminary ``get()``. A value the field cannot accept
+        compiles to an always-false predicate (ordinary denial).
 
         The first successful registration may infer unset scope and
         operation models from its validated paths. Later adapters must

--- a/trusts/trustee.py
+++ b/trusts/trustee.py
@@ -22,8 +22,27 @@ tables.
 from django.apps import apps
 from django.core.exceptions import AppRegistryNotReady, FieldDoesNotExist
 from django.db import models
-from django.db.models import Exists, OuterRef, Q, UniqueConstraint
+from django.db.models import (
+    Exists,
+    F,
+    OuterRef,
+    Q,
+    UniqueConstraint,
+    BinaryField,
+    BooleanField,
+    CharField,
+    DateField,
+    DateTimeField,
+    DecimalField,
+    DurationField,
+    FloatField,
+    IntegerField,
+    TextField,
+    TimeField,
+    UUIDField,
+)
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.fields import GenericIPAddressField
 
 
 KIND_GRANT = 'grant'
@@ -289,6 +308,163 @@ def _scope_filter(scope_path, scopes):
     return {'%s__in' % scope_path: scopes}
 
 
+def _scalar_types_for_field(field):
+    """V1 type family for a scalar field. Relations are not scalars."""
+    if isinstance(field, BooleanField):
+        return (bool,)
+    if isinstance(field, IntegerField):
+        return (int,)
+    if isinstance(field, FloatField):
+        return (float, int)
+    if isinstance(field, DecimalField):
+        from decimal import Decimal
+        return (Decimal,)
+    if isinstance(field, (CharField, TextField, GenericIPAddressField)):
+        return (str,)
+    if isinstance(field, UUIDField):
+        from uuid import UUID
+        return (UUID,)
+    if isinstance(field, DateTimeField):
+        from datetime import datetime
+        return (datetime,)
+    if isinstance(field, DateField):
+        from datetime import date
+        return (date,)
+    if isinstance(field, TimeField):
+        from datetime import time
+        return (time,)
+    if isinstance(field, DurationField):
+        from datetime import timedelta
+        return (timedelta,)
+    if isinstance(field, BinaryField):
+        return (bytes,)
+    return ()
+
+
+def _field_is_unique_scalar(model, field_name):
+    """True when ``field_name`` is a unique non-relation scalar on ``model``."""
+    field = _get_field(model, field_name, field_name)
+    if getattr(field, 'is_relation', False):
+        return False
+    if getattr(field, 'unique', False):
+        return True
+    for constraint in getattr(model._meta, 'constraints', ()):
+        if _unconditional_single_field_unique(constraint, field_name):
+            return True
+    return False
+
+
+def _walk_alignment(model, path, api_name):
+    """Walk a grant-origin alignment path.
+
+    Intermediate hops must be single-valued relations. The terminal is a
+    single-valued FK or a scalar field. Returns
+    ``(terminal_field, related_model_or_None)``.
+    """
+    parts = _split_path(path, api_name)
+    seen = [_model_key(model)]
+    current = model
+    field = None
+    for index, name in enumerate(parts):
+        field = _get_field(current, name, path)
+        last = index == len(parts) - 1
+        if last:
+            if getattr(field, 'is_relation', False) is True:
+                _assert_single_valued_relation(field, path, current, name)
+                return field, _resolve_related_model(field)
+            if getattr(field, 'is_relation', False):
+                raise TrusteeRegistrationError(
+                    'Path %r: %r on %s is not a single-valued FK or scalar.' % (
+                        path, name, _model_label(current),
+                    )
+                )
+            return field, None
+        _assert_single_valued_relation(field, path, current, name)
+        target = _resolve_related_model(field)
+        key = _model_key(target)
+        if key in seen:
+            raise TrusteeRegistrationError(
+                'Path %r is cyclic: %s is visited twice.' % (
+                    path, _model_label(target),
+                )
+            )
+        seen.append(key)
+        current = target
+    raise TrusteeRegistrationError(
+        '%s %r is not a composable relational path.' % (api_name, path)
+    )
+
+
+def _alignment_terminals_compatible(left_field, left_related, right_field, right_related):
+    """True when two alignment terminals are the same identity kind."""
+    left_rel = left_related is not None
+    right_rel = right_related is not None
+    if left_rel and right_rel:
+        return _model_key(left_related) is _model_key(right_related)
+    if left_rel or right_rel:
+        return False
+    left_types = set(_scalar_types_for_field(left_field))
+    right_types = set(_scalar_types_for_field(right_field))
+    return bool(left_types and left_types.intersection(right_types))
+
+
+def _normalize_alignment_paths(alignment_paths):
+    """Validate shape. Return a tuple of ``(left, right)`` path pairs."""
+    if alignment_paths is None:
+        return ()
+    if callable(alignment_paths):
+        raise TrusteeRegistrationError(
+            'alignment_paths must be a sequence of pairs, not a callable.'
+        )
+    if isinstance(alignment_paths, (str, bytes)):
+        raise TrusteeRegistrationError(
+            'alignment_paths must be a sequence of pairs, not %r.' % (
+                alignment_paths,
+            )
+        )
+    try:
+        items = tuple(alignment_paths)
+    except TypeError:
+        raise TrusteeRegistrationError(
+            'alignment_paths must be a sequence of pairs, not %r.' % (
+                alignment_paths,
+            )
+        )
+    pairs = []
+    for item in items:
+        if callable(item):
+            raise TrusteeRegistrationError(
+                'alignment_paths entries must be pairs of relational paths, '
+                'not a callable.'
+            )
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            raise TrusteeRegistrationError(
+                'alignment_paths entries must be pairs of relational paths, '
+                'not %r.' % (item,)
+            )
+        left, right = item
+        pairs.append((left, right))
+    return tuple(pairs)
+
+
+def _validate_alignment_pair(grant_model, left, right):
+    left_field, left_related = _walk_alignment(grant_model, left, 'alignment_path')
+    right_field, right_related = _walk_alignment(
+        grant_model, right, 'alignment_path',
+    )
+    if not _alignment_terminals_compatible(
+        left_field, left_related, right_field, right_related,
+    ):
+        raise TrusteeRegistrationError(
+            'alignment_paths pair (%r, %r) on %s does not terminate in '
+            'compatible identities (same FK model or same scalar type '
+            'family; FK vs scalar PK is rejected).' % (
+                left, right, _model_label(grant_model),
+            )
+        )
+    return (left, right)
+
+
 class TrusteeMixin(models.Model):
     """Abstract declaration convenience. Adds no concrete fields.
 
@@ -307,12 +483,13 @@ class TrusteeAdapter(object):
     __slots__ = (
         'kind', 'name', 'trustee_model', 'membership_path', 'grant_model',
         'trustee_path', 'scope_path', 'operation_path', 'constraint_paths',
-        'registry',
+        'alignment_paths', 'registry',
     )
 
     def __init__(
         self, kind, name, trustee_model, membership_path, grant_model,
         trustee_path, scope_path, operation_path, constraint_paths, registry,
+        alignment_paths=(),
     ):
         self.kind = kind
         self.name = name
@@ -323,6 +500,7 @@ class TrusteeAdapter(object):
         self.scope_path = scope_path
         self.operation_path = operation_path
         self.constraint_paths = tuple(constraint_paths)
+        self.alignment_paths = tuple(alignment_paths)
         self.registry = registry
 
     def __repr__(self):
@@ -369,22 +547,55 @@ class TrusteeAdapter(object):
             and self.scope_path == other.scope_path
             and self.operation_path == other.operation_path
             and self.constraint_paths == other.constraint_paths
+            and self.alignment_paths == other.alignment_paths
         )
+
+    def _operation_filters(self, operation):
+        """Compile an operation instance or lookup string into grant filters.
+
+        Strings become ``{operation_path__lookup: value}`` when the registry
+        has ``operation_lookup``. There is no preliminary ``get()``.
+        """
+        if isinstance(operation, str):
+            lookup = None
+            if self.registry is not None:
+                lookup = getattr(self.registry, '_operation_lookup', None)
+            if not lookup:
+                raise TrusteeRegistrationError(
+                    'String operations require operation_lookup on the '
+                    'Trustee registry.'
+                )
+            return {'%s__%s' % (self.operation_path, lookup): operation}
+        return {self.operation_path: operation}
+
+    def _apply_alignments(self, qs):
+        """AND grant-row equalities. NULL on either side does not authorize."""
+        for left, right in self.alignment_paths:
+            qs = qs.filter(
+                Q(**{left: F(right)})
+                & Q(**{'%s__isnull' % left: False})
+                & Q(**{'%s__isnull' % right: False})
+            )
+        return qs
 
     def _base_grant_qs(self, requester, operation, extra=None):
         filters = {
             self.requester_from_grant_path(): requester,
-            self.operation_path: operation,
         }
+        filters.update(self._operation_filters(operation))
         if extra:
             filters.update(extra)
         qs = self.grant_model._default_manager.filter(**filters)
         if self.constraint_paths:
             constraint = Q()
             for path in self.constraint_paths:
-                constraint |= Q(**{path: operation})
+                if isinstance(operation, str):
+                    lookup = getattr(self.registry, '_operation_lookup', None)
+                    constraint |= Q(**{'%s__%s' % (path, lookup): operation})
+                else:
+                    constraint |= Q(**{path: operation})
             qs = qs.filter(constraint)
-        return qs
+        return self._apply_alignments(qs)
 
     def exists_q(self, requester, operation, scope_from_row=''):
         """``Exists`` matching this adapter on the filtered row's scope."""
@@ -405,21 +616,28 @@ class TrusteeAdapter(object):
             for path in self.constraint_paths:
                 constraint |= Q(**{path: OuterRef('pk')})
             qs = qs.filter(constraint)
+        qs = self._apply_alignments(qs)
         return Exists(qs)
 
 
 class TrusteeRegistry(object):
     """Mutable adapter map that freezes before authorization queries."""
 
-    def __init__(self, requester_model=None, scope_model=None, operation_model=None):
+    def __init__(
+        self, requester_model=None, scope_model=None, operation_model=None,
+        operation_lookup=None,
+    ):
         self._adapters = {}
         self._requester_model = requester_model
         self._scope_model = scope_model
         self._operation_model = operation_model
+        self._operation_lookup = None
         self._frozen = False
         self._finalizers = []
         self._finalized = False
         self._finalizing = False
+        if operation_lookup is not None:
+            self._set_operation_lookup(operation_lookup)
 
     def is_frozen(self):
         return self._frozen
@@ -444,6 +662,53 @@ class TrusteeRegistry(object):
                 'Operation model is not configured.'
             )
         return _resolve_model(self._operation_model, 'operation_model')
+
+    def operation_lookup(self):
+        return self._operation_lookup
+
+    def _validate_operation_lookup(self, lookup, operation_model=None):
+        """``lookup`` must name a unique scalar on the operation model."""
+        if lookup is None:
+            return None
+        if not isinstance(lookup, str) or not lookup or LOOKUP_SEP in lookup:
+            raise TrusteeRegistrationError(
+                'operation_lookup must be a unique scalar field name, not %r.' % (
+                    lookup,
+                )
+            )
+        if operation_model is None:
+            if self._operation_model is None:
+                return lookup
+            operation_model = _resolve_model(self._operation_model, 'operation_model')
+        if not _field_is_unique_scalar(operation_model, lookup):
+            raise TrusteeRegistrationError(
+                'operation_lookup %r on %s must be a unique scalar field.' % (
+                    lookup, _model_label(operation_model),
+                )
+            )
+        return lookup
+
+    def _set_operation_lookup(self, lookup):
+        resolved = self._validate_operation_lookup(lookup)
+        current = self._operation_lookup
+        if current is not None:
+            if current == resolved:
+                return current
+            if self._frozen or self._finalized:
+                raise TrusteeRegistryFrozen(
+                    'Trustee registry is frozen; cannot reconfigure '
+                    'operation_lookup.'
+                )
+            raise TrusteeRegistrationError(
+                'operation_lookup is already configured as %r; cannot '
+                'configure %r.' % (current, resolved)
+            )
+        if self._frozen or self._finalized:
+            raise TrusteeRegistryFrozen(
+                'Trustee registry is frozen; cannot configure operation_lookup.'
+            )
+        self._operation_lookup = resolved
+        return resolved
 
     def _set_configured_model(self, attr, value, what):
         resolved = _resolve_model(value, what)
@@ -472,8 +737,15 @@ class TrusteeRegistry(object):
         setattr(self, attr, resolved)
         return resolved
 
-    def configure(self, requester_model=None, scope_model=None, operation_model=None):
-        """Set requester / scope / operation models adapters must terminate at.
+    def configure(
+        self, requester_model=None, scope_model=None, operation_model=None,
+        operation_lookup=None,
+    ):
+        """Set requester / scope / operation terminals and optional lookup.
+
+        ``operation_lookup`` is a unique scalar on ``operation_model``.
+        String operations compile as ``operation_path__lookup`` inside
+        the grant ``Exists``; there is no preliminary ``get()``.
 
         The first successful registration may infer unset scope and
         operation models from its validated paths. Later adapters must
@@ -493,10 +765,22 @@ class TrusteeRegistry(object):
             resolved = self._set_configured_model(
                 '_operation_model', operation_model, 'operation_model',
             )
-        if requester_model is None and scope_model is None and operation_model is None:
+        if operation_lookup is not None:
+            resolved = self._set_operation_lookup(operation_lookup)
+        if (
+            requester_model is None and scope_model is None
+            and operation_model is None and operation_lookup is None
+        ):
             raise TrusteeRegistrationError(
-                'configure() requires requester_model, scope_model, or '
-                'operation_model.'
+                'configure() requires requester_model, scope_model, '
+                'operation_model, or operation_lookup.'
+            )
+        if self._operation_lookup and self._operation_model is not None:
+            self._validate_operation_lookup(
+                self._operation_lookup,
+                operation_model=_resolve_model(
+                    self._operation_model, 'operation_model',
+                ),
             )
         return resolved
 
@@ -533,15 +817,33 @@ class TrusteeRegistry(object):
                 requester_snapshot = self._requester_model
                 scope_snapshot = self._scope_model
                 operation_snapshot = self._operation_model
+                lookup_snapshot = self._operation_lookup
                 try:
                     for func in list(self._finalizers):
                         func()
+                    if self._operation_lookup is not None:
+                        self._validate_operation_lookup(
+                            self._operation_lookup,
+                            operation_model=(
+                                _resolve_model(
+                                    self._operation_model, 'operation_model',
+                                )
+                                if self._operation_model is not None
+                                else None
+                            ),
+                        )
+                        if self._operation_model is None:
+                            raise TrusteeRegistrationError(
+                                'operation_lookup is configured but '
+                                'operation_model is not.'
+                            )
                 except Exception:
                     self._adapters.clear()
                     self._adapters.update(snapshot)
                     self._requester_model = requester_snapshot
                     self._scope_model = scope_snapshot
                     self._operation_model = operation_snapshot
+                    self._operation_lookup = lookup_snapshot
                     raise
                 self._finalizers = []
                 self._finalized = True
@@ -576,6 +878,7 @@ class TrusteeRegistry(object):
     def register(
         self, name, trustee_model, grant_model, trustee_path, scope_path,
         operation_path, membership_path='', constraint_paths=(),
+        alignment_paths=(),
     ):
         """Register one grant adapter.
 
@@ -585,16 +888,23 @@ class TrusteeRegistry(object):
         operation model; they constrain a completed path and never create
         authorization. They are OR-composed with each other and AND-ed
         with the grant match.
+
+        ``alignment_paths`` are grant-origin pairs of compatible
+        identities. Each pair is AND-ed into this adapter's ``Exists``
+        with ``F()`` equality and non-NULL on both sides. They are not
+        ``constraint_paths`` and never mention the operation model.
         """
         adapter = self._build_adapter(
             KIND_GRANT, name, trustee_model, membership_path, grant_model,
             trustee_path, scope_path, operation_path, constraint_paths,
+            alignment_paths=alignment_paths,
         )
         return self._commit(adapter)
 
     def _build_adapter(
         self, kind, name, trustee_model, membership_path, grant_model,
         trustee_path, scope_path, operation_path, constraint_paths,
+        alignment_paths=(),
     ):
         if callable(name):
             raise TrusteeRegistrationError(
@@ -699,9 +1009,26 @@ class TrusteeRegistry(object):
                     )
                 )
 
+        pairs = _normalize_alignment_paths(alignment_paths)
+        validated_pairs = []
+        for left, right in pairs:
+            validated_pairs.append(
+                _validate_alignment_pair(grant_model, left, right)
+            )
+        alignment_paths = tuple(validated_pairs)
+
+        if self._operation_lookup is not None and self._operation_model is not None:
+            self._validate_operation_lookup(
+                self._operation_lookup,
+                operation_model=_resolve_model(
+                    self._operation_model, 'operation_model',
+                ),
+            )
+
         return TrusteeAdapter(
             kind, name, trustee_model, membership_path, grant_model,
             trustee_path, scope_path, operation_path, constraint_paths, self,
+            alignment_paths=alignment_paths,
         )
 
     def _commit(self, adapter):
@@ -723,6 +1050,7 @@ class TrusteeRegistry(object):
                 and other.scope_path == adapter.scope_path
                 and other.operation_path == adapter.operation_path
                 and other.constraint_paths == adapter.constraint_paths
+                and other.alignment_paths == adapter.alignment_paths
             ):
                 raise TrusteeRegistrationError(
                     'Trustee adapter %r duplicates %r for the same '
@@ -780,10 +1108,20 @@ class TrusteeRegistry(object):
 
     def revalidate(self, adapter):
         """Re-walk a stored adapter. Raise ``TrusteeRegistrationError`` if stale."""
+        if self._operation_lookup is not None:
+            self._validate_operation_lookup(
+                self._operation_lookup,
+                operation_model=(
+                    _resolve_model(self._operation_model, 'operation_model')
+                    if self._operation_model is not None
+                    else None
+                ),
+            )
         rebuilt = self._build_adapter(
             adapter.kind, adapter.name, adapter.trustee_model,
             adapter.membership_path, adapter.grant_model, adapter.trustee_path,
             adapter.scope_path, adapter.operation_path, adapter.constraint_paths,
+            alignment_paths=adapter.alignment_paths,
         )
         if not rebuilt.equivalent(adapter):
             raise TrusteeRegistrationError(
@@ -852,7 +1190,9 @@ class TrusteeRegistry(object):
 def check_registration(
     name, trustee_model, grant_model, trustee_path, scope_path,
     operation_path, membership_path='', constraint_paths=(),
-    requester_model=None, scope_model=None, operation_model=None, registry=None,
+    alignment_paths=(),
+    requester_model=None, scope_model=None, operation_model=None,
+    operation_lookup=None, registry=None,
 ):
     """Validate a proposed registration without committing it.
 
@@ -864,6 +1204,7 @@ def check_registration(
             requester_model=requester_model,
             scope_model=scope_model,
             operation_model=operation_model,
+            operation_lookup=operation_lookup,
         )
     else:
         if requester_model is not None and registry._requester_model is None:
@@ -872,10 +1213,13 @@ def check_registration(
             registry.configure(scope_model=scope_model)
         if operation_model is not None and registry._operation_model is None:
             registry.configure(operation_model=operation_model)
+        if operation_lookup is not None and registry._operation_lookup is None:
+            registry.configure(operation_lookup=operation_lookup)
     try:
         registry._build_adapter(
             KIND_GRANT, name, trustee_model, membership_path, grant_model,
             trustee_path, scope_path, operation_path, constraint_paths,
+            alignment_paths=alignment_paths,
         )
     except TrusteeRegistrationError as exc:
         return exc
@@ -894,22 +1238,28 @@ class Trustee(object):
     KIND_GRANT = KIND_GRANT
 
     @classmethod
-    def configure(cls, requester_model=None, scope_model=None, operation_model=None):
+    def configure(
+        cls, requester_model=None, scope_model=None, operation_model=None,
+        operation_lookup=None,
+    ):
         return cls.registry.configure(
             requester_model=requester_model,
             scope_model=scope_model,
             operation_model=operation_model,
+            operation_lookup=operation_lookup,
         )
 
     @classmethod
     def register(
         cls, name, trustee_model, grant_model, trustee_path, scope_path,
         operation_path, membership_path='', constraint_paths=(),
+        alignment_paths=(),
     ):
         return cls.registry.register(
             name, trustee_model, grant_model, trustee_path, scope_path,
             operation_path, membership_path=membership_path,
             constraint_paths=constraint_paths,
+            alignment_paths=alignment_paths,
         )
 
     @classmethod


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#47 kernel S1 only, per accepted framework-execution-r1+r2+r3. Does **not** close #47. Does not modify django-trusts-zero, start gh-permissions#1, resume #17, or implement S2 backend / S3 decorators / S4 UI.

**HEAD:** `9709bd1d11f9d3640239dd182247d02585db7a8f`

## What this ships

1. `Context.register_identity` — resource *is* its policy scope; compiled `scope_path` is empty.
2. Trustee `operation_lookup` on `configure` / isolated `TrusteeRegistry`. String operations are prepared through the lookup field (no preliminary `get()`) and compile as `{operation_path__lookup: prepared}` inside the same `Exists`. A value the field cannot accept (for example `operation_lookup='id'` plus `'missing'`) is an always-false predicate — ordinary denial, not `ValueError` / `FieldError`.
3. Trustee `alignment_paths` — grant-row pairs, frozen on adapter/branch, revalidated by `E007`. AND-ed into that adapter's `Exists` with `F()` + non-NULL. Not `constraint_paths`.
4. `AuthorizationPath.compose_scope` — explicit scope-origin compiler. No public `scope_from_row`.
5. `trusts.runtime` object/scope APIs. Unusable principal / unknown operation data deny. Unregistered resource, raw PK, wrong model, missing adapters, incomplete lookup raise `AuthorizationConfigError`. Explicitly unusable principals (incl. Django `AnonymousUser`) deny **before** requester-model mismatch.
6. `trusts.query.AuthorizedQuerySet.authorized` / `AuthorizedManager`. Class name stays `AuthorizedQuerySet` (r1/r2 verb `authorized`; Zero keeps `permitted`).
7. Isolated kernel tests: object≡list, one-query, cross-org malformed grant deny, NULL alignment deny, registration traps, AnonymousUser ordinary denial path, non-text `operation_lookup` unknown-string denial.
8. `migrates.md` for the new public API and authorization implications.

## Query counts (local, isolated S1 fixtures)

Every supported object/list decision is **one SQL statement** (unusable-principal short-circuit is zero-query):

| Path | Queries |
|---|---:|
| `is_authorized` / `row_is_granted` | 1 |
| `filter_authorized` list | 1 |
| `exists()` of `authorized_q` | 1 |
| string `'read'` object / list | 1 (no `Operation.objects.get`) |
| unknown string code (`operation_lookup='code'`) | 1 (deny) |
| `operation_lookup='id'` + `str(op.pk)` object / list / scope | 1 |
| `operation_lookup='id'` + `'missing'` object / list / scope | 1 (always-false predicate, deny) |
| `is_scope_authorized` / `filter_authorized_scope` | 1 |
| `AuthorizedQuerySet.authorized` | 1 |
| trap-grant evaluate (no getters) | 1 |
| unusable / AnonymousUser deny | 0 |

Alignment adds joins inside the same `Exists`, not a preliminary query. Equivalence: `is_authorized(p, op, obj) == type(obj).objects.filter(pk=obj.pk).filter(authorized_q(...)).exists() == obj in filter_authorized(...)`.

## Test matrix (local)

| Command | Result |
|---|---|
| `python -m tests.runtests` | 383 tests, OK (1 expected failure, historical Junction) |
| `python -m tests.runtests_custom` | 7 tests, OK |
| `python -m django check --settings=tests.settings` | OK |
| `python -m django check --settings=tests.custom_settings` | OK |

r? @chatforthomas

<!-- CURSOR_AGENT_PR_BODY_END -->