### PR TITLE
Kernel S2: object-only ObjectAuthorizationBackend

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -24,6 +24,10 @@ installable `trusts/` package:
   identity Context / `operation_lookup` / `alignment_paths` / `compose_scope`
   (isolated registries; object≡list; one-query; cross-org and NULL
   alignment deny; registration traps)
+- `tests/core/test_s2_backend.py` — issue #47 S2 object-only
+  `ObjectAuthorizationBackend` (`BaseBackend`; `obj is None` False;
+  config error → denial; superuser does not grant objects; ModelBackend
+  coexistence)
 - `tests/core/test_zero_path.py` — issue #43 Step 2 Zero consumer of compose
   (`ContentQuerySet.permitted` / `TrustModelBackend`; same-PK fail-closed)
 - `tests/core/test_kernel_split.py` — issue #43 Step 3 kernel/Zero AppConfig,
@@ -33,6 +37,7 @@ installable `trusts/` package:
   by explicit labels (`tests.core.test_core`, `tests.core.test_context`,
   `tests.core.test_trustee`, `tests.core.test_path`,
   `tests.core.test_gh_vocab`, `tests.core.test_s1_kernel`,
+  `tests.core.test_s2_backend`,
   `tests.core.test_zero_path`,
   `tests.core.test_kernel_split`, `tests.core.test_wheel_install`,
   `tests.regressions.test_issue_*`)

--- a/migrates.md
+++ b/migrates.md
@@ -2084,3 +2084,108 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #47 from this PR.
 
