### PR TITLE
Kernel S3: native require_authorized decorators and request-data binders

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ AUTHENTICATION_BACKENDS = (
 
 Import concrete models from ``trusts.zero.models``. Kernel APIs stay
 ``trusts.context``, ``trusts.trustee``, ``trusts.path``, ``trusts.runtime``,
-and ``trusts.query``. This package does not ship ``trusts/zero``.
+``trusts.query``, ``trusts.backends``, and ``trusts.decorators``. This
+package does not ship ``trusts/zero``.
 
 API and compatibility notes for this modernization are in [migrates.md](migrates.md).
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -28,6 +28,10 @@ installable `trusts/` package:
   `ObjectAuthorizationBackend` (`BaseBackend`; `obj is None` False;
   config error → denial; superuser does not grant objects; ModelBackend
   coexistence)
+- `tests/core/test_s3_decorators.py` — issue #47 S3 native
+  `require_authorized` / `P` / `K` / `G` / `O` (URL/GET/POST binding;
+  404 vs 403; login redirect; config error → 403; superuser does not
+  bypass; bounded query counts)
 - `tests/core/test_zero_path.py` — issue #43 Step 2 Zero consumer of compose
   (`ContentQuerySet.permitted` / `TrustModelBackend`; same-PK fail-closed)
 - `tests/core/test_kernel_split.py` — issue #43 Step 3 kernel/Zero AppConfig,
@@ -38,6 +42,7 @@ installable `trusts/` package:
   `tests.core.test_trustee`, `tests.core.test_path`,
   `tests.core.test_gh_vocab`, `tests.core.test_s1_kernel`,
   `tests.core.test_s2_backend`,
+  `tests.core.test_s3_decorators`,
   `tests.core.test_zero_path`,
   `tests.core.test_kernel_split`, `tests.core.test_wheel_install`,
   `tests.regressions.test_issue_*`)

--- a/migrates.md
+++ b/migrates.md
@@ -2219,6 +2219,14 @@ trusts.decorators:
   (URL kwarg → primary key) and inert `K` / `G` / `O` field selectors.
   Getter/resolver callbacks and other callables are configuration
   errors.
+- Selectors identify *the* protected resource. A PK, unique scalar, or
+  unconditional compound unique key may combine lookup + auth in one
+  SQL. A non-unique selector (`title=G('title')`) is allowed only when
+  exactly one row matches; two or more matches fail closed (403) and
+  are never an existential grant on any authorized subset.
+- Every `P` leaf's configuration is validated before any grant
+  decision. A malformed leaf cannot be hidden by `|` ordering or a
+  valid sibling.
 - Authorization is S1 `filter_authorized` / the shared `grant_q`. The
   decorator does not call `request.user.has_perm()` and does not add a
   second policy walker. Active `is_superuser` does not bypass
@@ -2244,9 +2252,11 @@ Query contract (honest):
 | --- | ---: |
 | Missing request key | 0 |
 | Unusable principal (exists / missing) | 1 existence, no auth `Exists` |
-| Granted (lookup + auth combined) | 1 |
-| Unauthorized or not-found after a combined miss | 2 (combined miss + existence) |
-| `P` composition | one leaf's counts per evaluated leaf |
+| Granted unique identity (PK / unique key; lookup + auth combined) | 1 |
+| Unauthorized or not-found after a unique-identity combined miss | 2 (combined miss + existence) |
+| Ambiguous non-unique selector (2+ rows) | 1 (`[:2]`), fail closed 403 |
+| Single non-unique match then authorize that instance | 2 |
+| `P` composition | config walk is 0 SQL; then one leaf's counts per evaluated leaf |
 
 Isolated tests pass `context=` / `trustee=` to the decorator
 (process-wide maps remain the no-arg default).
@@ -2270,7 +2280,7 @@ Isolated tests pass `context=` / `trustee=` to the decorator
 | New | Native `@require_authorized('read', resource_model=Repository, resource_kwarg='pk')` plus `pk=K(...)` / `G` / `O` and optional `P` composition. Isolated registries via `context=` / `trustee=`. |
 | Replacement | New kernel consumers use `trusts.decorators.require_authorized`. Zero compatibility stays `from trusts.zero.decorators import permission_required, P, K, G, O`. Do not treat the new module as a drop-in for the Zero wrapper. |
 | Affected | New kernel consumers. Zero is not re-exported from `trusts.decorators`. |
-| Authorization | Granted views run only after S1 `filter_authorized` matches. 404 vs 403 follows resource existence, not a silent deny. Config errors are 403. Superuser flags are ignored. |
+| Authorization | Granted views run only after the declared keys identify exactly one row and S1 authorizes that row. A non-unique selector that matches two rows (one granted, one denied) is 403, not an existential grant. `P` OR with a malformed leaf is 403 even when the other leaf would grant. 404 vs 403 follows unique-identity existence. Superuser flags are ignored. |
 
 ### 47. `trusts.decorators.P` / `K` / `G` / `O` / `request_passes_test` (new)
 
@@ -2311,6 +2321,8 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Import native `@require_authorized` from `trusts.decorators`, not Zero.
 - [ ] Pass an explicit `resource_model`; do not parse `app.action_model`.
 - [ ] Bind identity with `resource_kwarg` or `K`/`G`/`O` only; no getter callbacks.
+- [ ] Treat a non-unique selector that matches more than one row as 403, not a grant.
+- [ ] Treat a malformed `P` leaf as 403 for the whole expression, including `|`.
 - [ ] Expect 404 for missing/unknown resources and 403 for unauthorized ones.
 - [ ] Catch `AuthorizationConfigError` only at security boundaries (this decorator already does).
 - [ ] Keep `from trusts.zero.decorators import permission_required` for Django-permission compatibility; do not expect that wrapper here.

--- a/migrates.md
+++ b/migrates.md
@@ -2225,8 +2225,11 @@ trusts.decorators:
   exactly one row matches; two or more matches fail closed (403) and
   are never an existential grant on any authorized subset.
 - Every `P` leaf's configuration is validated before any grant
-  decision. A malformed leaf cannot be hidden by `|` ordering or a
-  valid sibling.
+  decision, including declared lookup names and `resource_kwarg`
+  (``_meta`` only; no request data and no SQL). A malformed leaf
+  (unknown field, unregistered model, missing selector) cannot be
+  hidden by `|` / `&` ordering, a missing request key, or a valid
+  sibling.
 - Authorization is S1 `filter_authorized` / the shared `grant_q`. The
   decorator does not call `request.user.has_perm()` and does not add a
   second policy walker. Active `is_superuser` does not bypass
@@ -2323,6 +2326,7 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Bind identity with `resource_kwarg` or `K`/`G`/`O` only; no getter callbacks.
 - [ ] Treat a non-unique selector that matches more than one row as 403, not a grant.
 - [ ] Treat a malformed `P` leaf as 403 for the whole expression, including `|`.
+- [ ] Unknown declared lookup names fail closed at preflight (403), even if another `|` leaf would grant.
 - [ ] Expect 404 for missing/unknown resources and 403 for unauthorized ones.
 - [ ] Catch `AuthorizationConfigError` only at security boundaries (this decorator already does).
 - [ ] Keep `from trusts.zero.decorators import permission_required` for Django-permission compatibility; do not expect that wrapper here.

--- a/migrates.md
+++ b/migrates.md
@@ -2189,3 +2189,132 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #47 from this PR.
 
+# Issue #47 S3: native decorators and request-data binders (1.0.0.dev0)
+
+This record covers the third kernel execution slice. Version remains
+**1.0.0.dev0**. This PR does **not** close
+[#47](https://github.com/django-trusts/django-trusts/issues/47); review
+owns that. It implements accepted **framework-execution-r1+r2+r3**
+kernel S3 only. It does **not** modify `django-trusts-zero`, start
+S4 admin/CBVs/templates, start S5 checks cleanup, gh-permissions#1,
+or resume #17.
+
+## Decision
+
+```text
+trusts.decorators:
+  require_authorized(operation, resource_model=..., resource_kwarg=...)
+  request_passes_test
+  P / K / G / O
+```
+
+`require_authorized` is the native HTTP security boundary:
+
+- Operation is an operation-model instance, an `operation_lookup`
+  string, or a `P` expression of those. There is no
+  `app.action_model` parser and no `ContentType` inference.
+- `resource_model` is required (decorator or each `P` leaf). The
+  framework does not guess a model from a Django permission string.
+- Resource identity is declared request keys only: `resource_kwarg`
+  (URL kwarg → primary key) and inert `K` / `G` / `O` field selectors.
+  Getter/resolver callbacks and other callables are configuration
+  errors.
+- Authorization is S1 `filter_authorized` / the shared `grant_q`. The
+  decorator does not call `request.user.has_perm()` and does not add a
+  second policy walker. Active `is_superuser` does not bypass
+  registered object policy on this path.
+- Missing or unresolvable resource identity → **404**.
+- Existing but unauthorized, unusable principal, or unknown operation
+  data → **403**, or a login redirect when `raise_exception=False`.
+- `AuthorizationConfigError` → **403** at this boundary. Direct
+  runtime APIs still raise. Malformed configuration cannot produce
+  access, and does not become a login redirect.
+
+`P` boolean composition (`&` / `|`) is operation-and-selector data
+over the same decorator machinery. It is **not** Zero's Django-permission
+`P`. Zero's `permission_required` (Permission strings + `ContentType`)
+stays in `trusts.zero.decorators` as later Zero work.
+
+`request_passes_test` is the generic request test / login-redirect
+helper. Wrapped-view metadata is preserved (`functools.wraps`).
+
+Query contract (honest):
+
+| Path | SQL |
+| --- | ---: |
+| Missing request key | 0 |
+| Unusable principal (exists / missing) | 1 existence, no auth `Exists` |
+| Granted (lookup + auth combined) | 1 |
+| Unauthorized or not-found after a combined miss | 2 (combined miss + existence) |
+| `P` composition | one leaf's counts per evaluated leaf |
+
+Isolated tests pass `context=` / `trustee=` to the decorator
+(process-wide maps remain the no-arg default).
+
+## No change to these public call sites
+
+- S1 `trusts.runtime` / `trusts.query` / `compose` / `compose_scope`
+- S2 `ObjectAuthorizationBackend` / `ObjectAuthorizationModelBackend`
+- Zero `trusts.zero.decorators.permission_required`, `P`, `K`, `G`, `O`
+- Zero `TrustModelBackend`, `ContentQuerySet.permitted`, admin, views,
+  historical migrations, app label `trusts`
+- Package version `1.0.0.dev0`
+
+## Changes
+
+### 46. `trusts.decorators.require_authorized` (new)
+
+| | |
+| --- | --- |
+| Previous | Consumers called `User.has_perm` in the view, or used Zero `permission_required` (Django permission strings, `ContentType` model inference, `has_perms`). After #43 those Zero names live at `trusts.zero.decorators`. |
+| New | Native `@require_authorized('read', resource_model=Repository, resource_kwarg='pk')` plus `pk=K(...)` / `G` / `O` and optional `P` composition. Isolated registries via `context=` / `trustee=`. |
+| Replacement | New kernel consumers use `trusts.decorators.require_authorized`. Zero compatibility stays `from trusts.zero.decorators import permission_required, P, K, G, O`. Do not treat the new module as a drop-in for the Zero wrapper. |
+| Affected | New kernel consumers. Zero is not re-exported from `trusts.decorators`. |
+| Authorization | Granted views run only after S1 `filter_authorized` matches. 404 vs 403 follows resource existence, not a silent deny. Config errors are 403. Superuser flags are ignored. |
+
+### 47. `trusts.decorators.P` / `K` / `G` / `O` / `request_passes_test` (new)
+
+| | |
+| --- | --- |
+| Previous | Same names existed on Zero's decorator module as Django-permission binders (`P('app.action_model', ...)`, `ContentType` lookup). |
+| New | Framework `P` holds an operation and request-key selectors. `K`/`G`/`O` are inert key sources (URL kwargs / GET / POST). `request_passes_test` redirects to login when the test returns `False`. |
+| Replacement | Import from `trusts.decorators` for native operation data. Keep Zero imports for Django permission strings. The two `P` types are not interchangeable. |
+| Affected | New kernel view decorators. Existing Zero decorator tests still import `trusts.zero.decorators`. |
+| Authorization | `P` composition does not introduce callbacks or Zero `:condition` / Permission semantics. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m tests.runtests
+```
+
+No Trusts schema migration. S3 uses the existing isolated S1 test models.
+
+## Upgrade of a representative legacy database
+
+Unchanged. `scripts/verify-legacy-upgrade.py` still expects
+`{0001_initial, 0002_trustgroup}` on label `trusts`.
+
+## Out of scope (unchanged)
+
+- S4 admin / CBV mixins / stub templates
+- S5 `E008` / kernel `Content` leftover import cleanup
+- Generic `register_row_condition`
+- `RecursiveEdge` / `OrderedContribution`
+- django-trusts-zero `permission_required` wrapper or pin bump
+- gh-permissions#1
+- Closing #17 or #47
+
+## Migration-bot summary (issue #47 S3)
+
+- [ ] Import native `@require_authorized` from `trusts.decorators`, not Zero.
+- [ ] Pass an explicit `resource_model`; do not parse `app.action_model`.
+- [ ] Bind identity with `resource_kwarg` or `K`/`G`/`O` only; no getter callbacks.
+- [ ] Expect 404 for missing/unknown resources and 403 for unauthorized ones.
+- [ ] Catch `AuthorizationConfigError` only at security boundaries (this decorator already does).
+- [ ] Keep `from trusts.zero.decorators import permission_required` for Django-permission compatibility; do not expect that wrapper here.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_s3_decorators`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #47 from this PR.
+

--- a/scripts/verify-wheel-install.py
+++ b/scripts/verify-wheel-install.py
@@ -100,6 +100,7 @@ def main() -> int:
     from trusts.trustee import Trustee
     from trusts.path import AuthorizationPath, AuthorizationBranch, compose
     from trusts.backends import ObjectAuthorizationBackend
+    from trusts.decorators import require_authorized
     from django_trusts import TQ, condition_refs
 
     trusts_file = Path(trusts.__file__).resolve()
@@ -134,6 +135,7 @@ def main() -> int:
     print('AuthorizationBranch', AuthorizationBranch)
     print('compose', compose)
     print('ObjectAuthorizationBackend', ObjectAuthorizationBackend)
+    print('require_authorized', require_authorized)
     print('TQ', TQ)
     print('condition_refs', condition_refs)
     print('absent test modules', ' '.join(ABSENT_TEST_MODULES))

--- a/tests/core/test_s3_decorators.py
+++ b/tests/core/test_s3_decorators.py
@@ -413,6 +413,48 @@ class S3BooleanPTest(S3DecoratorFixtureMixin, TestCase):
             with self.assertRaises(PermissionDenied):
                 view(request, pk=self.repo_a.pk)
 
+    def test_or_unknown_lookup_on_either_side_is_403(self):
+        valid = P('read', resource_model=S1Repository, resource_kwarg='pk')
+        broken = P(
+            'read', resource_model=S1Repository, typo_field=G('id'),
+        )
+        request = self._get(self.member, data={'id': str(self.repo_a.pk)})
+        for expr in (broken | valid, valid | broken):
+            view = require_authorized(
+                expr, context=self.context, trustee=self.trustee,
+            )(_ok_view)
+            with self.assertNumQueries(0):
+                with self.assertRaises(PermissionDenied):
+                    view(request, pk=self.repo_a.pk)
+
+    def test_or_unknown_lookup_missing_key_still_403(self):
+        valid = P('read', resource_model=S1Repository, resource_kwarg='pk')
+        broken = P(
+            'read', resource_model=S1Repository, typo_field=G('missing'),
+        )
+        request = self._get(self.member)
+        for expr in (broken | valid, valid | broken):
+            view = require_authorized(
+                expr, context=self.context, trustee=self.trustee,
+            )(_ok_view)
+            with self.assertNumQueries(0):
+                with self.assertRaises(PermissionDenied):
+                    view(request, pk=self.repo_a.pk)
+
+    def test_and_unknown_lookup_on_either_side_is_403(self):
+        valid = P('read', resource_model=S1Repository, resource_kwarg='pk')
+        broken = P(
+            'read', resource_model=S1Repository, typo_field=K('pk'),
+        )
+        request = self._get(self.member)
+        for expr in (broken & valid, valid & broken):
+            view = require_authorized(
+                expr, context=self.context, trustee=self.trustee,
+            )(_ok_view)
+            with self.assertNumQueries(0):
+                with self.assertRaises(PermissionDenied):
+                    view(request, pk=self.repo_a.pk)
+
     def test_and_does_not_grant_when_separate_rows_satisfy_leaves(self):
         self.repo_a.title = 'shared'
         self.repo_a.save(update_fields=['title'])

--- a/tests/core/test_s3_decorators.py
+++ b/tests/core/test_s3_decorators.py
@@ -1,0 +1,441 @@
+"""Isolated kernel tests for #47 S3 (native decorators / request binders).
+
+``require_authorized`` routes through S1 ``filter_authorized``. Resource
+identity is URL kwargs / ``K`` / ``G`` / ``O`` only. Isolated registries.
+Does not close #47. Does not implement S4–S5.
+"""
+
+import inspect
+import re
+from pathlib import Path
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from trusts.context import ContextRegistry
+from trusts.decorators import G, K, O, P, require_authorized, request_passes_test
+from trusts.runtime import AuthorizationConfigError, is_authorized
+from trusts.trustee import TrusteeRegistry
+from tests.core.test_s1_kernel import S1_DIRECT, _s1_maps
+from tests.models import (
+    S1Account,
+    S1Bundle,
+    S1DirectGrant,
+    S1Operation,
+    S1Organization,
+    S1Repository,
+    S1Team,
+    S1TeamGrant,
+    S1UnregisteredNote,
+)
+
+
+def _ok_view(request, **kwargs):
+    """S3 decorated view."""
+    return HttpResponse('ok')
+
+
+class S3DecoratorContractTest(TestCase):
+    def test_decorators_module_has_no_product_nouns_or_perm_parser(self):
+        from trusts import decorators
+        source = Path(inspect.getfile(decorators)).read_text()
+        for noun in ('Trust', 'Content', 'Junction', 'GitHub'):
+            self.assertIsNone(
+                re.search(r'\b%s\b' % noun, source),
+                '%r appears as a product noun in trusts.decorators' % (noun,),
+            )
+        self.assertNotIn('parse_perm_code', source)
+        self.assertNotIn('ContentType', source)
+        self.assertNotIn('has_perm', source)
+        self.assertNotIn('app.action_model', source)
+        self.assertNotIn('permission_required', source)
+
+    def test_wrapped_view_metadata_is_preserved(self):
+        context, trustee = _s1_maps()
+        wrapped = require_authorized(
+            'read', resource_model=S1Repository, resource_kwarg='pk',
+            context=context, trustee=trustee,
+        )(_ok_view)
+        self.assertEqual(wrapped.__name__, '_ok_view')
+        self.assertEqual(wrapped.__doc__, 'S3 decorated view.')
+
+    def test_callable_selector_is_rejected_as_config(self):
+        with self.assertRaises(AuthorizationConfigError):
+            require_authorized(
+                'read', resource_model=S1Repository, pk=lambda request: 1,
+            )
+        with self.assertRaises(AuthorizationConfigError):
+            P('read', resource_model=S1Repository, pk=S1Repository.objects.get)
+
+    def test_p_rejects_non_p_boolean_operands(self):
+        with self.assertRaises(TypeError):
+            P('read') & 'write'
+        with self.assertRaises(TypeError):
+            P('read') | 1
+
+
+class S3DecoratorFixtureMixin(object):
+    def setUp(self):
+        super(S3DecoratorFixtureMixin, self).setUp()
+        self.factory = RequestFactory()
+        self.org = S1Organization.objects.create(name='acme')
+        self.team = S1Team.objects.create(organization=self.org, name='writers')
+        self.member = S1Account.objects.create(name='member')
+        self.stranger = S1Account.objects.create(name='stranger')
+        self.team.members.add(self.member)
+        self.read = S1Operation.objects.create(code='read')
+        self.write = S1Operation.objects.create(code='write')
+        self.repo_a = S1Repository.objects.create(
+            organization=self.org, title='repo-a',
+        )
+        self.repo_b = S1Repository.objects.create(
+            organization=self.org, title='repo-b',
+        )
+        bundle = S1Bundle.objects.create(team=self.team, name='reader')
+        bundle.operations.add(self.read)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.read,
+        )
+        self.context, self.trustee = _s1_maps()
+        self.runtime = dict(context=self.context, trustee=self.trustee)
+        self.decorate = dict(
+            resource_model=S1Repository,
+            context=self.context,
+            trustee=self.trustee,
+        )
+
+    def _wrap(self, operation='read', **kwargs):
+        options = dict(self.decorate)
+        options.update(kwargs)
+        return require_authorized(operation, **options)(_ok_view)
+
+    def _get(self, user, path='/', data=None, **kwargs):
+        request = self.factory.get(path, data=data or {})
+        request.user = user
+        return request
+
+
+class S3BindingAndDecisionTest(S3DecoratorFixtureMixin, TestCase):
+    def test_url_kwarg_granted_is_one_combined_query(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            response = view(request, pk=self.repo_a.pk)
+        self.assertEqual(response.content, b'ok')
+        self.assertTrue(
+            is_authorized(self.member, 'read', self.repo_a, **self.runtime)
+        )
+
+    def test_url_kwarg_denied_uses_existence_query(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_b.pk)
+        request = self._get(self.stranger)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+    def test_missing_kwarg_is_404_without_sql(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(request)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(request, pk='')
+
+    def test_unknown_pk_is_404(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(self.member)
+        missing_pk = self.repo_a.pk + self.repo_b.pk + 1000
+        with self.assertNumQueries(2):
+            with self.assertRaises(Http404):
+                view(request, pk=missing_pk)
+
+    def test_k_selector_matches_resource_kwarg(self):
+        view = self._wrap(pk=K('repo_id'))
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            response = view(request, repo_id=self.repo_a.pk)
+        self.assertEqual(response.content, b'ok')
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, repo_id=self.repo_b.pk)
+
+    def test_g_selector_reads_get(self):
+        view = self._wrap(pk=G('id'))
+        request = self._get(self.member, data={'id': str(self.repo_a.pk)})
+        with self.assertNumQueries(1):
+            response = view(request)
+        self.assertEqual(response.content, b'ok')
+        missing = self._get(self.member)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(missing)
+
+    def test_o_selector_reads_post(self):
+        view = self._wrap(pk=O('id'))
+        request = self.factory.post('/', data={'id': str(self.repo_a.pk)})
+        request.user = self.member
+        with self.assertNumQueries(1):
+            response = view(request)
+        self.assertEqual(response.content, b'ok')
+        denied = self.factory.post('/', data={'id': str(self.repo_b.pk)})
+        denied.user = self.member
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(denied)
+        missing = self.factory.post('/')
+        missing.user = self.member
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(missing)
+
+    def test_operation_instance_is_accepted(self):
+        view = self._wrap(self.read, resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+
+
+class S3UnusablePrincipalTest(S3DecoratorFixtureMixin, TestCase):
+    def test_anonymous_existing_resource_is_403_one_existence_query(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(AnonymousUser())
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+    def test_anonymous_missing_key_is_404_without_sql(self):
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(AnonymousUser())
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(request)
+
+    def test_inactive_and_unauthenticated_are_403(self):
+        view = self._wrap(resource_kwarg='pk')
+        self.member.is_active = False
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+        del self.member.is_active
+        self.member.is_authenticated = False
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+
+class S3UnknownOperationTest(S3DecoratorFixtureMixin, TestCase):
+    def test_unknown_operation_data_is_403_when_resource_exists(self):
+        view = self._wrap('missing', resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+
+class S3ConfigErrorTest(S3DecoratorFixtureMixin, TestCase):
+    def test_unregistered_resource_is_403(self):
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo_a, text='nope',
+        )
+        view = require_authorized(
+            'read', resource_model=S1UnregisteredNote, resource_kwarg='pk',
+            context=self.context, trustee=self.trustee,
+        )(_ok_view)
+        request = self._get(self.member)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.member, 'read', note,
+                context=self.context, trustee=self.trustee,
+            )
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=note.pk)
+
+    def test_empty_adapters_is_403(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='code',
+        )
+        view = require_authorized(
+            'read', resource_model=S1Repository, resource_kwarg='pk',
+            context=context, trustee=trustee,
+        )(_ok_view)
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+    def test_string_without_lookup_is_403(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+        )
+        trustee.register(
+            name=S1_DIRECT,
+            trustee_model=S1Account,
+            grant_model=S1DirectGrant,
+            trustee_path='account',
+            scope_path='repository',
+            operation_path='operation',
+        )
+        view = require_authorized(
+            'read', resource_model=S1Repository, resource_kwarg='pk',
+            context=context, trustee=trustee,
+        )(_ok_view)
+        request = self._get(self.member)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.member, 'read', self.repo_a,
+                context=context, trustee=trustee,
+            )
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+    def test_missing_resource_model_is_403(self):
+        view = require_authorized(
+            'read', resource_kwarg='pk',
+            context=self.context, trustee=self.trustee,
+        )(_ok_view)
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+    def test_missing_identity_selector_is_403(self):
+        view = self._wrap()
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+
+class S3SuperuserContractTest(S3DecoratorFixtureMixin, TestCase):
+    def test_is_superuser_does_not_bypass_object_policy(self):
+        self.member.is_superuser = True
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_b.pk)
+
+    def test_django_superuser_does_not_bypass_decorator(self):
+        superuser = User.objects.create_superuser(
+            'root', 'root@example.com', 'secret',
+        )
+        self.assertTrue(superuser.is_active)
+        self.assertTrue(superuser.is_superuser)
+        view = self._wrap(resource_kwarg='pk')
+        request = self._get(superuser)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+
+class S3BooleanPTest(S3DecoratorFixtureMixin, TestCase):
+    def test_or_grants_when_one_leaf_matches(self):
+        view = self._wrap(
+            P('read', resource_kwarg='pk') | P('write', resource_kwarg='pk'),
+        )
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+
+    def test_and_requires_both_operations(self):
+        view = self._wrap(
+            P('read', resource_kwarg='pk') & P('write', resource_kwarg='pk'),
+        )
+        request = self._get(self.member)
+        # read leaf grants in one combined query; write leaf then misses
+        # (combined) and confirms existence — 3 SQL, not one.
+        with self.assertNumQueries(3):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.write,
+        )
+        self.team.bundles.get().operations.add(self.write)
+        with self.assertNumQueries(2):
+            self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+
+    def test_p_inherits_decorator_resource_model(self):
+        view = require_authorized(
+            P('read', pk=K('pk')),
+            resource_model=S1Repository,
+            context=self.context,
+            trustee=self.trustee,
+        )(_ok_view)
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+
+
+class S3LoginRedirectTest(S3DecoratorFixtureMixin, TestCase):
+    @override_settings(LOGIN_URL='/accounts/login/')
+    def test_unauthorized_redirects_when_raise_exception_is_false(self):
+        view = self._wrap(resource_kwarg='pk', raise_exception=False)
+        request = self._get(self.stranger, path='/repos/%s/' % self.repo_a.pk)
+        response = view(request, pk=self.repo_a.pk)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/accounts/login/', response['Location'])
+        self.assertIn('next=', response['Location'])
+
+    @override_settings(LOGIN_URL='/accounts/login/')
+    def test_missing_resource_is_still_404_when_login_redirect_configured(self):
+        view = self._wrap(resource_kwarg='pk', raise_exception=False)
+        request = self._get(self.member)
+        with self.assertRaises(Http404):
+            view(request)
+
+    @override_settings(LOGIN_URL='/accounts/login/')
+    def test_config_error_stays_403_when_login_redirect_configured(self):
+        view = require_authorized(
+            'read', resource_model=S1UnregisteredNote, resource_kwarg='pk',
+            raise_exception=False,
+            context=self.context, trustee=self.trustee,
+        )(_ok_view)
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo_a, text='nope',
+        )
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=note.pk)
+
+
+class S3RequestPassesTestHelper(TestCase):
+    def test_true_calls_view_false_redirects(self):
+        factory = RequestFactory()
+
+        @request_passes_test(lambda request, **kwargs: request.GET.get('ok') == '1')
+        def view(request, **kwargs):
+            return HttpResponse('ok')
+
+        allowed = factory.get('/', data={'ok': '1'})
+        self.assertEqual(view(allowed).content, b'ok')
+        denied = factory.get('/secret/')
+        response = view(denied)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/accounts/login/', response['Location'])
+
+    def test_helper_preserves_wraps(self):
+        def probe(request, **kwargs):
+            return True
+
+        @request_passes_test(probe)
+        def named_view(request, **kwargs):
+            """helper doc"""
+            return HttpResponse('ok')
+
+        self.assertEqual(named_view.__name__, 'named_view')
+        self.assertEqual(named_view.__doc__, 'helper doc')