+# Issue #47 S2: object-only authorization backend (1.0.0.dev0)
+
+This record covers the second kernel execution slice. Version remains
+**1.0.0.dev0**. This PR does **not** close
+[#47](https://github.com/django-trusts/django-trusts/issues/47); review
+owns that. It implements accepted **framework-execution-r1+r2+r3**
+kernel S2 only. It does **not** modify `django-trusts-zero`, start
+gh-permissions#1, resume #17, or implement S3 decorators / S4
+admin/CBVs/templates.
+
+## Decision
+
+```text
+trusts.backends:
+  ObjectAuthorizationBackend          # advertised default; BaseBackend
+  ObjectAuthorizationModelBackend     # optional ModelBackend compose
+```
+
+`ObjectAuthorizationBackend` is object-only:
+
+- `authenticate()` abstains (`None`).
+- `obj is None` returns `False` (no global or model permissions).
+- A supplied object routes through S1 `is_authorized` / the shared
+  `grant_q` path. `perm` is an operation instance or
+  `operation_lookup` string. There is no `app.action_model` parser.
+- `AuthorizationConfigError` becomes denial (`False`) at this security
+  boundary. Direct runtime APIs still raise.
+- Ordinary denials (anonymous / inactive / unauthenticated principals,
+  unknown operation data) stay denials.
+- The generic backend does not assume Django User or `auth.Permission`
+  models and does not grant object access because `is_superuser`.
+
+`ObjectAuthorizationModelBackend` is a separately named convenience:
+`obj is None` uses Django `ModelBackend` model permissions; object
+checks stay on `ObjectAuthorizationBackend`. It is not required for GH
+and is not the advertised default. Zero keeps
+`trusts.zero.backends.TrustModelBackend` and its Permission / Content /
+cache / `:condition` policy.
+
+## No change to these public call sites
+
+- S1 `trusts.runtime` / `trusts.query` / `compose` / `compose_scope`
+- `Context.register_identity` / Trustee `operation_lookup` /
+  `alignment_paths`
+- Zero `TrustModelBackend`, `ContentQuerySet.permitted`, decorators,
+  admin, views, historical migrations, app label `trusts`
+- Package version `1.0.0.dev0`
+
+## Changes
+
+### 44. `trusts.backends.ObjectAuthorizationBackend` (new)
+
+| | |
+| --- | --- |
+| Previous | Consumers wired Django `User.has_perm` themselves, or used Zero `TrustModelBackend` (Permission strings, `Content.is_content`, `obj is None` → Django model perms). |
+| New | Object-only `BaseBackend`. Isolated tests pass `context=` / `trustee=` to the constructor (process-wide maps remain the no-arg default). |
+| Replacement | Add `trusts.backends.ObjectAuthorizationBackend` to `AUTHENTICATION_BACKENDS` for object checks. Keep Django `ModelBackend` (or Zero) beside it for login and model permissions. |
+| Affected | New kernel consumers. Zero does not subclass this in S2. |
+| Authorization | Object success/denial follow S1 `is_authorized` (one SQL `Exists`). `obj is None` is `False`. Malformed configuration denies rather than raising through `has_perm`. An active superuser is not granted object access by this backend. Django `PermissionsMixin.has_perm` still short-circuits active superusers before backends run. |
+
+### 45. `trusts.backends.ObjectAuthorizationModelBackend` (new, optional)
+
+| | |
+| --- | --- |
+| Previous | No framework `ModelBackend` compose. |
+| New | `ObjectAuthorizationBackend` + `ModelBackend`. `obj is None` → Django model permissions (including ModelBackend's active-superuser global grant). `obj` set → generic object path. `authenticate` / `get_user` follow `ModelBackend`. |
+| Replacement | Use only when one backend should serve both Django model permissions and object checks. Not required for GH. |
+| Affected | Optional convenience. |
+| Authorization | Object/global dispatch is explicit. Object access is not widened by model permissions or `is_superuser`. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m tests.runtests
+```
+
+No Trusts schema migration. S2 uses the existing isolated S1 test models.
+
+## Upgrade of a representative legacy database
+
+Unchanged. `scripts/verify-legacy-upgrade.py` still expects
+`{0001_initial, 0002_trustgroup}` on label `trusts`.
+
+## Out of scope (unchanged)
+
+- S3 native decorators / `P`/`K`/`G`/`O`
+- S4 admin / CBV mixins / stub templates
+- Generic `register_row_condition`
+- `RecursiveEdge` / `OrderedContribution`
+- django-trusts-zero wrappers or pin bump
+- gh-permissions#1
+- Closing #17 or #47
+
+## Migration-bot summary (issue #47 S2)
+
+- [ ] Use `ObjectAuthorizationBackend` for object `has_perm`; do not expect global grants from it.
+- [ ] Catch `AuthorizationConfigError` only at security boundaries (this backend already does).
+- [ ] Do not parse `app.action_model` in the generic backend; pass an operation instance or lookup string.
+- [ ] Keep Django `ModelBackend` (or Zero) if you still need login or model permissions.
+- [ ] Treat `ObjectAuthorizationModelBackend` as optional compose, not the default.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_s2_backend`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #47 from this PR.
+

--- a/scripts/verify-wheel-install.py
+++ b/scripts/verify-wheel-install.py
@@ -99,6 +99,7 @@ def main() -> int:
     from trusts.context import Context
     from trusts.trustee import Trustee
     from trusts.path import AuthorizationPath, AuthorizationBranch, compose
+    from trusts.backends import ObjectAuthorizationBackend
     from django_trusts import TQ, condition_refs
 
     trusts_file = Path(trusts.__file__).resolve()
@@ -132,6 +133,7 @@ def main() -> int:
     print('AuthorizationPath', AuthorizationPath)
     print('AuthorizationBranch', AuthorizationBranch)
     print('compose', compose)
+    print('ObjectAuthorizationBackend', ObjectAuthorizationBackend)
     print('TQ', TQ)
     print('condition_refs', condition_refs)
     print('absent test modules', ' '.join(ABSENT_TEST_MODULES))

--- a/tests/core/test_s2_backend.py
+++ b/tests/core/test_s2_backend.py
@@ -1,0 +1,352 @@
+"""Isolated kernel tests for #47 S2 (object-only authorization backend).
+
+``ObjectAuthorizationBackend`` is a ``BaseBackend``. Object checks route
+through S1 ``is_authorized``. ``AuthorizationConfigError`` becomes
+denial. Isolated registries only. Does not close #47. Does not
+implement S3–S4.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+from django.contrib.auth.backends import BaseBackend, ModelBackend
+from django.contrib.auth.models import AnonymousUser, Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+
+from trusts.backends import (
+    ObjectAuthorizationBackend,
+    ObjectAuthorizationModelBackend,
+)
+from trusts.context import ContextRegistry
+from trusts.runtime import AuthorizationConfigError, is_authorized
+from trusts.trustee import TrusteeRegistry
+from tests.core.test_s1_kernel import S1_DIRECT, _s1_maps
+from tests.models import (
+    S1Account,
+    S1Bundle,
+    S1DirectGrant,
+    S1Operation,
+    S1Organization,
+    S1Repository,
+    S1Team,
+    S1TeamGrant,
+    S1UnregisteredNote,
+)
+
+
+class S2BackendContractTest(TestCase):
+    def test_generic_backend_is_object_only_basebackend(self):
+        self.assertTrue(issubclass(ObjectAuthorizationBackend, BaseBackend))
+        self.assertFalse(issubclass(ObjectAuthorizationBackend, ModelBackend))
+        self.assertTrue(
+            issubclass(ObjectAuthorizationModelBackend, ObjectAuthorizationBackend)
+        )
+        self.assertTrue(issubclass(ObjectAuthorizationModelBackend, ModelBackend))
+
+    def test_backends_module_has_no_product_nouns_or_perm_parser(self):
+        from trusts import backends
+        source = Path(inspect.getfile(backends)).read_text()
+        for noun in ('Trust', 'Content', 'Junction', 'GitHub'):
+            self.assertIsNone(
+                re.search(r'\b%s\b' % noun, source),
+                '%r appears as a product noun in trusts.backends' % (noun,),
+            )
+        self.assertNotIn('parse_perm_code', source)
+        self.assertNotIn('is_content', source)
+        self.assertNotIn('is_superuser', source)
+        self.assertNotIn('app.action_model', source)
+
+    def test_authenticate_abstains(self):
+        backend = ObjectAuthorizationBackend()
+        self.assertIsNone(backend.authenticate(None))
+        self.assertIsNone(
+            backend.authenticate(None, username='pat', password='secret'),
+        )
+
+
+class S2ObjectHasPermTest(TestCase):
+    def setUp(self):
+        super(S2ObjectHasPermTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.team = S1Team.objects.create(organization=self.org, name='writers')
+        self.member = S1Account.objects.create(name='member')
+        self.stranger = S1Account.objects.create(name='stranger')
+        self.team.members.add(self.member)
+        self.read = S1Operation.objects.create(code='read')
+        self.repo_a = S1Repository.objects.create(
+            organization=self.org, title='repo-a',
+        )
+        self.repo_b = S1Repository.objects.create(
+            organization=self.org, title='repo-b',
+        )
+        bundle = S1Bundle.objects.create(team=self.team, name='reader')
+        bundle.operations.add(self.read)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.read,
+        )
+        self.context, self.trustee = _s1_maps()
+        self.backend = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+        self.runtime = dict(context=self.context, trustee=self.trustee)
+
+    def test_object_success_and_denial_via_has_perm(self):
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                self.backend.has_perm(self.member, 'read', self.repo_a)
+            )
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                self.backend.has_perm(self.member, 'read', self.repo_b)
+            )
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                self.backend.has_perm(self.stranger, 'read', self.repo_a)
+            )
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                self.backend.has_perm(self.member, self.read, self.repo_a)
+            )
+        self.assertEqual(
+            self.backend.has_perm(self.member, 'read', self.repo_a),
+            is_authorized(self.member, 'read', self.repo_a, **self.runtime),
+        )
+
+    def test_django_perm_string_is_not_parsed(self):
+        django_shaped = 'trusts_tests.read_s1repository'
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                self.backend.has_perm(self.member, django_shaped, self.repo_a)
+            )
+
+    def test_obj_none_is_false_without_sql(self):
+        with self.assertNumQueries(0):
+            self.assertFalse(self.backend.has_perm(self.member, 'read'))
+            self.assertFalse(
+                self.backend.has_perm(self.member, 'read', obj=None)
+            )
+            self.assertFalse(
+                self.backend.has_perm(self.member, 'trusts_tests.read_s1repository')
+            )
+
+
+class S2OrdinaryDenialTest(TestCase):
+    def setUp(self):
+        super(S2OrdinaryDenialTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+        self.context, self.trustee = _s1_maps()
+        self.backend = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+
+    def test_anonymous_user_ordinary_denial(self):
+        with self.assertNumQueries(0):
+            self.assertFalse(
+                self.backend.has_perm(AnonymousUser(), 'read', self.repo)
+            )
+
+    def test_inactive_and_unauthenticated_ordinary_denial(self):
+        self.account.is_active = False
+        with self.assertNumQueries(0):
+            self.assertFalse(
+                self.backend.has_perm(self.account, 'read', self.repo)
+            )
+        del self.account.is_active
+        self.account.is_authenticated = False
+        with self.assertNumQueries(0):
+            self.assertFalse(
+                self.backend.has_perm(self.account, 'read', self.repo)
+            )
+
+    def test_unknown_operation_data_ordinary_denial(self):
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                self.backend.has_perm(self.account, 'missing', self.repo)
+            )
+
+
+class S2ConfigErrorDenialTest(TestCase):
+    def setUp(self):
+        super(S2ConfigErrorDenialTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+        self.context, self.trustee = _s1_maps()
+        self.backend = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+
+    def test_unregistered_resource_denies_without_raising(self):
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo, text='nope',
+        )
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.account, 'read', note,
+                context=self.context, trustee=self.trustee,
+            )
+        self.assertFalse(self.backend.has_perm(self.account, 'read', note))
+
+    def test_wrong_model_and_raw_pk_deny_without_raising(self):
+        self.assertFalse(self.backend.has_perm(self.repo, 'read', self.repo))
+        self.assertFalse(
+            self.backend.has_perm(self.account.pk, 'read', self.repo)
+        )
+        self.assertFalse(
+            self.backend.has_perm(self.account, self.read.pk, self.repo)
+        )
+
+    def test_string_without_lookup_denies_without_raising(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        )
+        trustee.register(
+            name=S1_DIRECT,
+            trustee_model=S1Account,
+            grant_model=S1DirectGrant,
+            trustee_path='account',
+            scope_path='repository',
+            operation_path='operation',
+        )
+        backend = ObjectAuthorizationBackend(context=context, trustee=trustee)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.account, 'read', self.repo,
+                context=context, trustee=trustee,
+            )
+        self.assertFalse(backend.has_perm(self.account, 'read', self.repo))
+
+    def test_empty_adapters_deny_without_raising(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='code',
+        )
+        backend = ObjectAuthorizationBackend(context=context, trustee=trustee)
+        self.assertFalse(backend.has_perm(self.account, 'read', self.repo))
+
+
+class S2SuperuserContractTest(TestCase):
+    def setUp(self):
+        super(S2SuperuserContractTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+        S1DirectGrant.objects.create(
+            account=self.account, repository=self.repo, operation=self.read,
+        )
+        self.other = S1Repository.objects.create(
+            organization=self.org, title='other',
+        )
+        self.context, self.trustee = _s1_maps()
+        self.backend = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+
+    def test_is_superuser_does_not_grant_object_access(self):
+        self.account.is_superuser = True
+        self.assertTrue(self.backend.has_perm(self.account, 'read', self.repo))
+        self.assertFalse(
+            self.backend.has_perm(self.account, 'read', self.other)
+        )
+
+    def test_django_superuser_does_not_bypass_generic_backend(self):
+        superuser = User.objects.create_superuser(
+            'root', 'root@example.com', 'secret',
+        )
+        self.assertTrue(superuser.is_active)
+        self.assertTrue(superuser.is_superuser)
+        self.assertTrue(superuser.has_perm('anything.goes', self.repo))
+        self.assertFalse(self.backend.has_perm(superuser, 'read', self.repo))
+        self.assertFalse(self.backend.has_perm(superuser, 'read'))
+
+
+class S2CoexistenceTest(TestCase):
+    def setUp(self):
+        super(S2CoexistenceTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+        S1DirectGrant.objects.create(
+            account=self.account, repository=self.repo, operation=self.read,
+        )
+        self.context, self.trustee = _s1_maps()
+        self.user = User.objects.create_user('pat', password='secret')
+        content_type = ContentType.objects.get_for_model(S1Repository)
+        self.model_perm = Permission.objects.get(
+            content_type=content_type, codename='add_s1repository',
+        )
+        self.perm_code = '%s.add_s1repository' % content_type.app_label
+        self.user.user_permissions.add(self.model_perm)
+        self.user = User._default_manager.get(pk=self.user.pk)
+
+    def test_generic_backend_does_not_grant_model_perms(self):
+        backend = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+        self.assertFalse(backend.has_perm(self.user, self.perm_code))
+        self.assertFalse(backend.has_perm(self.user, self.perm_code, self.repo))
+        self.assertTrue(backend.has_perm(self.account, 'read', self.repo))
+
+    @override_settings(AUTHENTICATION_BACKENDS=(
+        'django.contrib.auth.backends.ModelBackend',
+        'trusts.backends.ObjectAuthorizationBackend',
+    ))
+    def test_modelbackend_coexistence_does_not_widen_object_access(self):
+        self.assertTrue(self.user.has_perm(self.perm_code))
+        self.assertFalse(self.user.has_perm(self.perm_code, self.repo))
+        model = ModelBackend()
+        generic = ObjectAuthorizationBackend(
+            context=self.context, trustee=self.trustee,
+        )
+        self.assertTrue(model.has_perm(self.user, self.perm_code))
+        self.assertFalse(model.has_perm(self.user, self.perm_code, self.repo))
+        self.assertFalse(generic.has_perm(self.user, self.perm_code))
+        self.assertFalse(generic.has_perm(self.user, self.perm_code, self.repo))
+        self.assertTrue(generic.has_perm(self.account, 'read', self.repo))
+
+    def test_optional_modelbackend_convenience_dispatch_boundary(self):
+        backend = ObjectAuthorizationModelBackend(
+            context=self.context, trustee=self.trustee,
+        )
+        self.assertTrue(backend.has_perm(self.user, self.perm_code))
+        self.assertFalse(backend.has_perm(self.user, self.perm_code, self.repo))
+        self.assertTrue(backend.has_perm(self.account, 'read', self.repo))
+
+        superuser = User.objects.create_superuser(
+            'root', 'root@example.com', 'secret',
+        )
+        self.assertTrue(backend.has_perm(superuser, self.perm_code))
+        self.assertFalse(backend.has_perm(superuser, 'read', self.repo))
+        self.assertFalse(backend.has_perm(superuser, self.perm_code, self.repo))
+
+        found = backend.authenticate(None, username='pat', password='secret')
+        self.assertEqual(found.pk, self.user.pk)
+        self.assertIsNone(
+            ObjectAuthorizationBackend().authenticate(
+                None, username='pat', password='secret',
+            )
+        )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -31,6 +31,7 @@ NORMAL_SUITE = [
     'tests.core.test_path',
     'tests.core.test_gh_vocab',
     'tests.core.test_s1_kernel',
+    'tests.core.test_s2_backend',
     'tests.core.test_zero_path',
     'tests.core.test_kernel_split',
     'tests.core.test_wheel_install',

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -1,0 +1,71 @@
+"""Object-only Django authentication backend (issue #47 S2).
+
+``ObjectAuthorizationBackend`` is a ``BaseBackend``, not a
+``ModelBackend``. It does not grant global or model permissions and
+does not assume Django User or ``auth.Permission`` models. ``perm`` is
+an operation instance or ``operation_lookup`` string, compiled by the
+S1 runtime. There is no Django permission-string parser.
+
+* ``authenticate()`` abstains (returns ``None``).
+* ``obj is None`` returns ``False``.
+* A supplied object routes through ``is_authorized``.
+* ``AuthorizationConfigError`` becomes denial (``False``) at this
+  security boundary. Direct runtime APIs still raise.
+
+``ObjectAuthorizationModelBackend`` is an optional convenience that
+composes Django ``ModelBackend`` for ``obj is None`` only. Object
+checks stay on the generic path. It is not the advertised default and
+is not required for GH.
+"""
+
+from django.contrib.auth.backends import BaseBackend, ModelBackend
+
+from trusts.runtime import AuthorizationConfigError, is_authorized
+
+
+class ObjectAuthorizationBackend(BaseBackend):
+    """Object-only authorization. No Django user or model-permission default."""
+
+    def __init__(self, context=None, trustee=None, names=None):
+        self.context = context
+        self.trustee = trustee
+        self.names = names
+
+    def authenticate(self, request, **credentials):
+        return None
+
+    def has_perm(self, user_obj, perm, obj=None):
+        if obj is None:
+            return False
+        try:
+            return bool(is_authorized(
+                user_obj, perm, obj,
+                context=self.context,
+                trustee=self.trustee,
+                names=self.names,
+            ))
+        except AuthorizationConfigError:
+            return False
+
+
+class ObjectAuthorizationModelBackend(ObjectAuthorizationBackend, ModelBackend):
+    """Optional: ``obj is None`` uses Django model permissions.
+
+    Object decisions still go through ``ObjectAuthorizationBackend``.
+    An active superuser is not granted object access by this class.
+    Not required for GH.
+    """
+
+    def authenticate(self, request, **credentials):
+        return ModelBackend.authenticate(self, request, **credentials)
+
+    def has_perm(self, user_obj, perm, obj=None):
+        if obj is None:
+            return ModelBackend.has_perm(self, user_obj, perm, obj=None)
+        return ObjectAuthorizationBackend.has_perm(self, user_obj, perm, obj)
+
+
+__all__ = [
+    'ObjectAuthorizationBackend',
+    'ObjectAuthorizationModelBackend',
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#47 kernel S2 only, per accepted framework-execution-r1+r2+r3. Does **not** close #47. Does not modify django-trusts-zero, start gh-permissions#1, resume #17, or implement S3 decorators / S4 admin/CBVs/templates.

**HEAD:** `c94a12e892df587f55f4108b024b75778fe1ba69`

## What this ships

1. `trusts.backends.ObjectAuthorizationBackend` — advertised default. Django `BaseBackend`, not `ModelBackend`.
2. `authenticate()` abstains (`None`).
3. `obj is None` returns `False` (no global or model permissions).
4. A supplied object routes through S1 `is_authorized` / the shared `grant_q` path. `perm` is an operation instance or `operation_lookup` string. Isolated tests pass `context=` / `trustee=` to the constructor.
5. `AuthorizationConfigError` becomes denial (`False`) at this security boundary. Direct runtime APIs still raise.
6. Ordinary denials for anonymous / inactive / unauthenticated principals and unknown operation data.
7. No Django permission-string parser and no User / `auth.Permission` assumption in the generic backend. `is_superuser` does not grant object access.
8. Optional `ObjectAuthorizationModelBackend` (`ObjectAuthorizationBackend` + `ModelBackend`): `obj is None` → Django model permissions; object checks stay on the generic path. Not required for GH.
9. Isolated kernel tests and `migrates.md` for the new public API and authorization implications.

## Query counts (local, isolated S1 fixtures)

| Path | Queries |
|---|---:|
| `has_perm(principal, 'read', granted_obj)` | 1 |
| `has_perm(principal, operation_instance, granted_obj)` | 1 |
| `has_perm(principal, 'read', ungranted_obj)` | 1 |
| `has_perm(stranger, 'read', obj)` | 1 |
| unknown operation data `'missing'` | 1 (deny) |
| Django-shaped `'trusts_tests.read_s1repository'` (not parsed) | 1 (deny) |
| `obj is None` | 0 |
| AnonymousUser / inactive / unauthenticated | 0 |

Same one-SQL object `Exists` as S1. No preliminary operation `get()`.

## Test matrix (local)

| Command | Result |
|---|---|
| `python -m tests.runtests` | 401 tests, OK (1 expected failure, historical Junction) |
| `python -m tests.runtests_custom` | 7 tests, OK |
| `python -m django check --settings=tests.settings` | OK |
| `python -m django check --settings=tests.custom_settings` | OK |

r? @chatforthomas
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae8d0196-49c1-46b1-a629-8ab253e5d358?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae8d0196-49c1-46b1-a629-8ab253e5d358&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