--- a/tests/core/test_s3_decorators.py
+++ b/tests/core/test_s3_decorators.py
@@ -201,6 +201,26 @@ class S3BindingAndDecisionTest(S3DecoratorFixtureMixin, TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
 
+    def test_ambiguous_non_pk_selector_does_not_existentially_grant(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        S1Repository.objects.create(organization=self.org, title='shared')
+        view = self._wrap(title=G('title'))
+        request = self._get(self.member, data={'title': 'shared'})
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request)
+
+    def test_single_non_pk_match_still_authorizes_that_row(self):
+        view = self._wrap(title=G('title'))
+        request = self._get(self.member, data={'title': self.repo_a.title})
+        with self.assertNumQueries(2):
+            self.assertEqual(view(request).content, b'ok')
+        denied = self._get(self.member, data={'title': self.repo_b.title})
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(denied)
+
 
 class S3UnusablePrincipalTest(S3DecoratorFixtureMixin, TestCase):
     def test_anonymous_existing_resource_is_403_one_existence_query(self):
@@ -379,6 +399,37 @@ class S3BooleanPTest(S3DecoratorFixtureMixin, TestCase):
         request = self._get(self.member)
         with self.assertNumQueries(1):
             self.assertEqual(view(request, pk=self.repo_a.pk).content, b'ok')
+
+    def test_or_broken_leaf_on_either_side_is_403(self):
+        broken = P(
+            'read', resource_model=S1UnregisteredNote, resource_kwarg='pk',
+        )
+        valid = P('read', resource_model=S1Repository, resource_kwarg='pk')
+        request = self._get(self.member)
+        for expr in (broken | valid, valid | broken):
+            view = require_authorized(
+                expr, context=self.context, trustee=self.trustee,
+            )(_ok_view)
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+    def test_and_does_not_grant_when_separate_rows_satisfy_leaves(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        other = S1Repository.objects.create(
+            organization=self.org, title='shared',
+        )
+        S1TeamGrant.objects.create(
+            team=self.team, repository=other, operation=self.write,
+        )
+        self.team.bundles.get().operations.add(self.write)
+        view = self._wrap(
+            P('read', title=G('title')) & P('write', title=G('title')),
+        )
+        request = self._get(self.member, data={'title': 'shared'})
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request)
 
 
 class S3LoginRedirectTest(S3DecoratorFixtureMixin, TestCase):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -32,6 +32,7 @@ NORMAL_SUITE = [
     'tests.core.test_gh_vocab',
     'tests.core.test_s1_kernel',
     'tests.core.test_s2_backend',
+    'tests.core.test_s3_decorators',
     'tests.core.test_zero_path',
     'tests.core.test_kernel_split',
     'tests.core.test_wheel_install',

--- a/trusts/decorators.py
+++ b/trusts/decorators.py
@@ -331,6 +331,56 @@ def _trustee_registry(value):
     )
 
 
+def _require_identity_lookup(model, lookup):
+    """``_meta``-only check that ``lookup`` is a single-valued field path."""
+    if lookup == 'pk':
+        return
+    if not isinstance(lookup, str) or not lookup:
+        raise AuthorizationConfigError(
+            'Lookup %r is not a field on %s.' % (lookup, model._meta.label)
+        )
+    parts = lookup.split('__')
+    if any(part == '' for part in parts):
+        raise AuthorizationConfigError(
+            'Lookup %r is not a field on %s.' % (lookup, model._meta.label)
+        )
+    current = model
+    for i, part in enumerate(parts):
+        try:
+            field = current._meta.get_field(part)
+        except FieldDoesNotExist:
+            raise AuthorizationConfigError(
+                'Unknown field %r on %s (from %r).' % (
+                    part, current._meta.label, lookup,
+                )
+            )
+        if i == len(parts) - 1:
+            return
+        remote = getattr(field, 'remote_field', None)
+        if remote is None:
+            raise AuthorizationConfigError(
+                'Lookup %r has a non-relation hop %r.' % (lookup, part)
+            )
+        if getattr(field, 'many_to_many', False) or getattr(field, 'one_to_many', False):
+            raise AuthorizationConfigError(
+                'Lookup %r may not use many-valued hop %r.' % (lookup, part)
+            )
+        current = remote.model
+
+
+def _validate_leaf_lookups(leaf, resource_model):
+    """Validate declared keys without reading the request or running SQL."""
+    if leaf._resource_kwarg is not None:
+        if not isinstance(leaf._resource_kwarg, str) or not leaf._resource_kwarg:
+            raise AuthorizationConfigError(
+                'resource_kwarg must be a non-empty URL kwarg name string, '
+                'not %r.' % (leaf._resource_kwarg,)
+            )
+        _require_identity_lookup(resource_model, 'pk')
+    for field in leaf._fieldlookups:
+        _require_identity_lookup(resource_model, field)
+
+
 def _validate_leaf_config(leaf, runtime):
     """Fail closed on malformed leaf config before any grant decision."""
     resource_model = _require_model(leaf._resource_model)
@@ -339,6 +389,7 @@ def _validate_leaf_config(leaf, runtime):
             'require_authorized needs resource_kwarg or a K/G/O selector '
             'so resource identity comes from declared request keys.'
         )
+    _validate_leaf_lookups(leaf, resource_model)
     try:
         compose(
             resource_model, None,

--- a/trusts/decorators.py
+++ b/trusts/decorators.py
@@ -24,11 +24,16 @@ Query contract (honest):
 
 * Missing request key → 0 SQL.
 * Unusable principal + existence check → 1 SQL (no auth ``Exists``).
-* Granted path combines lookup + auth in **one** SQL
-  (``filter_authorized`` on the lookup queryset, then ``.first()``).
-* Unauthorized / not-found after a combined miss needs a **second**
-  existence query so 403 and 404 stay distinct.
-* ``P`` composition evaluates each leaf on that same machinery.
+* Unique identity (PK / unique scalar / unconditional unique key):
+  granted lookup + auth combine in **one** SQL.
+* Unauthorized or not-found after a unique-identity combined miss
+  needs a **second** existence query so 403 and 404 stay distinct.
+* Non-unique selectors identify *the* resource only when exactly one
+  row matches. Two or more matches fail closed (**403**, 1 SQL
+  ``[:2]``) and are never an existential grant.
+* A single non-unique match then authorizes that instance (2 SQL).
+* ``P`` composition validates every leaf's configuration first, then
+  evaluates leaves on that same machinery.
 
 Zero's Django-permission compatibility decorator stays in
 ``trusts.zero.decorators``.
@@ -42,18 +47,23 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import (
+    FieldDoesNotExist,
     FieldError,
     PermissionDenied,
     ValidationError,
 )
+from django.db.models import UniqueConstraint
 from django.http import Http404
 from django.shortcuts import resolve_url
 
+from trusts.path import AuthorizationPathError, compose
 from trusts.runtime import (
     AuthorizationConfigError,
     filter_authorized,
+    is_authorized,
     principal_is_usable,
 )
+from trusts.trustee import Trustee, TrusteeRegistrationError, TrusteeRegistry
 
 
 _MISSING = object()
@@ -271,6 +281,104 @@ def _lookups_usable(resolved):
     return True
 
 
+def _lookups_uniquely_identify(model, lookup_names):
+    """True when the declared fields are a unique identity, not a filter.
+
+    A PK, a ``unique=True`` scalar, or an unconditional unique-together /
+    ``UniqueConstraint`` covering the lookups (or any unique field among
+    them) is enough. Callers still fail closed if a non-unique selector
+    matches more than one row.
+    """
+    names = set(lookup_names)
+    if not names:
+        return False
+    unique_name_sets = []
+    pk = model._meta.pk
+    unique_name_sets.append(frozenset((pk.attname, pk.name, 'pk')))
+    for field in model._meta.fields:
+        if field.primary_key or getattr(field, 'unique', False):
+            unique_name_sets.append(frozenset((field.attname, field.name)))
+    for group in unique_name_sets:
+        if names & group:
+            return True
+    for together in model._meta.unique_together:
+        if names == set(together):
+            return True
+    for constraint in model._meta.constraints:
+        if not isinstance(constraint, UniqueConstraint):
+            continue
+        if getattr(constraint, 'condition', None) is not None:
+            continue
+        if names == set(constraint.fields):
+            return True
+    for name in names:
+        try:
+            field = model._meta.get_field(name)
+        except FieldDoesNotExist:
+            return False
+        if field.primary_key or getattr(field, 'unique', False):
+            return True
+    return False
+
+
+def _trustee_registry(value):
+    if value is None or value is Trustee:
+        return Trustee.registry
+    if isinstance(value, TrusteeRegistry):
+        return value
+    raise AuthorizationConfigError(
+        'trustee must be a TrusteeRegistry, not %r.' % (value,)
+    )
+
+
+def _validate_leaf_config(leaf, runtime):
+    """Fail closed on malformed leaf config before any grant decision."""
+    resource_model = _require_model(leaf._resource_model)
+    if leaf._resource_kwarg is None and not leaf._fieldlookups:
+        raise AuthorizationConfigError(
+            'require_authorized needs resource_kwarg or a K/G/O selector '
+            'so resource identity comes from declared request keys.'
+        )
+    try:
+        compose(
+            resource_model, None,
+            context=runtime.get('context'),
+            trustee=runtime.get('trustee'),
+            names=runtime.get('names'),
+        )
+    except AuthorizationPathError as exc:
+        raise AuthorizationConfigError(str(exc)) from exc
+    operation = leaf._operation
+    registry = _trustee_registry(runtime.get('trustee'))
+    if isinstance(operation, str):
+        if not registry.operation_lookup():
+            raise AuthorizationConfigError(
+                'String operations require operation_lookup on the '
+                'Trustee registry.'
+            )
+        return
+    if operation is None or operation == '':
+        raise AuthorizationConfigError(
+            'require_authorized needs an operation on each P leaf.'
+        )
+    try:
+        operation_model = registry.operation_model()
+    except TrusteeRegistrationError as exc:
+        raise AuthorizationConfigError(str(exc)) from exc
+    meta = getattr(operation, '_meta', None)
+    if meta is None or meta.concrete_model is not operation_model._meta.concrete_model:
+        raise AuthorizationConfigError(
+            'operation must be a %s instance or lookup string.' % (
+                operation_model._meta.label,
+            )
+        )
+
+
+def _validate_expr_config(expr, runtime):
+    for leaf in expr.get_leaves():
+        _validate_leaf_config(leaf, runtime)
+
+
 def _evaluate_leaf(request, view_kwargs, leaf, runtime):
     try:
         resource_model = _require_model(leaf._resource_model)
@@ -290,6 +398,20 @@ def _evaluate_leaf(request, view_kwargs, leaf, runtime):
                 'require_authorized requires request.user.'
             )
         candidates = resource_model._default_manager.filter(**resolved)
+        unique = _lookups_uniquely_identify(resource_model, resolved.keys())
+        if not unique:
+            matched = list(candidates[:2])
+            if len(matched) == 0:
+                return NOT_FOUND
+            if len(matched) > 1:
+                return DENIED
+            if not principal_is_usable(principal):
+                return DENIED
+            if is_authorized(
+                principal, leaf._operation, matched[0], **runtime,
+            ):
+                return GRANTED
+            return DENIED
         if not principal_is_usable(principal):
             if candidates.exists():
                 return DENIED
@@ -315,21 +437,26 @@ def _evaluate_expr(request, view_kwargs, expr, runtime):
         left = _evaluate_expr(
             request, view_kwargs, expr._left_operand, runtime,
         )
+        if left is CONFIG_ERROR:
+            return CONFIG_ERROR
         if expr._operator is and_:
             if left is not GRANTED:
                 return left
-            return _evaluate_expr(
+            right = _evaluate_expr(
                 request, view_kwargs, expr._right_operand, runtime,
             )
+            if right is CONFIG_ERROR:
+                return CONFIG_ERROR
+            return right
         if left is GRANTED:
             return left
         right = _evaluate_expr(
             request, view_kwargs, expr._right_operand, runtime,
         )
+        if right is CONFIG_ERROR:
+            return CONFIG_ERROR
         if right is GRANTED:
             return GRANTED
-        if left is CONFIG_ERROR or right is CONFIG_ERROR:
-            return CONFIG_ERROR
         if left is DENIED or right is DENIED:
             return DENIED
         return NOT_FOUND
@@ -406,6 +533,10 @@ def require_authorized(
     runtime = dict(context=context, trustee=trustee, names=names)
 
     def _check(request, *args, **kwargs):
+        try:
+            _validate_expr_config(expr, runtime)
+        except AuthorizationConfigError:
+            raise PermissionDenied
         outcome = _evaluate_expr(request, kwargs, expr, runtime)
         if outcome is GRANTED:
             return True

--- a/trusts/decorators.py
+++ b/trusts/decorators.py
@@ -1,0 +1,432 @@
+"""Native view decorators and request-data binders (issue #47 S3).
+
+``@require_authorized(operation, resource_model=..., resource_kwarg=...)``
+is the framework HTTP security boundary. Resource identity comes only
+from declared request keys: URL kwargs via ``resource_kwarg`` or inert
+``K`` / ``G`` / ``O`` selectors. There are no getter callbacks, no
+content-type model inference, and no Django permission-string parser.
+
+Authorization is the S1 runtime (``filter_authorized`` / the shared
+``grant_q``). This module does not call the Django user-permission
+helper and does not walk policy a second time. Active superuser status
+does not bypass registered object policy.
+
+HTTP outcomes:
+
+* Missing or unresolvable resource identity → ``Http404`` (default).
+* Existing but unauthorized, unusable principal, unknown operation
+  data → ``PermissionDenied`` (403), or a login redirect when
+  ``raise_exception=False``.
+* ``AuthorizationConfigError`` → ``PermissionDenied`` (403). Malformed
+  configuration cannot produce access.
+
+Query contract (honest):
+
+* Missing request key → 0 SQL.
+* Unusable principal + existence check → 1 SQL (no auth ``Exists``).
+* Granted path combines lookup + auth in **one** SQL
+  (``filter_authorized`` on the lookup queryset, then ``.first()``).
+* Unauthorized / not-found after a combined miss needs a **second**
+  existence query so 403 and 404 stay distinct.
+* ``P`` composition evaluates each leaf on that same machinery.
+
+Zero's Django-permission compatibility decorator stays in
+``trusts.zero.decorators``.
+"""
+
+from functools import wraps
+from operator import and_, or_
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import (
+    FieldError,
+    PermissionDenied,
+    ValidationError,
+)
+from django.http import Http404
+from django.shortcuts import resolve_url
+
+from trusts.runtime import (
+    AuthorizationConfigError,
+    filter_authorized,
+    principal_is_usable,
+)
+
+
+_MISSING = object()
+
+GRANTED = 'granted'
+DENIED = 'denied'
+NOT_FOUND = 'not_found'
+CONFIG_ERROR = 'config_error'
+
+
+class K(object):
+    """Inert URL-kwarg key selector. Not a getter."""
+
+    def __init__(self, key):
+        if not isinstance(key, str) or not key:
+            raise AuthorizationConfigError(
+                'K() requires a non-empty request key string, not %r.' % (key,)
+            )
+        self.key = key
+
+    def __repr__(self):
+        return 'K(%r)' % (self.key,)
+
+
+class G(object):
+    """Inert GET-parameter key selector. Not a getter."""
+
+    def __init__(self, key):
+        if not isinstance(key, str) or not key:
+            raise AuthorizationConfigError(
+                'G() requires a non-empty request key string, not %r.' % (key,)
+            )
+        self.key = key
+
+    def __repr__(self):
+        return 'G(%r)' % (self.key,)
+
+
+class O(object):
+    """Inert POST-parameter key selector. Not a getter."""
+
+    def __init__(self, key):
+        if not isinstance(key, str) or not key:
+            raise AuthorizationConfigError(
+                'O() requires a non-empty request key string, not %r.' % (key,)
+            )
+        self.key = key
+
+    def __repr__(self):
+        return 'O(%r)' % (self.key,)
+
+
+class P(object):
+    """Operation-and-selector data. ``&`` / ``|`` compose over the same leaves.
+
+    A leaf holds an operation (instance or ``operation_lookup`` string),
+    an explicit ``resource_model``, and request-key selectors. Parent
+    nodes created by ``&`` / ``|`` hold no operation of their own.
+    Callables are rejected. This is not Zero's Django-permission ``P``.
+    """
+
+    def __init__(self, operation, resource_model=None, resource_kwarg=None, **fieldlookups):
+        self._operation = operation
+        self._resource_model = resource_model
+        self._resource_kwarg = resource_kwarg
+        self._fieldlookups = fieldlookups
+        self._left_operand = None
+        self._right_operand = None
+        self._operator = None
+        if resource_kwarg is not None and not isinstance(resource_kwarg, str):
+            raise AuthorizationConfigError(
+                'resource_kwarg must be a URL kwarg name string, not %r.' % (
+                    resource_kwarg,
+                )
+            )
+        for field, selector in fieldlookups.items():
+            _require_selector(selector, field)
+
+    def __and__(self, other):
+        if not isinstance(other, P):
+            raise TypeError(
+                "unsupported operand type(s) for &: '%s' and '%s'" % (
+                    type(self), type(other),
+                )
+            )
+        parent = P('')
+        parent._left_operand = self
+        parent._right_operand = other
+        parent._operator = and_
+        return parent
+
+    def __or__(self, other):
+        if not isinstance(other, P):
+            raise TypeError(
+                "unsupported operand type(s) for |: '%s' and '%s'" % (
+                    type(self), type(other),
+                )
+            )
+        parent = P('')
+        parent._left_operand = self
+        parent._right_operand = other
+        parent._operator = or_
+        return parent
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        if self._operator:
+            return 'P object'
+        if isinstance(self._operation, str):
+            return self._operation
+        return 'P object'
+
+    def get_leaves(self):
+        if not self._operator:
+            return [self]
+        return self._left_operand.get_leaves() + self._right_operand.get_leaves()
+
+    def with_defaults(self, resource_model=None, resource_kwarg=None, fieldlookups=None):
+        """Copy this tree, filling missing model/selectors from decorator args."""
+        if fieldlookups is None:
+            fieldlookups = {}
+        if self._operator:
+            left = self._left_operand.with_defaults(
+                resource_model, resource_kwarg, fieldlookups,
+            )
+            right = self._right_operand.with_defaults(
+                resource_model, resource_kwarg, fieldlookups,
+            )
+            if self._operator is and_:
+                return left & right
+            return left | right
+        merged = dict(fieldlookups)
+        merged.update(self._fieldlookups)
+        return P(
+            self._operation,
+            resource_model=self._resource_model or resource_model,
+            resource_kwarg=self._resource_kwarg or resource_kwarg,
+            **merged
+        )
+
+
+def _require_selector(value, field):
+    if isinstance(value, (K, G, O)):
+        return value
+    if callable(value):
+        raise AuthorizationConfigError(
+            'Field %r must be a K, G, or O selector, not a callable.' % (field,)
+        )
+    raise AuthorizationConfigError(
+        'Field %r must be a K, G, or O selector, not %r.' % (field, value)
+    )
+
+
+def _require_model(resource_model):
+    meta = getattr(resource_model, '_meta', None)
+    if not isinstance(resource_model, type) or meta is None:
+        raise AuthorizationConfigError(
+            'resource_model must be an explicit Django model class, not %r.' % (
+                resource_model,
+            )
+        )
+    return resource_model
+
+
+def _source_has(source, key):
+    try:
+        return key in source
+    except (TypeError, ValueError):
+        return False
+
+
+def _source_get(source, key):
+    try:
+        return source[key]
+    except (KeyError, TypeError, ValueError):
+        return _MISSING
+
+
+def _bind_lookups(request, view_kwargs, resource_kwarg, fieldlookups):
+    """Resolve declared keys to field lookups. Missing keys stay ``_MISSING``."""
+    resolved = {}
+    if resource_kwarg is not None:
+        if _source_has(view_kwargs, resource_kwarg):
+            resolved['pk'] = view_kwargs[resource_kwarg]
+        else:
+            resolved['pk'] = _MISSING
+    for field, selector in fieldlookups.items():
+        if isinstance(selector, K):
+            source = view_kwargs
+        elif isinstance(selector, G):
+            source = request.GET
+        elif isinstance(selector, O):
+            source = request.POST
+        else:
+            raise AuthorizationConfigError(
+                'Field %r must be a K, G, or O selector, not %r.' % (
+                    field, selector,
+                )
+            )
+        if _source_has(source, selector.key):
+            resolved[field] = _source_get(source, selector.key)
+        else:
+            resolved[field] = _MISSING
+    return resolved
+
+
+def _lookups_usable(resolved):
+    if not resolved:
+        return False
+    for value in resolved.values():
+        if value is _MISSING or value is None or value == '':
+            return False
+    return True
+
+
+def _evaluate_leaf(request, view_kwargs, leaf, runtime):
+    try:
+        resource_model = _require_model(leaf._resource_model)
+        resolved = _bind_lookups(
+            request, view_kwargs, leaf._resource_kwarg, leaf._fieldlookups,
+        )
+        if not resolved:
+            raise AuthorizationConfigError(
+                'require_authorized needs resource_kwarg or a K/G/O selector '
+                'so resource identity comes from declared request keys.'
+            )
+        if not _lookups_usable(resolved):
+            return NOT_FOUND
+        principal = getattr(request, 'user', _MISSING)
+        if principal is _MISSING:
+            raise AuthorizationConfigError(
+                'require_authorized requires request.user.'
+            )
+        candidates = resource_model._default_manager.filter(**resolved)
+        if not principal_is_usable(principal):
+            if candidates.exists():
+                return DENIED
+            return NOT_FOUND
+        authorized = filter_authorized(
+            candidates, principal, leaf._operation, **runtime,
+        )
+        if authorized.first() is not None:
+            return GRANTED
+        if candidates.exists():
+            return DENIED
+        return NOT_FOUND
+    except AuthorizationConfigError:
+        return CONFIG_ERROR
+    except (ValidationError, ValueError, TypeError):
+        return NOT_FOUND
+    except FieldError:
+        return CONFIG_ERROR
+
+
+def _evaluate_expr(request, view_kwargs, expr, runtime):
+    if expr._operator:
+        left = _evaluate_expr(
+            request, view_kwargs, expr._left_operand, runtime,
+        )
+        if expr._operator is and_:
+            if left is not GRANTED:
+                return left
+            return _evaluate_expr(
+                request, view_kwargs, expr._right_operand, runtime,
+            )
+        if left is GRANTED:
+            return left
+        right = _evaluate_expr(
+            request, view_kwargs, expr._right_operand, runtime,
+        )
+        if right is GRANTED:
+            return GRANTED
+        if left is CONFIG_ERROR or right is CONFIG_ERROR:
+            return CONFIG_ERROR
+        if left is DENIED or right is DENIED:
+            return DENIED
+        return NOT_FOUND
+    return _evaluate_leaf(request, view_kwargs, expr, runtime)
+
+
+def request_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):
+    """Run ``test_func(request, *args, **kwargs)``; login-redirect on ``False``.
+
+    ``Http404`` / ``PermissionDenied`` raised by the test propagate.
+    Wrapped-view metadata is preserved with ``functools.wraps``.
+    """
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped_view(request, *args, **kwargs):
+            if test_func(request, *args, **kwargs):
+                return view_func(request, *args, **kwargs)
+            path = request.build_absolute_uri()
+            resolved_login_url = resolve_url(login_url or settings.LOGIN_URL)
+            login_scheme, login_netloc = urlparse(resolved_login_url)[:2]
+            current_scheme, current_netloc = urlparse(path)[:2]
+            if ((not login_scheme or login_scheme == current_scheme) and
+                    (not login_netloc or login_netloc == current_netloc)):
+                path = request.get_full_path()
+            return redirect_to_login(
+                path, resolved_login_url, redirect_field_name)
+        return _wrapped_view
+    return decorator
+
+
+def require_authorized(
+    operation,
+    resource_model=None,
+    resource_kwarg=None,
+    raise_exception=True,
+    login_url=None,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    context=None,
+    trustee=None,
+    names=None,
+    **fieldlookups
+):
+    """Authorize a view from operation data and declared request keys.
+
+    ``operation`` is an operation instance, an ``operation_lookup``
+    string, or a ``P`` expression. ``resource_model`` is required on the
+    decorator or on each ``P`` leaf. ``resource_kwarg`` names the URL
+    kwarg that holds the resource primary key. Additional field lookups
+    must use ``K`` / ``G`` / ``O``.
+
+    Isolated tests pass ``context=`` / ``trustee=`` (process-wide maps
+    remain the no-arg default).
+    """
+    if resource_kwarg is not None and not isinstance(resource_kwarg, str):
+        raise AuthorizationConfigError(
+            'resource_kwarg must be a URL kwarg name string, not %r.' % (
+                resource_kwarg,
+            )
+        )
+    for field, selector in fieldlookups.items():
+        _require_selector(selector, field)
+    if isinstance(operation, P):
+        expr = operation.with_defaults(
+            resource_model, resource_kwarg, fieldlookups,
+        )
+    else:
+        expr = P(
+            operation,
+            resource_model=resource_model,
+            resource_kwarg=resource_kwarg,
+            **fieldlookups
+        )
+    runtime = dict(context=context, trustee=trustee, names=names)
+
+    def _check(request, *args, **kwargs):
+        outcome = _evaluate_expr(request, kwargs, expr, runtime)
+        if outcome is GRANTED:
+            return True
+        if outcome is NOT_FOUND:
+            raise Http404
+        if outcome is CONFIG_ERROR:
+            raise PermissionDenied
+        if raise_exception:
+            raise PermissionDenied
+        return False
+
+    return request_passes_test(
+        _check, login_url=login_url, redirect_field_name=redirect_field_name,
+    )
+
+
+__all__ = [
+    'G',
+    'K',
+    'O',
+    'P',
+    'require_authorized',
+    'request_passes_test',
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Focused kernel **S3** only against current master (`fdcea9c` / S2 merge). Implements accepted framework-execution-r1+r2+r3 decorator surface.

HEAD: `a541979be90a513b3a5ad2d0812a6cef4e3ffa47`

Review fixes on this head:

- Declared keys identify *the* resource. Unique identity may combine lookup+auth; a non-unique selector must match exactly one row or the request is **403** (not an existential grant).
- `P(read) & P(write)` cannot grant when separate matching rows satisfy separate leaves.
- Every `P` leaf is config-validated before any grant, including declared lookup names and `resource_kwarg` (`_meta` only; no request data, no SQL). A broken `|` / `&` leaf (unregistered model, unknown field, missing selector) is **403** even when another leaf would grant or its request key is missing.

## What this ships

- `trusts.decorators.require_authorized(operation, resource_model=..., resource_kwarg=...)`
- Generic `request_passes_test`
- Inert `P` / `K` / `G` / `O` (operation-and-selector data; no getter callbacks)
- Authorization through S1 `filter_authorized` / shared `grant_q`
- Default **404** for missing/unresolvable unique-identity
- Default **403** for existing-but-unauthorized, unusable principal, unknown operation data, ambiguous identity, malformed config
- Wrapped-view metadata via `functools.wraps`
- Isolated tests + `migrates.md` record (change 46–47)

## Query matrix (honest)

| Path | SQL |
| --- | ---: |
| Missing request key | 0 |
| Config preflight (unknown field / unregistered / broken `P` leaf) | 0 |
| Unusable principal (exists / missing) | 1 existence, no auth `Exists` |
| Granted unique identity (PK / unique key; lookup + auth combined) | 1 |
| Unauthorized or not-found after a unique-identity combined miss | 2 |
| Ambiguous non-unique selector (2+ rows) | 1 (`[:2]`), fail closed 403 |
| Single non-unique match then authorize that instance | 2 |
| `P` AND of granted + denied unique-identity leaves | 1 + 2 = 3 |
| `P` AND of two non-unique leaves that share 2+ rows | 1 |

## Out of scope

- django-trusts-zero (`permission_required` stays Zero)
- S4 admin / CBVs / templates
- S5 checks cleanup
- gh-permissions#1
- #17
- Does **not** close #47

Package version remains `1.0.0.dev0`.

r? @chatforthomas
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae7a4c06-d1f9-430f-a104-e05b89c39200?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae7a4c06-d1f9-430f-a104-e05b89c39200&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

