### PR TITLE
Kernel S4: AuthorizedModelAdmin, CBV mixins, and stub templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ AUTHENTICATION_BACKENDS = (
 
 Import concrete models from ``trusts.zero.models``. Kernel APIs stay
 ``trusts.context``, ``trusts.trustee``, ``trusts.path``, ``trusts.runtime``,
-``trusts.query``, ``trusts.backends``, and ``trusts.decorators``. This
+``trusts.query``, ``trusts.backends``, ``trusts.decorators``,
+``trusts.admin``, and ``trusts.views``. This
 package does not ship ``trusts/zero``.
 
 API and compatibility notes for this modernization are in [migrates.md](migrates.md).

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -32,6 +32,11 @@ installable `trusts/` package:
   `require_authorized` / `P` / `K` / `G` / `O` (URL/GET/POST binding;
   404 vs 403; login redirect; config error → 403; superuser does not
   bypass; bounded query counts)
+- `tests/core/test_s4_admin_views.py` — issue #47 S4
+  `AuthorizedModelAdmin` / `AuthorizedQuerySetMixin` /
+  `AuthorizedObjectMixin` / `trusts/` stub templates (pre-pagination
+  SQL filter; object≡list; 404 vs 403; config error → 403; superuser
+  does not bypass; template override; bounded query counts)
 - `tests/core/test_zero_path.py` — issue #43 Step 2 Zero consumer of compose
   (`ContentQuerySet.permitted` / `TrustModelBackend`; same-PK fail-closed)
 - `tests/core/test_kernel_split.py` — issue #43 Step 3 kernel/Zero AppConfig,
@@ -43,6 +48,7 @@ installable `trusts/` package:
   `tests.core.test_gh_vocab`, `tests.core.test_s1_kernel`,
   `tests.core.test_s2_backend`,
   `tests.core.test_s3_decorators`,
+  `tests.core.test_s4_admin_views`,
   `tests.core.test_zero_path`,
   `tests.core.test_kernel_split`, `tests.core.test_wheel_install`,
   `tests.regressions.test_issue_*`)

--- a/migrates.md
+++ b/migrates.md
@@ -2366,29 +2366,35 @@ data (instance or `operation_lookup` string). Django hooks:
 - `list_operation` → `get_queryset` uses S1 `filter_authorized`.
   `ChangeList.root_queryset` is that authorized queryset, so pagination
   happens after the SQL grant filter.
-- `view_operation` (fallback: `list_operation`) → `has_view_permission`
-  / `get_object`.
+- `view_operation` (fallback: `list_operation`) → `has_view_permission`.
 - `change_operation` → `has_change_permission`.
 - `delete_operation` → `has_delete_permission`.
 - Add is fail-closed (`has_add_permission` is False). No FK/form
   queryset helper is shipped; generic UI tests did not demonstrate a
   need.
 
-`get_object` looks up identity on the default manager, then applies
-`view_operation`. Missing rows stay `None` (admin 404). Existing
-unauthorized rows raise `PermissionDenied` (403). The list queryset
-is not reused for that lookup, so an unauthorized row cannot be hidden
-as missing.
+`get_object` retrieves a **singular identity** from
+`get_identity_base_queryset` (unauthorized consumer scope; default
+manager). It does **not** apply `view_operation`. Missing rows stay
+`None` (admin 404). Ambiguous identity (2+ candidates) is 403.
+Existing rows are returned so Django's change/delete/view hooks apply
+their own operations independently. A change-only or delete-only grant
+is not blocked by a view ceiling. The authorization-filtered list
+queryset is not reused for identity.
 
 `AuthorizedQuerySetMixin` is the list CBV hook (`list_operation` or
 fallback `operation`). `AuthorizedObjectMixin` is the detail/update
 hook (`object_operation` / `view_operation` / `operation`; identity
-from `pk_url_kwarg` or `slug_url_kwarg`). Both reuse S1
-`filter_authorized`. There is no second authorization walker and no
-resolver/policy callback.
+from `pk_url_kwarg` / `slug_url_kwarg`, honoring `query_pk_and_slug`).
+Application scoping belongs on the CBV `queryset` or
+`get_identity_base_queryset()` — not on `get_queryset()` after the
+list mixin has already applied `list_operation`. Both mixins reuse S1
+`filter_authorized` / `is_authorized`. There is no second authorization
+walker and no resolver/policy callback.
 
-`resolve_authorized_object` is the shared identity + auth helper used
-by the object mixin and admin `get_object`.
+`require_singular_identity` fails closed on 0 (404) or 2+ (403)
+candidates and never uses `.first()`. `resolve_authorized_object`
+requires that singular source identity, then authorizes that one row.
 
 Stub templates live under the `trusts/` namespace only. Consumers set
 `template_name` or place an earlier `trusts/authorized_*.html` on the
@@ -2414,12 +2420,17 @@ Query contract (honest):
 | Authorized list (`get_queryset` / unpaginated CBV) | 1 |
 | Paginated CBV list (count + page) | 2, both on the authorized queryset |
 | Admin `ChangeList` page | Django changelist queries on the already-filtered root queryset |
-| Granted unique object (admin `get_object` / CBV detail) | 1 combined lookup+auth |
-| Existing unauthorized / unknown operation data | 2 (combined miss + existence) → 403 |
-| Missing object after a combined miss | 2 → 404 (admin `None`) |
+| Admin `get_object` (PK identity only; no view ceiling) | 1 (`[:2]`) |
+| Admin missing PK | 1 → `None` (404) |
+| Admin ambiguous identity | 1 (`[:2]`) → 403 |
+| CBV granted unique object | 2 (identity `[:2]` + `is_authorized`) |
+| CBV existing unauthorized / unknown operation data | 2 → 403 |
+| CBV missing unique identity | 1 (`[:2]` empty) → 404 |
+| Ambiguous slug / candidate set (one or both granted) | 1 (`[:2]`) → 403, no row returned |
 | Missing URL identity | 0 → 404 |
-| Unusable principal + existing object | 1 existence, no auth `Exists` → 403 |
+| Unusable principal + existing singular object | 1 identity, no auth `Exists` → 403 |
 | Unusable principal list | 0 (empty queryset) |
+| Consumer-scoped identity excluding an authorized row | 1 (`[:2]` empty) → 404 |
 
 No per-row permission checks.
 
@@ -2443,17 +2454,17 @@ No per-row permission checks.
 | New | Noun-independent `AuthorizedModelAdmin` configured by operation data. Isolated registries via `context` / `trustee` class attributes. |
 | Replacement | Subclass `AuthorizedModelAdmin` and set `list_operation` / `view_operation` / `change_operation` / `delete_operation`. Keep Zero product ModelAdmins in `trusts.zero.admin`. |
 | Affected | New kernel consumers. Zero is not re-exported from `trusts.admin`. |
-| Authorization | List membership is the S1 grant `Exists` before pagination. Object view/change/delete agree with `is_authorized` for the configured operation. Missing objects are 404; existing unauthorized objects are 403. Malformed configuration cannot produce access. Superuser flags are ignored. Add stays closed. |
+| Authorization | List membership is the S1 grant `Exists` before pagination. `get_object` is identity-only. Object view/change/delete are independent `is_authorized` hooks. Missing objects are 404; in-scope unauthorized objects are 403. Change-only / delete-only grants reach their hook. Malformed configuration cannot produce access. Superuser flags are ignored. Add stays closed. |
 
 ### 49. `trusts.views` mixins and stub templates (new)
 
 | | |
 | --- | --- |
 | Previous | Consumers wrote List/Detail/Update `get_queryset` / `get_object` by hand, or copied Zero team views (`auth/group_*`, `SelectUserForm`). |
-| New | `AuthorizedQuerySetMixin` / `AuthorizedObjectMixin` plus four `trusts/` stubs. `resolve_authorized_object` for the 404/403 identity dance. |
-| Replacement | Mix the classes into Django CBVs and set operation data + `model`. Override `template_name` or the `trusts/authorized_*.html` stubs. Do not import Zero team views for generic CRUD. |
+| New | `AuthorizedQuerySetMixin` / `AuthorizedObjectMixin` plus four `trusts/` stubs. `require_singular_identity` + `resolve_authorized_object` for singular identity then 404/403. `get_identity_base_queryset()` is the unauthorized application scope. |
+| Replacement | Mix the classes into Django CBVs and set operation data + `model`. Put tenant / soft-delete filters on `queryset` or `get_identity_base_queryset()`, not only on an authorized `get_queryset()`. Override `template_name` or the `trusts/authorized_*.html` stubs. Do not import Zero team views for generic CRUD. |
 | Affected | New kernel list/detail/update views. |
-| Authorization | Same S1 predicate as admin/runtime. Missing identity → 404. Existing unauthorized / unusable principal / unknown operation / config error → 403. Superuser flags are ignored. |
+| Authorization | Same S1 predicate as admin/runtime. Source identity must be singular; 2+ candidates are 403 even if one or both are granted. Absent from consumer scope → 404. Present in that scope but denied → 403. `query_pk_and_slug` applies both request values. Superuser flags are ignored. |
 
 ## Fresh database
 
@@ -2485,7 +2496,10 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Import `AuthorizedModelAdmin` from `trusts.admin`, not Zero.
 - [ ] Import CBV mixins from `trusts.views`; set operation data and `model`.
 - [ ] Expect list querysets to be S1-filtered before pagination.
-- [ ] Expect 404 for missing objects and 403 for existing unauthorized ones.
+- [ ] Expect 404 for missing / out-of-scope objects and 403 for in-scope unauthorized ones.
+- [ ] Put application scope on `queryset` / `get_identity_base_queryset()`, not on the authorized list queryset.
+- [ ] Treat ambiguous slug/candidate identity as 403; do not take `.first()` of the authorized subset.
+- [ ] Do not expect admin `get_object` to apply `view_operation`; change/delete hooks are independent.
 - [ ] Catch `AuthorizationConfigError` only at security boundaries (admin/CBVs already do).
 - [ ] Override `trusts/authorized_*.html` or set `template_name`; do not move Zero `auth/group_*`.
 - [ ] Do not expect framework `urlpatterns` or an add/FK form helper.

--- a/migrates.md
+++ b/migrates.md
@@ -2334,3 +2334,163 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #47 from this PR.
 
+# Issue #47 S4: authorized admin, CBV mixins, stub templates (1.0.0.dev0)
+
+This record covers the fourth kernel execution slice. Version remains
+**1.0.0.dev0**. This PR does **not** close
+[#47](https://github.com/django-trusts/django-trusts/issues/47); review
+owns that. It implements accepted **framework-execution-r1+r2+r3**
+kernel S4 only. It does **not** modify `django-trusts-zero`, start S5
+checks cleanup, gh-permissions#1, or resume #17.
+
+## Decision
+
+```text
+trusts.admin:
+  AuthorizedModelAdmin
+    list_operation / view_operation / change_operation / delete_operation
+trusts.views:
+  AuthorizedQuerySetMixin
+  AuthorizedObjectMixin
+  resolve_authorized_object
+trusts/templates/trusts/:
+  authorized_list.html
+  authorized_detail.html
+  authorized_form.html
+  authorized_confirm_delete.html
+```
+
+`AuthorizedModelAdmin` is noun-independent and configured by operation
+data (instance or `operation_lookup` string). Django hooks:
+
+- `list_operation` → `get_queryset` uses S1 `filter_authorized`.
+  `ChangeList.root_queryset` is that authorized queryset, so pagination
+  happens after the SQL grant filter.
+- `view_operation` (fallback: `list_operation`) → `has_view_permission`
+  / `get_object`.
+- `change_operation` → `has_change_permission`.
+- `delete_operation` → `has_delete_permission`.
+- Add is fail-closed (`has_add_permission` is False). No FK/form
+  queryset helper is shipped; generic UI tests did not demonstrate a
+  need.
+
+`get_object` looks up identity on the default manager, then applies
+`view_operation`. Missing rows stay `None` (admin 404). Existing
+unauthorized rows raise `PermissionDenied` (403). The list queryset
+is not reused for that lookup, so an unauthorized row cannot be hidden
+as missing.
+
+`AuthorizedQuerySetMixin` is the list CBV hook (`list_operation` or
+fallback `operation`). `AuthorizedObjectMixin` is the detail/update
+hook (`object_operation` / `view_operation` / `operation`; identity
+from `pk_url_kwarg` or `slug_url_kwarg`). Both reuse S1
+`filter_authorized`. There is no second authorization walker and no
+resolver/policy callback.
+
+`resolve_authorized_object` is the shared identity + auth helper used
+by the object mixin and admin `get_object`.
+
+Stub templates live under the `trusts/` namespace only. Consumers set
+`template_name` or place an earlier `trusts/authorized_*.html` on the
+template loaders. Object stubs accept optional `update_url` /
+`delete_url` context. There are **no** framework `urlpatterns`.
+
+Zero team URLs, forms, `auth/group_*` templates, and product
+ModelAdmins stay in `django-trusts-zero`.
+
+`AuthorizationConfigError` → `PermissionDenied` / `False` at these
+security boundaries. Direct runtime APIs still raise. Unusable
+principals deny. Active `is_superuser` does not bypass registered
+object policy. `has_*` methods do not call the Django user-permission
+helper.
+
+Isolated tests pass `context=` / `trustee=` as class attributes
+(process-wide maps remain the no-arg default).
+
+Query contract (honest):
+
+| Path | SQL |
+| --- | ---: |
+| Authorized list (`get_queryset` / unpaginated CBV) | 1 |
+| Paginated CBV list (count + page) | 2, both on the authorized queryset |
+| Admin `ChangeList` page | Django changelist queries on the already-filtered root queryset |
+| Granted unique object (admin `get_object` / CBV detail) | 1 combined lookup+auth |
+| Existing unauthorized / unknown operation data | 2 (combined miss + existence) → 403 |
+| Missing object after a combined miss | 2 → 404 (admin `None`) |
+| Missing URL identity | 0 → 404 |
+| Unusable principal + existing object | 1 existence, no auth `Exists` → 403 |
+| Unusable principal list | 0 (empty queryset) |
+
+No per-row permission checks.
+
+## No change to these public call sites
+
+- S1 `trusts.runtime` / `trusts.query` / `compose` / `compose_scope`
+- S2 `ObjectAuthorizationBackend` / `ObjectAuthorizationModelBackend`
+- S3 `trusts.decorators.require_authorized` / `P` / `K` / `G` / `O`
+- Zero `trusts.zero.admin`, team views / urls / `auth/group_*`
+  templates, `TrustModelBackend`, `ContentQuerySet.permitted`,
+  historical migrations, app label `trusts`
+- Package version `1.0.0.dev0`
+
+## Changes
+
+### 48. `trusts.admin.AuthorizedModelAdmin` (new)
+
+| | |
+| --- | --- |
+| Previous | Consumers copied `get_queryset` / `has_*_permission` onto `ModelAdmin`, or used Zero's concrete Trust/Role/TrustGroup admins and `auto_modeladmin`. |
+| New | Noun-independent `AuthorizedModelAdmin` configured by operation data. Isolated registries via `context` / `trustee` class attributes. |
+| Replacement | Subclass `AuthorizedModelAdmin` and set `list_operation` / `view_operation` / `change_operation` / `delete_operation`. Keep Zero product ModelAdmins in `trusts.zero.admin`. |
+| Affected | New kernel consumers. Zero is not re-exported from `trusts.admin`. |
+| Authorization | List membership is the S1 grant `Exists` before pagination. Object view/change/delete agree with `is_authorized` for the configured operation. Missing objects are 404; existing unauthorized objects are 403. Malformed configuration cannot produce access. Superuser flags are ignored. Add stays closed. |
+
+### 49. `trusts.views` mixins and stub templates (new)
+
+| | |
+| --- | --- |
+| Previous | Consumers wrote List/Detail/Update `get_queryset` / `get_object` by hand, or copied Zero team views (`auth/group_*`, `SelectUserForm`). |
+| New | `AuthorizedQuerySetMixin` / `AuthorizedObjectMixin` plus four `trusts/` stubs. `resolve_authorized_object` for the 404/403 identity dance. |
+| Replacement | Mix the classes into Django CBVs and set operation data + `model`. Override `template_name` or the `trusts/authorized_*.html` stubs. Do not import Zero team views for generic CRUD. |
+| Affected | New kernel list/detail/update views. |
+| Authorization | Same S1 predicate as admin/runtime. Missing identity → 404. Existing unauthorized / unusable principal / unknown operation / config error → 403. Superuser flags are ignored. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m tests.runtests
+```
+
+No Trusts schema migration. S4 uses the existing isolated S1 test models.
+
+## Upgrade of a representative legacy database
+
+Unchanged. `scripts/verify-legacy-upgrade.py` still expects
+`{0001_initial, 0002_trustgroup}` on label `trusts`.
+
+## Out of scope (unchanged)
+
+- S5 `E008` / kernel `Content` leftover import cleanup
+- Framework URL patterns
+- FK / `ModelChoiceField` queryset helper
+- Generic `register_row_condition`
+- `RecursiveEdge` / `OrderedContribution`
+- django-trusts-zero admin/views/templates wrappers or pin bump
+- gh-permissions#1
+- Closing #17 or #47
+
+## Migration-bot summary (issue #47 S4)
+
+- [ ] Import `AuthorizedModelAdmin` from `trusts.admin`, not Zero.
+- [ ] Import CBV mixins from `trusts.views`; set operation data and `model`.
+- [ ] Expect list querysets to be S1-filtered before pagination.
+- [ ] Expect 404 for missing objects and 403 for existing unauthorized ones.
+- [ ] Catch `AuthorizationConfigError` only at security boundaries (admin/CBVs already do).
+- [ ] Override `trusts/authorized_*.html` or set `template_name`; do not move Zero `auth/group_*`.
+- [ ] Do not expect framework `urlpatterns` or an add/FK form helper.
+- [ ] Keep Zero product ModelAdmins and team People UI in `django-trusts-zero`.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_s4_admin_views`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #47 from this PR.
+

--- a/migrates.md
+++ b/migrates.md
@@ -2393,8 +2393,11 @@ list mixin has already applied `list_operation`. Both mixins reuse S1
 walker and no resolver/policy callback.
 
 `require_singular_identity` fails closed on 0 (404) or 2+ (403)
-candidates and never uses `.first()`. `resolve_authorized_object`
-requires that singular source identity, then authorizes that one row.
+candidates and never uses `.first()`. The candidate queryset must be
+**unsliced**: a pre-sliced `qs[:1]` (or any limit/offset) is
+`AuthorizationConfigError` on the helper so a hidden second row cannot
+be accepted as singular. `resolve_authorized_object` converts that
+config error to denial (403), then authorizes the one remaining row.
 
 Stub templates live under the `trusts/` namespace only. Consumers set
 `template_name` or place an earlier `trusts/authorized_*.html` on the
@@ -2427,6 +2430,7 @@ Query contract (honest):
 | CBV existing unauthorized / unknown operation data | 2 → 403 |
 | CBV missing unique identity | 1 (`[:2]` empty) → 404 |
 | Ambiguous slug / candidate set (one or both granted) | 1 (`[:2]`) → 403, no row returned |
+| Pre-sliced candidate queryset (`ambiguous[:1]`) | 0 → config error / 403 |
 | Missing URL identity | 0 → 404 |
 | Unusable principal + existing singular object | 1 identity, no auth `Exists` → 403 |
 | Unusable principal list | 0 (empty queryset) |
@@ -2464,7 +2468,7 @@ No per-row permission checks.
 | New | `AuthorizedQuerySetMixin` / `AuthorizedObjectMixin` plus four `trusts/` stubs. `require_singular_identity` + `resolve_authorized_object` for singular identity then 404/403. `get_identity_base_queryset()` is the unauthorized application scope. |
 | Replacement | Mix the classes into Django CBVs and set operation data + `model`. Put tenant / soft-delete filters on `queryset` or `get_identity_base_queryset()`, not only on an authorized `get_queryset()`. Override `template_name` or the `trusts/authorized_*.html` stubs. Do not import Zero team views for generic CRUD. |
 | Affected | New kernel list/detail/update views. |
-| Authorization | Same S1 predicate as admin/runtime. Source identity must be singular; 2+ candidates are 403 even if one or both are granted. Absent from consumer scope → 404. Present in that scope but denied → 403. `query_pk_and_slug` applies both request values. Superuser flags are ignored. |
+| Authorization | Same S1 predicate as admin/runtime. Source identity must be singular and unsliced; 2+ candidates are 403 even if one or both are granted. A pre-sliced `qs[:1]` is `AuthorizationConfigError` on `require_singular_identity` and 403 on `resolve_authorized_object`. Absent from consumer scope → 404. Present in that scope but denied → 403. `query_pk_and_slug` applies both request values. Superuser flags are ignored. |
 
 ## Fresh database
 
@@ -2499,6 +2503,7 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Expect 404 for missing / out-of-scope objects and 403 for in-scope unauthorized ones.
 - [ ] Put application scope on `queryset` / `get_identity_base_queryset()`, not on the authorized list queryset.
 - [ ] Treat ambiguous slug/candidate identity as 403; do not take `.first()` of the authorized subset.
+- [ ] Pass unsliced candidate querysets to `require_singular_identity` / `resolve_authorized_object`; `qs[:1]` is a config error / 403.
 - [ ] Do not expect admin `get_object` to apply `view_operation`; change/delete hooks are independent.
 - [ ] Catch `AuthorizationConfigError` only at security boundaries (admin/CBVs already do).
 - [ ] Override `trusts/authorized_*.html` or set `template_name`; do not move Zero `auth/group_*`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ include = ["trusts*"]
 exclude = ["trusts.zero*", "tests*", "docs*", "scripts*", "packaging*"]
 
 [tool.setuptools.package-data]
-trusts = ["*"]
+trusts = ["*", "templates/trusts/*.html"]

--- a/scripts/verify-wheel-install.py
+++ b/scripts/verify-wheel-install.py
@@ -101,6 +101,8 @@ def main() -> int:
     from trusts.path import AuthorizationPath, AuthorizationBranch, compose
     from trusts.backends import ObjectAuthorizationBackend
     from trusts.decorators import require_authorized
+    from trusts.admin import AuthorizedModelAdmin
+    from trusts.views import AuthorizedObjectMixin, AuthorizedQuerySetMixin
     from django_trusts import TQ, condition_refs
 
     trusts_file = Path(trusts.__file__).resolve()
@@ -136,6 +138,9 @@ def main() -> int:
     print('compose', compose)
     print('ObjectAuthorizationBackend', ObjectAuthorizationBackend)
     print('require_authorized', require_authorized)
+    print('AuthorizedModelAdmin', AuthorizedModelAdmin)
+    print('AuthorizedQuerySetMixin', AuthorizedQuerySetMixin)
+    print('AuthorizedObjectMixin', AuthorizedObjectMixin)
     print('TQ', TQ)
     print('condition_refs', condition_refs)
     print('absent test modules', ' '.join(ABSENT_TEST_MODULES))

--- a/tests/core/test_s4_admin_views.py
+++ b/tests/core/test_s4_admin_views.py
@@ -26,6 +26,7 @@ from trusts.trustee import TrusteeRegistry
 from trusts.views import (
     AuthorizedObjectMixin,
     AuthorizedQuerySetMixin,
+    require_singular_identity,
     resolve_authorized_object,
 )
 from tests.core.test_s1_kernel import _s1_maps
@@ -105,6 +106,12 @@ class S4FixtureMixin(object):
         )
         self.context, self.trustee = _s1_maps()
         self.runtime = dict(context=self.context, trustee=self.trustee)
+
+    def _grant_write(self, repository):
+        self.team.bundles.get().operations.add(self.write)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=repository, operation=self.write,
+        )
 
 
 class S4RepositoryAdmin(AuthorizedModelAdmin):
@@ -195,22 +202,50 @@ class S4AdminObjectGateTest(S4FixtureMixin, TestCase):
                 is_authorized(self.member, 'read', repo, **self.runtime),
             )
 
-    def test_get_object_granted_is_one_combined_query(self):
+    def test_get_object_is_identity_only_one_sql(self):
         model_admin = self._admin()
         request = self._request(self.member)
         with self.assertNumQueries(1):
             obj = model_admin.get_object(request, str(self.repo_a.pk))
         self.assertEqual(obj.pk, self.repo_a.pk)
-
-    def test_get_object_unauthorized_is_403_not_404(self):
-        model_admin = self._admin()
-        request = self._request(self.member)
-        with self.assertNumQueries(2):
-            with self.assertRaises(PermissionDenied):
-                model_admin.get_object(request, str(self.repo_b.pk))
+        with self.assertNumQueries(1):
+            denied = model_admin.get_object(request, str(self.repo_b.pk))
+        self.assertEqual(denied.pk, self.repo_b.pk)
+        self.assertFalse(model_admin.has_view_permission(request, denied))
         missing_pk = self.repo_a.pk + self.repo_b.pk + self.repo_c.pk + 1000
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertIsNone(model_admin.get_object(request, str(missing_pk)))
+
+    def test_change_only_grant_reaches_change_not_view(self):
+        self._grant_write(self.repo_b)
+        model_admin = self._admin(
+            view_operation='read',
+            change_operation='write',
+            delete_operation='read',
+        )
+        request = self._request(self.member)
+        with self.assertNumQueries(1):
+            obj = model_admin.get_object(request, str(self.repo_b.pk))
+        self.assertEqual(obj.pk, self.repo_b.pk)
+        self.assertFalse(model_admin.has_view_permission(request, obj))
+        self.assertTrue(model_admin.has_change_permission(request, obj))
+        self.assertFalse(model_admin.has_delete_permission(request, obj))
+        self.assertTrue(model_admin.has_view_or_change_permission(request, obj))
+
+    def test_delete_only_grant_reaches_delete_not_view(self):
+        self._grant_write(self.repo_b)
+        model_admin = self._admin(
+            view_operation='read',
+            change_operation='read',
+            delete_operation='write',
+        )
+        request = self._request(self.member)
+        obj = model_admin.get_object(request, str(self.repo_b.pk))
+        self.assertEqual(obj.pk, self.repo_b.pk)
+        self.assertFalse(model_admin.has_view_permission(request, obj))
+        self.assertFalse(model_admin.has_change_permission(request, obj))
+        self.assertTrue(model_admin.has_delete_permission(request, obj))
+        self.assertFalse(model_admin.has_view_or_change_permission(request, obj))
 
     def test_change_and_delete_require_write(self):
         model_admin = self._admin()
@@ -268,8 +303,9 @@ class S4AdminConfigAndSuperuserTest(S4FixtureMixin, TestCase):
             )
         with self.assertRaises(PermissionDenied):
             list(model_admin.get_queryset(request))
-        with self.assertRaises(PermissionDenied):
-            model_admin.get_object(request, str(note.pk))
+        self.assertEqual(
+            model_admin.get_object(request, str(note.pk)).pk, note.pk,
+        )
         self.assertFalse(model_admin.has_view_permission(request, note))
 
     def test_missing_list_operation_is_403(self):
@@ -323,8 +359,9 @@ class S4AdminConfigAndSuperuserTest(S4FixtureMixin, TestCase):
             model_admin.get_object(request, str(self.repo_a.pk)).pk,
             self.repo_a.pk,
         )
-        with self.assertRaises(PermissionDenied):
-            model_admin.get_object(request, str(self.repo_b.pk))
+        repo_b = model_admin.get_object(request, str(self.repo_b.pk))
+        self.assertEqual(repo_b.pk, self.repo_b.pk)
+        self.assertFalse(model_admin.has_view_permission(request, repo_b))
         superuser = User.objects.create_superuser(
             'root', 'root@example.com', 'secret',
         )
@@ -416,10 +453,11 @@ class S4CBVObjectTest(S4FixtureMixin, TestCase):
         request.user = user
         return request
 
-    def test_detail_granted_is_one_combined_query(self):
+    def test_detail_granted_is_identity_then_auth(self):
         view = self._detail()
         request = self._get(self.member)
-        with self.assertNumQueries(1):
+        # Singular identity ``[:2]`` plus ``is_authorized``.
+        with self.assertNumQueries(2):
             response = view(request, pk=self.repo_a.pk)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context_data['object'].pk, self.repo_a.pk)
@@ -435,7 +473,7 @@ class S4CBVObjectTest(S4FixtureMixin, TestCase):
             with self.assertRaises(PermissionDenied):
                 view(request, pk=self.repo_b.pk)
         missing_pk = self.repo_a.pk + self.repo_b.pk + self.repo_c.pk + 1000
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             with self.assertRaises(Http404):
                 view(request, pk=missing_pk)
 
@@ -475,7 +513,7 @@ class S4CBVObjectTest(S4FixtureMixin, TestCase):
             team=self.team, repository=self.repo_a, operation=self.write,
         )
         self.team.bundles.get().operations.add(self.write)
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = view(request, pk=self.repo_a.pk)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response.render(), 'csrf')
@@ -539,6 +577,114 @@ class S4CBVObjectTest(S4FixtureMixin, TestCase):
         with self.assertNumQueries(2):
             with self.assertRaises(PermissionDenied):
                 view(request, pk=self.repo_a.pk)
+
+    def test_consumer_queryset_excludes_authorized_row(self):
+        scoped = S1Repository.objects.filter(pk=self.repo_b.pk)
+        self.assertTrue(
+            is_authorized(self.member, 'read', self.repo_a, **self.runtime)
+        )
+        list_view = type(
+            'ScopedList', (AuthorizedQuerySetMixin, ListView), dict(
+                queryset=scoped,
+                list_operation='read',
+                context=self.context,
+                trustee=self.trustee,
+                paginate_by=None,
+                ordering=('pk',),
+            ),
+        ).as_view()
+        detail_view = type(
+            'ScopedDetail', (AuthorizedObjectMixin, DetailView), dict(
+                queryset=scoped,
+                model=S1Repository,
+                object_operation='read',
+                context=self.context,
+                trustee=self.trustee,
+            ),
+        ).as_view()
+        request = self._get(self.member)
+        listed = list(list_view(request).context_data['object_list'])
+        self.assertEqual(listed, [])
+        with self.assertRaises(Http404):
+            detail_view(request, pk=self.repo_a.pk)
+        with self.assertRaises(PermissionDenied):
+            detail_view(request, pk=self.repo_b.pk)
+
+    def test_duplicate_slug_one_authorized_fails_closed(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        self.repo_b.title = 'shared'
+        self.repo_b.save(update_fields=['title'])
+        view = self._detail(slug_field='title', slug_url_kwarg='slug')
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, slug='shared')
+        with self.assertRaises(PermissionDenied):
+            resolve_authorized_object(
+                S1Repository.objects.filter(title='shared'),
+                self.member, 'read', **self.runtime,
+            )
+
+    def test_duplicate_slug_both_authorized_fails_closed(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        self.repo_b.title = 'shared'
+        self.repo_b.save(update_fields=['title'])
+        self._grant_write(self.repo_b)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_b, operation=self.read,
+        )
+        self.assertTrue(
+            is_authorized(self.member, 'read', self.repo_b, **self.runtime)
+        )
+        view = self._detail(slug_field='title', slug_url_kwarg='slug')
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, slug='shared')
+
+    def test_query_pk_and_slug_both_constrain_identity(self):
+        view = self._detail(
+            slug_field='title',
+            slug_url_kwarg='slug',
+            query_pk_and_slug=True,
+        )
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            response = view(
+                request, pk=self.repo_a.pk, slug=self.repo_a.title,
+            )
+        self.assertEqual(response.context_data['object'].pk, self.repo_a.pk)
+        with self.assertNumQueries(1):
+            with self.assertRaises(Http404):
+                view(request, pk=self.repo_a.pk, slug=self.repo_b.title)
+        with self.assertNumQueries(1):
+            with self.assertRaises(Http404):
+                view(request, pk=self.repo_b.pk, slug=self.repo_a.title)
+
+    def test_require_singular_identity_rejects_ambiguous_candidates(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        self.repo_b.title = 'shared'
+        self.repo_b.save(update_fields=['title'])
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                require_singular_identity(
+                    S1Repository.objects.filter(title='shared'),
+                )
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                require_singular_identity(
+                    S1Repository.objects.filter(pk=self.repo_a.pk),
+                ).pk,
+                self.repo_a.pk,
+            )
+        with self.assertNumQueries(1):
+            with self.assertRaises(Http404):
+                require_singular_identity(
+                    S1Repository.objects.filter(pk=self.repo_a.pk + 10000),
+                )
 
 
 class S4TemplateOverrideTest(S4FixtureMixin, TestCase):

--- a/tests/core/test_s4_admin_views.py
+++ b/tests/core/test_s4_admin_views.py
@@ -1,0 +1,566 @@
+"""Isolated kernel tests for #47 S4 (admin, CBV mixins, stub templates).
+
+List querysets use S1 ``filter_authorized`` before pagination. Object
+gates agree with that queryset. ``AuthorizationConfigError`` is 403.
+Isolated registries only. Does not close #47. Does not implement S5.
+"""
+
+import inspect
+import re
+import tempfile
+from pathlib import Path
+
+from django.conf import settings
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.template.loader import get_template
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.views.generic import DetailView, ListView, UpdateView
+
+from trusts.admin import AuthorizedModelAdmin
+from trusts.context import ContextRegistry
+from trusts.runtime import AuthorizationConfigError, filter_authorized, is_authorized
+from trusts.trustee import TrusteeRegistry
+from trusts.views import (
+    AuthorizedObjectMixin,
+    AuthorizedQuerySetMixin,
+    resolve_authorized_object,
+)
+from tests.core.test_s1_kernel import _s1_maps
+from tests.models import (
+    S1Account,
+    S1Bundle,
+    S1Operation,
+    S1Organization,
+    S1Repository,
+    S1Team,
+    S1TeamGrant,
+    S1UnregisteredNote,
+)
+
+
+class S4ContractTest(SimpleTestCase):
+    def test_admin_and_views_have_no_product_nouns_or_perm_parser(self):
+        from trusts import admin as admin_mod
+        from trusts import views as views_mod
+        for module in (admin_mod, views_mod):
+            source = Path(inspect.getfile(module)).read_text()
+            for noun in ('Trust', 'Content', 'Junction', 'GitHub'):
+                self.assertIsNone(
+                    re.search(r'\b%s\b' % noun, source),
+                    '%r appears as a product noun in %s' % (
+                        noun, module.__name__,
+                    ),
+                )
+            self.assertNotIn('parse_perm_code', source)
+            self.assertNotIn('ContentType', source)
+            self.assertNotIn('has_perm(', source)
+            self.assertNotIn('app.action_model', source)
+            self.assertNotIn('urlpatterns', source)
+
+    def test_stub_templates_are_under_trusts_namespace(self):
+        names = (
+            'trusts/authorized_list.html',
+            'trusts/authorized_detail.html',
+            'trusts/authorized_form.html',
+            'trusts/authorized_confirm_delete.html',
+        )
+        for name in names:
+            template = get_template(name)
+            source = template.template.source
+            self.assertIn('Override with template_name', source)
+            for noun in ('Trust', 'Content', 'Junction', 'GitHub', 'Team'):
+                self.assertIsNone(
+                    re.search(r'\b%s\b' % noun, source),
+                    '%r appears in %s' % (noun, name),
+                )
+
+
+class S4FixtureMixin(object):
+    def setUp(self):
+        super(S4FixtureMixin, self).setUp()
+        self.factory = RequestFactory()
+        self.org = S1Organization.objects.create(name='acme')
+        self.team = S1Team.objects.create(organization=self.org, name='writers')
+        self.member = S1Account.objects.create(name='member')
+        self.stranger = S1Account.objects.create(name='stranger')
+        self.team.members.add(self.member)
+        self.read = S1Operation.objects.create(code='read')
+        self.write = S1Operation.objects.create(code='write')
+        self.repo_a = S1Repository.objects.create(
+            organization=self.org, title='repo-a',
+        )
+        self.repo_b = S1Repository.objects.create(
+            organization=self.org, title='repo-b',
+        )
+        self.repo_c = S1Repository.objects.create(
+            organization=self.org, title='repo-c',
+        )
+        bundle = S1Bundle.objects.create(team=self.team, name='reader')
+        bundle.operations.add(self.read)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.read,
+        )
+        self.context, self.trustee = _s1_maps()
+        self.runtime = dict(context=self.context, trustee=self.trustee)
+
+
+class S4RepositoryAdmin(AuthorizedModelAdmin):
+    list_operation = 'read'
+    view_operation = 'read'
+    change_operation = 'write'
+    delete_operation = 'write'
+    list_display = ('title',)
+
+
+class S4AdminListTest(S4FixtureMixin, TestCase):
+    def _admin(self, **attrs):
+        attrs.setdefault('context', self.context)
+        attrs.setdefault('trustee', self.trustee)
+        admin_class = type('BoundAdmin', (S4RepositoryAdmin,), attrs)
+        return admin_class(S1Repository, AdminSite(name='s4'))
+
+    def _request(self, user, path='/s4/s1repository/'):
+        request = self.factory.get(path)
+        request.user = user
+        return request
+
+    def test_get_queryset_filters_before_pagination_in_one_sql(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        with self.assertNumQueries(1):
+            pks = list(
+                model_admin.get_queryset(request).values_list('pk', flat=True)
+            )
+        self.assertEqual(pks, [self.repo_a.pk])
+        expected = list(
+            filter_authorized(
+                S1Repository.objects.all(), self.member, 'read', **self.runtime
+            ).values_list('pk', flat=True)
+        )
+        self.assertEqual(pks, expected)
+
+    def test_changelist_paginates_authorized_queryset_not_all_rows(self):
+        model_admin = self._admin(list_per_page=1)
+        request = self._request(self.member)
+        changelist = model_admin.get_changelist_instance(request)
+        self.assertEqual(changelist.result_count, 1)
+        self.assertEqual([row.pk for row in changelist.result_list], [self.repo_a.pk])
+        self.assertEqual(S1Repository.objects.count(), 3)
+        self.assertLessEqual(changelist.paginator.count, 1)
+
+    def test_unusable_principal_list_is_empty_without_auth_exists(self):
+        model_admin = self._admin()
+        request = self._request(AnonymousUser())
+        with self.assertNumQueries(0):
+            self.assertEqual(list(model_admin.get_queryset(request)), [])
+        self.member.is_active = False
+        request = self._request(self.member)
+        with self.assertNumQueries(0):
+            self.assertEqual(list(model_admin.get_queryset(request)), [])
+
+    def test_stranger_list_is_empty_one_sql(self):
+        model_admin = self._admin()
+        request = self._request(self.stranger)
+        with self.assertNumQueries(1):
+            self.assertEqual(list(model_admin.get_queryset(request)), [])
+
+
+class S4AdminObjectGateTest(S4FixtureMixin, TestCase):
+    def _admin(self, **attrs):
+        attrs.setdefault('context', self.context)
+        attrs.setdefault('trustee', self.trustee)
+        admin_class = type('BoundAdmin', (S4RepositoryAdmin,), attrs)
+        return admin_class(S1Repository, AdminSite(name='s4'))
+
+    def _request(self, user):
+        request = self.factory.get('/s4/s1repository/')
+        request.user = user
+        return request
+
+    def test_object_and_list_gates_agree(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        authorized = set(
+            model_admin.get_queryset(request).values_list('pk', flat=True)
+        )
+        for repo in (self.repo_a, self.repo_b, self.repo_c):
+            listed = repo.pk in authorized
+            viewed = model_admin.has_view_permission(request, repo)
+            self.assertEqual(listed, viewed)
+            self.assertEqual(
+                viewed,
+                is_authorized(self.member, 'read', repo, **self.runtime),
+            )
+
+    def test_get_object_granted_is_one_combined_query(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        with self.assertNumQueries(1):
+            obj = model_admin.get_object(request, str(self.repo_a.pk))
+        self.assertEqual(obj.pk, self.repo_a.pk)
+
+    def test_get_object_unauthorized_is_403_not_404(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                model_admin.get_object(request, str(self.repo_b.pk))
+        missing_pk = self.repo_a.pk + self.repo_b.pk + self.repo_c.pk + 1000
+        with self.assertNumQueries(2):
+            self.assertIsNone(model_admin.get_object(request, str(missing_pk)))
+
+    def test_change_and_delete_require_write(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        self.assertTrue(model_admin.has_view_permission(request, self.repo_a))
+        self.assertFalse(model_admin.has_change_permission(request, self.repo_a))
+        self.assertFalse(model_admin.has_delete_permission(request, self.repo_a))
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.write,
+        )
+        self.team.bundles.get().operations.add(self.write)
+        self.assertTrue(model_admin.has_change_permission(request, self.repo_a))
+        self.assertTrue(model_admin.has_delete_permission(request, self.repo_a))
+        self.assertFalse(model_admin.has_change_permission(request, self.repo_b))
+
+    def test_add_is_fail_closed(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        self.assertFalse(model_admin.has_add_permission(request))
+        self.member.is_superuser = True
+        self.assertFalse(model_admin.has_add_permission(request))
+
+    def test_module_permission_does_not_use_django_model_perms(self):
+        model_admin = self._admin()
+        request = self._request(self.member)
+        self.assertTrue(model_admin.has_module_permission(request))
+        self.assertTrue(model_admin.has_view_permission(request))
+        request = self._request(AnonymousUser())
+        self.assertFalse(model_admin.has_module_permission(request))
+        self.assertFalse(model_admin.has_view_permission(request))
+
+
+class S4AdminConfigAndSuperuserTest(S4FixtureMixin, TestCase):
+    def _request(self, user):
+        request = self.factory.get('/s4/s1repository/')
+        request.user = user
+        return request
+
+    def test_unregistered_resource_is_403(self):
+        admin_class = type('NoteAdmin', (AuthorizedModelAdmin,), dict(
+            list_operation='read',
+            view_operation='read',
+            context=self.context,
+            trustee=self.trustee,
+        ))
+        model_admin = admin_class(S1UnregisteredNote, AdminSite(name='s4'))
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo_a, text='nope',
+        )
+        request = self._request(self.member)
+        with self.assertRaises(AuthorizationConfigError):
+            is_authorized(
+                self.member, 'read', note,
+                context=self.context, trustee=self.trustee,
+            )
+        with self.assertRaises(PermissionDenied):
+            list(model_admin.get_queryset(request))
+        with self.assertRaises(PermissionDenied):
+            model_admin.get_object(request, str(note.pk))
+        self.assertFalse(model_admin.has_view_permission(request, note))
+
+    def test_missing_list_operation_is_403(self):
+        admin_class = type('BareAdmin', (AuthorizedModelAdmin,), dict(
+            context=self.context,
+            trustee=self.trustee,
+        ))
+        model_admin = admin_class(S1Repository, AdminSite(name='s4'))
+        request = self._request(self.member)
+        with self.assertRaises(PermissionDenied):
+            list(model_admin.get_queryset(request))
+        self.assertFalse(model_admin.has_view_permission(request, self.repo_a))
+        self.assertFalse(model_admin.has_change_permission(request, self.repo_a))
+
+    def test_callable_operation_is_403(self):
+        admin_class = type('CallableAdmin', (S4RepositoryAdmin,), dict(
+            list_operation=lambda request: 'read',
+            context=self.context,
+            trustee=self.trustee,
+        ))
+        model_admin = admin_class(S1Repository, AdminSite(name='s4'))
+        request = self._request(self.member)
+        with self.assertRaises(PermissionDenied):
+            list(model_admin.get_queryset(request))
+
+    def test_empty_adapters_is_403(self):
+        context = ContextRegistry()
+        context.register_identity(S1Repository)
+        trustee = TrusteeRegistry(
+            requester_model=S1Account,
+            scope_model=S1Repository,
+            operation_model=S1Operation,
+            operation_lookup='code',
+        )
+        admin_class = type('EmptyAdmin', (S4RepositoryAdmin,), dict(
+            context=context, trustee=trustee,
+        ))
+        model_admin = admin_class(S1Repository, AdminSite(name='s4'))
+        request = self._request(self.member)
+        with self.assertRaises(PermissionDenied):
+            list(model_admin.get_queryset(request))
+
+    def test_is_superuser_does_not_bypass_object_policy(self):
+        admin_class = type('BoundAdmin', (S4RepositoryAdmin,), dict(
+            context=self.context, trustee=self.trustee,
+        ))
+        model_admin = admin_class(S1Repository, AdminSite(name='s4'))
+        self.member.is_superuser = True
+        request = self._request(self.member)
+        self.assertEqual(
+            model_admin.get_object(request, str(self.repo_a.pk)).pk,
+            self.repo_a.pk,
+        )
+        with self.assertRaises(PermissionDenied):
+            model_admin.get_object(request, str(self.repo_b.pk))
+        superuser = User.objects.create_superuser(
+            'root', 'root@example.com', 'secret',
+        )
+        request = self._request(superuser)
+        with self.assertRaises(PermissionDenied):
+            list(model_admin.get_queryset(request))
+        self.assertFalse(model_admin.has_view_permission(request, self.repo_a))
+
+
+class S4CBVListTest(S4FixtureMixin, TestCase):
+    def _view(self, **attrs):
+        attrs.setdefault('model', S1Repository)
+        attrs.setdefault('list_operation', 'read')
+        attrs.setdefault('context', self.context)
+        attrs.setdefault('trustee', self.trustee)
+        attrs.setdefault('paginate_by', 1)
+        attrs.setdefault('ordering', ('pk',))
+        view_class = type('RepoList', (AuthorizedQuerySetMixin, ListView), attrs)
+        return view_class.as_view()
+
+    def _get(self, user, path='/', data=None):
+        request = self.factory.get(path, data=data or {})
+        request.user = user
+        return request
+
+    def test_list_filters_before_pagination(self):
+        view = self._view()
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            response = view(request)
+            objects = list(response.context_data['object_list'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([obj.pk for obj in objects], [self.repo_a.pk])
+        self.assertEqual(response.context_data['paginator'].count, 1)
+        self.assertEqual(S1Repository.objects.count(), 3)
+        rendered = response.render()
+        self.assertContains(rendered, 'repo-a')
+        self.assertNotContains(rendered, 'repo-b')
+        self.assertNotContains(rendered, 'repo-c')
+
+    def test_list_equivalents_filter_authorized(self):
+        view = self._view(paginate_by=None)
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            response = view(request)
+            pks = [obj.pk for obj in response.context_data['object_list']]
+        expected = list(
+            filter_authorized(
+                S1Repository.objects.all(), self.member, 'read', **self.runtime
+            ).values_list('pk', flat=True)
+        )
+        self.assertEqual(pks, expected)
+
+    def test_anonymous_list_is_empty_without_sql(self):
+        view = self._view(paginate_by=None)
+        request = self._get(AnonymousUser())
+        with self.assertNumQueries(0):
+            response = view(request)
+        self.assertEqual(list(response.context_data['object_list']), [])
+
+
+class S4CBVObjectTest(S4FixtureMixin, TestCase):
+    def _detail(self, **attrs):
+        attrs.setdefault('model', S1Repository)
+        attrs.setdefault('object_operation', 'read')
+        attrs.setdefault('context', self.context)
+        attrs.setdefault('trustee', self.trustee)
+        attrs.setdefault('update_url', '/update/')
+        attrs.setdefault('delete_url', '/delete/')
+        view_class = type(
+            'RepoDetail', (AuthorizedObjectMixin, DetailView), attrs,
+        )
+        return view_class.as_view()
+
+    def _update(self, **attrs):
+        attrs.setdefault('model', S1Repository)
+        attrs.setdefault('object_operation', 'write')
+        attrs.setdefault('fields', ('title',))
+        attrs.setdefault('context', self.context)
+        attrs.setdefault('trustee', self.trustee)
+        attrs.setdefault('template_name', 'trusts/authorized_form.html')
+        view_class = type(
+            'RepoUpdate', (AuthorizedObjectMixin, UpdateView), attrs,
+        )
+        return view_class.as_view()
+
+    def _get(self, user):
+        request = self.factory.get('/detail/')
+        request.user = user
+        return request
+
+    def test_detail_granted_is_one_combined_query(self):
+        view = self._detail()
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            response = view(request, pk=self.repo_a.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context_data['object'].pk, self.repo_a.pk)
+        rendered = response.render()
+        self.assertContains(rendered, 'repo-a')
+        self.assertContains(rendered, '/update/')
+        self.assertContains(rendered, '/delete/')
+
+    def test_detail_unauthorized_is_403_not_404(self):
+        view = self._detail()
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_b.pk)
+        missing_pk = self.repo_a.pk + self.repo_b.pk + self.repo_c.pk + 1000
+        with self.assertNumQueries(2):
+            with self.assertRaises(Http404):
+                view(request, pk=missing_pk)
+
+    def test_missing_pk_is_404_without_sql(self):
+        view = self._detail()
+        request = self._get(self.member)
+        with self.assertNumQueries(0):
+            with self.assertRaises(Http404):
+                view(request)
+
+    def test_anonymous_existing_is_403_one_existence_query(self):
+        view = self._detail()
+        request = self._get(AnonymousUser())
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+    def test_inactive_and_unauthenticated_are_403(self):
+        view = self._detail()
+        self.member.is_active = False
+        request = self._get(self.member)
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+        del self.member.is_active
+        self.member.is_authenticated = False
+        with self.assertNumQueries(1):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+    def test_update_requires_write(self):
+        view = self._update()
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+        S1TeamGrant.objects.create(
+            team=self.team, repository=self.repo_a, operation=self.write,
+        )
+        self.team.bundles.get().operations.add(self.write)
+        with self.assertNumQueries(1):
+            response = view(request, pk=self.repo_a.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response.render(), 'csrf')
+
+    def test_object_agrees_with_list_queryset(self):
+        for repo in (self.repo_a, self.repo_b):
+            listed = filter_authorized(
+                S1Repository.objects.filter(pk=repo.pk),
+                self.member, 'read', **self.runtime,
+            ).exists()
+            if listed:
+                obj = resolve_authorized_object(
+                    S1Repository.objects.filter(pk=repo.pk),
+                    self.member, 'read', **self.runtime,
+                )
+                self.assertEqual(obj.pk, repo.pk)
+            else:
+                with self.assertRaises(PermissionDenied):
+                    resolve_authorized_object(
+                        S1Repository.objects.filter(pk=repo.pk),
+                        self.member, 'read', **self.runtime,
+                    )
+
+    def test_unregistered_resource_is_403(self):
+        view_class = type('NoteDetail', (AuthorizedObjectMixin, DetailView), dict(
+            model=S1UnregisteredNote,
+            object_operation='read',
+            context=self.context,
+            trustee=self.trustee,
+        ))
+        note = S1UnregisteredNote.objects.create(
+            repository=self.repo_a, text='nope',
+        )
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view_class.as_view()(request, pk=note.pk)
+
+    def test_callable_operation_is_403(self):
+        view = self._detail(object_operation=lambda request: 'read')
+        request = self._get(self.member)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+    def test_is_superuser_does_not_bypass_object_policy(self):
+        view = self._detail()
+        self.member.is_superuser = True
+        request = self._get(self.member)
+        self.assertEqual(view(request, pk=self.repo_a.pk).status_code, 200)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_b.pk)
+        superuser = User.objects.create_superuser(
+            'root', 'root@example.com', 'secret',
+        )
+        request = self._get(superuser)
+        with self.assertRaises(PermissionDenied):
+            view(request, pk=self.repo_a.pk)
+
+    def test_unknown_operation_data_is_403_when_resource_exists(self):
+        view = self._detail(object_operation='missing')
+        request = self._get(self.member)
+        with self.assertNumQueries(2):
+            with self.assertRaises(PermissionDenied):
+                view(request, pk=self.repo_a.pk)
+
+
+class S4TemplateOverrideTest(S4FixtureMixin, TestCase):
+    def test_consumer_template_override_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / 'trusts'
+            dest.mkdir()
+            (dest / 'authorized_list.html').write_text('CONSUMER-OVERRIDE')
+            templates = dict(settings.TEMPLATES[0])
+            templates['DIRS'] = [tmp]
+            with override_settings(TEMPLATES=[templates]):
+                source = get_template('trusts/authorized_list.html').template.source
+                self.assertEqual(source, 'CONSUMER-OVERRIDE')
+        self.assertIn(
+            'Authorized list',
+            get_template('trusts/authorized_list.html').template.source,
+        )
+
+    def test_form_and_delete_stubs_render(self):
+        form = get_template('trusts/authorized_form.html')
+        self.assertIn('form.as_p', form.template.source)
+        self.assertIn('csrf_token', form.template.source)
+        confirm = get_template('trusts/authorized_confirm_delete.html')
+        self.assertIn('Confirm', confirm.template.source)
+        self.assertIn('csrf_token', confirm.template.source)

--- a/tests/core/test_s4_admin_views.py
+++ b/tests/core/test_s4_admin_views.py
@@ -686,6 +686,25 @@ class S4CBVObjectTest(S4FixtureMixin, TestCase):
                     S1Repository.objects.filter(pk=self.repo_a.pk + 10000),
                 )
 
+    def test_pre_sliced_ambiguous_queryset_fails_closed(self):
+        self.repo_a.title = 'shared'
+        self.repo_a.save(update_fields=['title'])
+        self.repo_b.title = 'shared'
+        self.repo_b.save(update_fields=['title'])
+        ambiguous = S1Repository.objects.filter(title='shared')
+        sliced = ambiguous[:1]
+        with self.assertNumQueries(0):
+            with self.assertRaises(AuthorizationConfigError):
+                require_singular_identity(sliced)
+        with self.assertNumQueries(0):
+            with self.assertRaises(PermissionDenied):
+                resolve_authorized_object(
+                    sliced, self.member, 'read', **self.runtime,
+                )
+        with self.assertNumQueries(0):
+            with self.assertRaises(AuthorizationConfigError):
+                require_singular_identity(ambiguous[1:])
+
 
 class S4TemplateOverrideTest(S4FixtureMixin, TestCase):
     def test_consumer_template_override_wins(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -33,6 +33,7 @@ NORMAL_SUITE = [
     'tests.core.test_s1_kernel',
     'tests.core.test_s2_backend',
     'tests.core.test_s3_decorators',
+    'tests.core.test_s4_admin_views',
     'tests.core.test_zero_path',
     'tests.core.test_kernel_split',
     'tests.core.test_wheel_install',

--- a/trusts/admin.py
+++ b/trusts/admin.py
@@ -3,16 +3,23 @@
 ``AuthorizedModelAdmin`` is configured by operation data. List
 querysets use S1 ``filter_authorized`` as ``ChangeList.root_queryset``,
 so Django paginates the authorized set. Object gates use S1
-``is_authorized`` and must agree with that queryset when the
-operations match.
+``is_authorized`` on the action-specific hook and must agree with the
+list queryset when that hook's operation matches ``list_operation``.
 
 Django hooks covered:
 
 * ``list_operation`` → ``get_queryset``
 * ``view_operation`` (fallback: ``list_operation``) →
-  ``has_view_permission`` / ``get_object``
+  ``has_view_permission``
 * ``change_operation`` → ``has_change_permission``
 * ``delete_operation`` → ``has_delete_permission``
+
+``get_object`` retrieves a **singular identity** from the unauthorized
+consumer-scoped base (``get_identity_base_queryset``). It does **not**
+apply ``view_operation``. Django's change/delete views then call
+``has_change_permission`` / ``has_delete_permission`` /
+``has_view_or_change_permission``, so a change-only or delete-only
+grant is not blocked by an undocumented view ceiling.
 
 Add is fail-closed (``has_add_permission`` is False). An FK/form
 queryset helper is not shipped; S4 tests did not demonstrate a generic
@@ -34,7 +41,7 @@ from trusts.runtime import (
     is_authorized,
     principal_is_usable,
 )
-from trusts.views import resolve_authorized_object
+from trusts.views import require_singular_identity
 
 
 class AuthorizedModelAdmin(admin.ModelAdmin):
@@ -112,14 +119,26 @@ class AuthorizedModelAdmin(admin.ModelAdmin):
         except AuthorizationConfigError:
             raise PermissionDenied
 
-    def get_object(self, request, object_id, from_field=None):
-        """Identity lookup, then view/change gate.
+    def get_identity_base_queryset(self, request):
+        """Unauthorized consumer-scoped base for admin object identity.
 
-        Missing rows stay ``None`` (admin 404). Existing unauthorized
-        rows raise ``PermissionDenied`` (403). The list queryset is not
-        used here so an unauthorized row cannot be hidden as missing.
+        Default is the model's default manager. Does **not** use
+        ``get_queryset()`` (that applies ``list_operation``). Override
+        to add tenant / soft-delete filters. Application scoping
+        belongs here, not in the authorization-filtered list.
         """
-        queryset = self.model._default_manager.get_queryset()
+        return self.model._default_manager.get_queryset()
+
+    def get_object(self, request, object_id, from_field=None):
+        """Singular identity lookup. No view/change/delete ceiling.
+
+        Missing rows stay ``None`` (admin 404). Ambiguous identity
+        (2+ candidates) raises ``PermissionDenied``. Existing rows are
+        returned so Django's action hook can apply
+        ``view_operation`` / ``change_operation`` / ``delete_operation``
+        independently.
+        """
+        queryset = self.get_identity_base_queryset(request)
         field = (
             self.model._meta.pk if from_field is None
             else self.model._meta.get_field(from_field)
@@ -130,12 +149,7 @@ class AuthorizedModelAdmin(admin.ModelAdmin):
         except (ValidationError, ValueError):
             return None
         try:
-            return resolve_authorized_object(
-                identity,
-                self._principal(request),
-                self.get_view_operation(),
-                **self.get_authorization_runtime()
-            )
+            return require_singular_identity(identity)
         except Http404:
             return None
         except AuthorizationConfigError:

--- a/trusts/admin.py
+++ b/trusts/admin.py
@@ -1,0 +1,187 @@
+"""Noun-independent authorized ModelAdmin (issue #47 S4).
+
+``AuthorizedModelAdmin`` is configured by operation data. List
+querysets use S1 ``filter_authorized`` as ``ChangeList.root_queryset``,
+so Django paginates the authorized set. Object gates use S1
+``is_authorized`` and must agree with that queryset when the
+operations match.
+
+Django hooks covered:
+
+* ``list_operation`` → ``get_queryset``
+* ``view_operation`` (fallback: ``list_operation``) →
+  ``has_view_permission`` / ``get_object``
+* ``change_operation`` → ``has_change_permission``
+* ``delete_operation`` → ``has_delete_permission``
+
+Add is fail-closed (``has_add_permission`` is False). An FK/form
+queryset helper is not shipped; S4 tests did not demonstrate a generic
+need. Consumers who need create-under-scope override add themselves.
+
+``AuthorizationConfigError`` is denied at this security boundary.
+``has_*`` methods do not call the Django user-permission helper, so an
+active superuser does not bypass registered object policy. Isolated
+tests set ``context`` / ``trustee`` on the admin class.
+"""
+
+from django.contrib import admin
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.http import Http404
+
+from trusts.runtime import (
+    AuthorizationConfigError,
+    filter_authorized,
+    is_authorized,
+    principal_is_usable,
+)
+from trusts.views import resolve_authorized_object
+
+
+class AuthorizedModelAdmin(admin.ModelAdmin):
+    """ModelAdmin whose list and object gates are S1 operation data."""
+
+    list_operation = None
+    view_operation = None
+    change_operation = None
+    delete_operation = None
+    context = None
+    trustee = None
+    names = None
+
+    def get_authorization_runtime(self):
+        return dict(context=self.context, trustee=self.trustee, names=self.names)
+
+    def get_list_operation(self):
+        return self._require_operation(self.list_operation, 'list_operation')
+
+    def get_view_operation(self):
+        operation = self.view_operation
+        if operation is None:
+            operation = self.list_operation
+        return self._require_operation(operation, 'view_operation')
+
+    def get_change_operation(self):
+        return self._require_operation(self.change_operation, 'change_operation')
+
+    def get_delete_operation(self):
+        return self._require_operation(self.delete_operation, 'delete_operation')
+
+    def _require_operation(self, operation, what):
+        if operation is None:
+            raise AuthorizationConfigError(
+                'AuthorizedModelAdmin requires %s.' % what
+            )
+        if callable(operation) and getattr(operation, '_meta', None) is None:
+            raise AuthorizationConfigError(
+                '%s must be operation data, not a callable.' % what
+            )
+        return operation
+
+    def _principal(self, request):
+        return getattr(request, 'user', None)
+
+    def _object_authorized(self, request, operation, obj):
+        try:
+            return bool(is_authorized(
+                self._principal(request), operation, obj,
+                **self.get_authorization_runtime()
+            ))
+        except AuthorizationConfigError:
+            return False
+
+    def _module_authorized(self, request, operation):
+        if operation is None:
+            return False
+        if not principal_is_usable(self._principal(request)):
+            return False
+        try:
+            self._require_operation(operation, 'operation')
+        except AuthorizationConfigError:
+            return False
+        return True
+
+    def get_queryset(self, request):
+        queryset = super(AuthorizedModelAdmin, self).get_queryset(request)
+        try:
+            return filter_authorized(
+                queryset,
+                self._principal(request),
+                self.get_list_operation(),
+                **self.get_authorization_runtime()
+            )
+        except AuthorizationConfigError:
+            raise PermissionDenied
+
+    def get_object(self, request, object_id, from_field=None):
+        """Identity lookup, then view/change gate.
+
+        Missing rows stay ``None`` (admin 404). Existing unauthorized
+        rows raise ``PermissionDenied`` (403). The list queryset is not
+        used here so an unauthorized row cannot be hidden as missing.
+        """
+        queryset = self.model._default_manager.get_queryset()
+        field = (
+            self.model._meta.pk if from_field is None
+            else self.model._meta.get_field(from_field)
+        )
+        try:
+            object_id = field.to_python(object_id)
+            identity = queryset.filter(**{field.name: object_id})
+        except (ValidationError, ValueError):
+            return None
+        try:
+            return resolve_authorized_object(
+                identity,
+                self._principal(request),
+                self.get_view_operation(),
+                **self.get_authorization_runtime()
+            )
+        except Http404:
+            return None
+        except AuthorizationConfigError:
+            raise PermissionDenied
+
+    def has_view_permission(self, request, obj=None):
+        try:
+            operation = self.get_view_operation()
+        except AuthorizationConfigError:
+            return False
+        if obj is None:
+            return self._module_authorized(request, operation)
+        return self._object_authorized(request, operation, obj)
+
+    def has_change_permission(self, request, obj=None):
+        try:
+            operation = self.get_change_operation()
+        except AuthorizationConfigError:
+            return False
+        if obj is None:
+            return self._module_authorized(request, operation)
+        return self._object_authorized(request, operation, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        try:
+            operation = self.get_delete_operation()
+        except AuthorizationConfigError:
+            return False
+        if obj is None:
+            return self._module_authorized(request, operation)
+        return self._object_authorized(request, operation, obj)
+
+    def has_add_permission(self, request):
+        # Fail closed. Create-under-scope / FK form helpers are not S4.
+        return False
+
+    def has_module_permission(self, request):
+        try:
+            operation = self.list_operation
+            if operation is None:
+                operation = self.view_operation
+            return self._module_authorized(request, operation)
+        except AuthorizationConfigError:
+            return False
+
+
+__all__ = [
+    'AuthorizedModelAdmin',
+]

--- a/trusts/templates/trusts/authorized_confirm_delete.html
+++ b/trusts/templates/trusts/authorized_confirm_delete.html
@@ -1,0 +1,17 @@
+{# Framework stub. Override with template_name or an earlier trusts/authorized_confirm_delete.html. #}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Confirm delete</title>
+</head>
+<body>
+  <h1>Confirm delete</h1>
+  {% if object %}
+  <p>{{ object }}</p>
+  {% endif %}
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit">Confirm</button>
+  </form>
+</body>
+</html>

--- a/trusts/templates/trusts/authorized_detail.html
+++ b/trusts/templates/trusts/authorized_detail.html
@@ -1,0 +1,19 @@
+{# Framework stub. Override with template_name or an earlier trusts/authorized_detail.html. #}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Authorized detail</title>
+</head>
+<body>
+  <h1>Authorized detail</h1>
+  {% if object %}
+  <p>{{ object }}</p>
+  {% endif %}
+  {% if update_url %}
+  <p><a href="{{ update_url }}">Update</a></p>
+  {% endif %}
+  {% if delete_url %}
+  <p><a href="{{ delete_url }}">Delete</a></p>
+  {% endif %}
+</body>
+</html>

--- a/trusts/templates/trusts/authorized_form.html
+++ b/trusts/templates/trusts/authorized_form.html
@@ -1,0 +1,15 @@
+{# Framework stub. Override with template_name or an earlier trusts/authorized_form.html. #}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Authorized form</title>
+</head>
+<body>
+  <h1>Authorized form</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+  </form>
+</body>
+</html>

--- a/trusts/templates/trusts/authorized_list.html
+++ b/trusts/templates/trusts/authorized_list.html
@@ -1,0 +1,30 @@
+{# Framework stub. Override with template_name or an earlier trusts/authorized_list.html. #}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Authorized list</title>
+</head>
+<body>
+  <h1>Authorized list</h1>
+  {% if object_list %}
+  <ul>
+    {% for object in object_list %}
+    <li>{{ object }}</li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No authorized objects.</p>
+  {% endif %}
+  {% if is_paginated %}
+  <p class="pagination">
+    {% if page_obj.has_previous %}
+    <a href="?page={{ page_obj.previous_page_number }}">Previous</a>
+    {% endif %}
+    Page {{ page_obj.number }} of {{ paginator.num_pages }}
+    {% if page_obj.has_next %}
+    <a href="?page={{ page_obj.next_page_number }}">Next</a>
+    {% endif %}
+  </p>
+  {% endif %}
+</body>
+</html>

--- a/trusts/views.py
+++ b/trusts/views.py
@@ -1,0 +1,226 @@
+"""Generic authorized CBV mixins and stub-template helpers (issue #47 S4).
+
+``AuthorizedQuerySetMixin`` SQL-filters list querysets with S1
+``filter_authorized`` before pagination. ``AuthorizedObjectMixin``
+resolves a declared URL identity through the same predicate: missing
+rows are 404, existing unauthorized rows are 403.
+
+Operations and the resource model are declarative data (class
+attributes / CBV ``model``). There are no getter, resolver, or policy
+callbacks, and no second authorization walker. Isolated tests pass
+``context`` / ``trustee`` as class attributes (process-wide maps remain
+the no-arg default).
+
+Active superuser status does not bypass registered object policy.
+``AuthorizationConfigError`` becomes ``PermissionDenied`` at this
+HTTP boundary.
+
+Stub templates live under the ``trusts/`` namespace. Consumers set
+``template_name`` or place an earlier ``trusts/authorized_*.html``.
+This module does not ship URL patterns or product chrome.
+"""
+
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    PermissionDenied,
+    ValidationError,
+)
+from django.http import Http404
+
+from trusts.runtime import (
+    AuthorizationConfigError,
+    filter_authorized,
+    principal_is_usable,
+)
+
+
+class AuthorizedQuerySetMixin(object):
+    """List-style CBV mixin. ``get_queryset`` is S1-filtered before pagination.
+
+    Declarative data:
+
+    * ``list_operation`` — operation instance or ``operation_lookup``
+      string. ``operation`` is accepted as a fallback.
+    * ``model`` / ``queryset`` — from the CBV; never inferred from a
+      Django permission string.
+    * ``context`` / ``trustee`` / ``names`` — isolated registries.
+
+    Default ``template_name`` is ``trusts/authorized_list.html``.
+    Override it on the view or with a project/app template of the same
+    name. Unusable principals receive an empty queryset (ordinary
+    denial). Malformed configuration is 403.
+    """
+
+    list_operation = None
+    operation = None
+    context = None
+    trustee = None
+    names = None
+    template_name = 'trusts/authorized_list.html'
+
+    def get_authorization_runtime(self):
+        return dict(context=self.context, trustee=self.trustee, names=self.names)
+
+    def get_list_operation(self):
+        operation = self.list_operation
+        if operation is None:
+            operation = self.operation
+        if operation is None:
+            raise AuthorizationConfigError(
+                'AuthorizedQuerySetMixin requires list_operation or operation.'
+            )
+        if callable(operation) and getattr(operation, '_meta', None) is None:
+            raise AuthorizationConfigError(
+                'list_operation must be operation data, not a callable.'
+            )
+        return operation
+
+    def get_queryset(self):
+        queryset = super(AuthorizedQuerySetMixin, self).get_queryset()
+        try:
+            return filter_authorized(
+                queryset,
+                getattr(self.request, 'user', None),
+                self.get_list_operation(),
+                **self.get_authorization_runtime()
+            )
+        except AuthorizationConfigError:
+            raise PermissionDenied
+
+
+class AuthorizedObjectMixin(object):
+    """Detail/update-style CBV mixin. Object identity is a declared URL key.
+
+    Declarative data:
+
+    * ``object_operation`` — operation instance or lookup string.
+      ``view_operation`` then ``operation`` are fallbacks.
+    * ``pk_url_kwarg`` / ``slug_url_kwarg`` / ``slug_field`` — Django
+      CBV identity keys, not resolver callbacks.
+    * ``model`` — explicit CBV model.
+    * ``context`` / ``trustee`` / ``names`` — isolated registries.
+
+    Default ``template_name`` is ``trusts/authorized_detail.html``.
+    Update-style views should set ``template_name`` to
+    ``trusts/authorized_form.html`` (or a consumer override).
+    """
+
+    object_operation = None
+    view_operation = None
+    operation = None
+    context = None
+    trustee = None
+    names = None
+    template_name = 'trusts/authorized_detail.html'
+
+    def get_authorization_runtime(self):
+        return dict(context=self.context, trustee=self.trustee, names=self.names)
+
+    def get_object_operation(self):
+        operation = self.object_operation
+        if operation is None:
+            operation = self.view_operation
+        if operation is None:
+            operation = self.operation
+        if operation is None:
+            raise AuthorizationConfigError(
+                'AuthorizedObjectMixin requires object_operation, '
+                'view_operation, or operation.'
+            )
+        if callable(operation) and getattr(operation, '_meta', None) is None:
+            raise AuthorizationConfigError(
+                'object_operation must be operation data, not a callable.'
+            )
+        return operation
+
+    def get_identity_queryset(self):
+        """Unfiltered identity queryset from declared URL keys.
+
+        Uses the CBV ``model`` default manager so a list mixin cannot
+        hide an existing unauthorized row as ``DoesNotExist``.
+        """
+        model = getattr(self, 'model', None)
+        if model is None:
+            raise AuthorizationConfigError(
+                'AuthorizedObjectMixin requires an explicit model.'
+            )
+        queryset = model._default_manager.all()
+        pk_url_kwarg = getattr(self, 'pk_url_kwarg', 'pk')
+        slug_url_kwarg = getattr(self, 'slug_url_kwarg', 'slug')
+        slug_field = getattr(self, 'slug_field', 'slug')
+        kwargs = getattr(self, 'kwargs', None) or {}
+        pk = kwargs.get(pk_url_kwarg, None)
+        if pk is not None and pk != '':
+            return queryset.filter(pk=pk)
+        slug = kwargs.get(slug_url_kwarg, None)
+        if slug is not None and slug != '':
+            try:
+                model._meta.get_field(slug_field)
+            except FieldDoesNotExist:
+                raise AuthorizationConfigError(
+                    'slug_field %r is not a field on %s.' % (
+                        slug_field, model._meta.label,
+                    )
+                )
+            return queryset.filter(**{slug_field: slug})
+        raise Http404
+
+    def get_context_data(self, **kwargs):
+        context = super(AuthorizedObjectMixin, self).get_context_data(**kwargs)
+        context.setdefault('update_url', getattr(self, 'update_url', None))
+        context.setdefault('delete_url', getattr(self, 'delete_url', None))
+        return context
+
+    def get_object(self, queryset=None):
+        try:
+            identity = self.get_identity_queryset()
+            return resolve_authorized_object(
+                identity,
+                getattr(self.request, 'user', None),
+                self.get_object_operation(),
+                **self.get_authorization_runtime()
+            )
+        except AuthorizationConfigError:
+            raise PermissionDenied
+        except (ValidationError, ValueError, TypeError):
+            raise Http404
+
+
+def resolve_authorized_object(queryset, principal, operation, **runtime):
+    """Return the authorized row from an identity-filtered queryset.
+
+    ``queryset`` must already identify the candidate row(s) (typically
+    ``pk=``). Authorization is S1 ``filter_authorized``.
+
+    * Unique authorized match → the instance (one SQL when identity is
+      unique).
+    * Unusable principal + existing row → ``PermissionDenied`` (one
+      existence query, no auth ``Exists``).
+    * Existing unauthorized / unknown operation data →
+      ``PermissionDenied`` (combined miss + existence).
+    * Missing row → ``Http404``.
+    * ``AuthorizationConfigError`` → ``PermissionDenied``.
+    """
+    try:
+        if not principal_is_usable(principal):
+            if queryset.exists():
+                raise PermissionDenied
+            raise Http404
+        authorized = filter_authorized(
+            queryset, principal, operation, **runtime
+        )
+        obj = authorized.first()
+        if obj is not None:
+            return obj
+        if queryset.exists():
+            raise PermissionDenied
+        raise Http404
+    except AuthorizationConfigError:
+        raise PermissionDenied
+
+
+__all__ = [
+    'AuthorizedObjectMixin',
+    'AuthorizedQuerySetMixin',
+    'resolve_authorized_object',
+]

--- a/trusts/views.py
+++ b/trusts/views.py
@@ -6,8 +6,9 @@ resolves a declared URL identity through the same predicate: missing
 rows are 404, existing unauthorized rows are 403.
 
 Source identity is established **before** authorization and must be
-singular. ``resolve_authorized_object`` never uses ``.first()`` to pick
-an authorized row from an ambiguous candidate set.
+singular and unsliced. ``resolve_authorized_object`` never uses
+``.first()`` to pick an authorized row from an ambiguous candidate
+set, and a caller-supplied ``qs[:1]`` cannot hide a second row.
 
 Application scoping (tenant, soft-delete, an explicit CBV
 ``queryset``) belongs on ``queryset`` or
@@ -221,17 +222,34 @@ class AuthorizedObjectMixin(object):
             raise Http404
 
 
+def _queryset_is_sliced(queryset):
+    query = getattr(queryset, 'query', None)
+    if query is None:
+        return True
+    if getattr(query, 'low_mark', 0):
+        return True
+    return getattr(query, 'high_mark', None) is not None
+
+
 def require_singular_identity(queryset):
     """Return the only row in ``queryset``, or fail closed.
 
     Source identity is checked **before** authorization. ``.first()``
-    is not used.
+    is not used. ``queryset`` must be **unsliced**: a caller-supplied
+    ``candidates[:1]`` (or any other limit/offset) cannot hide a second
+    row from this check.
 
+    * Pre-sliced queryset → ``AuthorizationConfigError`` (0 SQL).
     * 0 rows → ``Http404`` (1 SQL ``[:2]``).
     * 2+ rows → ``PermissionDenied`` (1 SQL ``[:2]``). Ambiguous
       identity is never resolved by order or by which row is granted.
     * 1 row → that instance.
     """
+    if _queryset_is_sliced(queryset):
+        raise AuthorizationConfigError(
+            'require_singular_identity requires an unsliced candidate '
+            'queryset. Do not pass a sliced queryset such as qs[:1].'
+        )
     matched = list(queryset[:2])
     if len(matched) > 1:
         raise PermissionDenied
@@ -245,7 +263,8 @@ def resolve_authorized_object(queryset, principal, operation, **runtime):
 
     ``queryset`` is the candidate set **after** application scope and
     declared identity filters, **before** Trusts authorization. It must
-    already be singular.
+    already be singular and **unsliced**. A pre-sliced queryset is
+    ``AuthorizationConfigError`` on the helper and denial (403) here.
 
     * 0 candidates → ``Http404``.
     * 2+ candidates → ``PermissionDenied`` (not an existential grant).

--- a/trusts/views.py
+++ b/trusts/views.py
@@ -5,6 +5,15 @@
 resolves a declared URL identity through the same predicate: missing
 rows are 404, existing unauthorized rows are 403.
 
+Source identity is established **before** authorization and must be
+singular. ``resolve_authorized_object`` never uses ``.first()`` to pick
+an authorized row from an ambiguous candidate set.
+
+Application scoping (tenant, soft-delete, an explicit CBV
+``queryset``) belongs on ``queryset`` or
+``get_identity_base_queryset()``. That hook is unauthorized. It does
+not call ``get_queryset()``, which the list mixin already filtered.
+
 Operations and the resource model are declarative data (class
 attributes / CBV ``model``). There are no getter, resolver, or policy
 callbacks, and no second authorization walker. Isolated tests pass
@@ -30,6 +39,7 @@ from django.http import Http404
 from trusts.runtime import (
     AuthorizationConfigError,
     filter_authorized,
+    is_authorized,
     principal_is_usable,
 )
 
@@ -42,7 +52,8 @@ class AuthorizedQuerySetMixin(object):
     * ``list_operation`` — operation instance or ``operation_lookup``
       string. ``operation`` is accepted as a fallback.
     * ``model`` / ``queryset`` — from the CBV; never inferred from a
-      Django permission string.
+      Django permission string. ``queryset`` is also the default
+      application scope for ``AuthorizedObjectMixin``.
     * ``context`` / ``trustee`` / ``names`` — isolated registries.
 
     Default ``template_name`` is ``trusts/authorized_list.html``.
@@ -95,10 +106,18 @@ class AuthorizedObjectMixin(object):
 
     * ``object_operation`` — operation instance or lookup string.
       ``view_operation`` then ``operation`` are fallbacks.
-    * ``pk_url_kwarg`` / ``slug_url_kwarg`` / ``slug_field`` — Django
-      CBV identity keys, not resolver callbacks.
-    * ``model`` — explicit CBV model.
+    * ``pk_url_kwarg`` / ``slug_url_kwarg`` / ``slug_field`` /
+      ``query_pk_and_slug`` — Django CBV identity keys, not resolver
+      callbacks. When ``query_pk_and_slug`` is True and both values
+      are present, both constrain the row.
+    * ``model`` / ``queryset`` — explicit CBV model and optional
+      application scope.
     * ``context`` / ``trustee`` / ``names`` — isolated registries.
+
+    Application filters belong on ``queryset`` or
+    ``get_identity_base_queryset()``. Do not put them only in an
+    override of ``get_queryset()`` after the list mixin has already
+    applied ``list_operation``.
 
     Default ``template_name`` is ``trusts/authorized_detail.html``.
     Update-style views should set ``template_name`` to
@@ -133,27 +152,41 @@ class AuthorizedObjectMixin(object):
             )
         return operation
 
-    def get_identity_queryset(self):
-        """Unfiltered identity queryset from declared URL keys.
+    def get_identity_base_queryset(self):
+        """Unauthorized consumer-scoped base for object identity.
 
-        Uses the CBV ``model`` default manager so a list mixin cannot
-        hide an existing unauthorized row as ``DoesNotExist``.
+        Uses the declared CBV ``queryset`` when set, otherwise the
+        model's default manager. Does **not** call ``get_queryset()``:
+        the list mixin filters that with ``list_operation``, which
+        would hide unauthorized-but-in-scope rows as 404.
         """
+        declared = getattr(self, 'queryset', None)
+        if declared is not None:
+            return declared.all()
         model = getattr(self, 'model', None)
         if model is None:
             raise AuthorizationConfigError(
-                'AuthorizedObjectMixin requires an explicit model.'
+                'AuthorizedObjectMixin requires an explicit model or queryset.'
             )
-        queryset = model._default_manager.all()
+        return model._default_manager.all()
+
+    def get_identity_queryset(self, queryset=None):
+        """Apply declared pk/slug identity to the consumer-scoped base."""
+        if queryset is None:
+            queryset = self.get_identity_base_queryset()
+        model = queryset.model
         pk_url_kwarg = getattr(self, 'pk_url_kwarg', 'pk')
         slug_url_kwarg = getattr(self, 'slug_url_kwarg', 'slug')
         slug_field = getattr(self, 'slug_field', 'slug')
+        query_pk_and_slug = getattr(self, 'query_pk_and_slug', False)
         kwargs = getattr(self, 'kwargs', None) or {}
         pk = kwargs.get(pk_url_kwarg, None)
-        if pk is not None and pk != '':
-            return queryset.filter(pk=pk)
         slug = kwargs.get(slug_url_kwarg, None)
-        if slug is not None and slug != '':
+        has_pk = pk is not None and pk != ''
+        has_slug = slug is not None and slug != ''
+        if has_pk:
+            queryset = queryset.filter(pk=pk)
+        if has_slug and (not has_pk or query_pk_and_slug):
             try:
                 model._meta.get_field(slug_field)
             except FieldDoesNotExist:
@@ -162,8 +195,10 @@ class AuthorizedObjectMixin(object):
                         slug_field, model._meta.label,
                     )
                 )
-            return queryset.filter(**{slug_field: slug})
-        raise Http404
+            queryset = queryset.filter(**{slug_field: slug})
+        if not has_pk and not has_slug:
+            raise Http404
+        return queryset
 
     def get_context_data(self, **kwargs):
         context = super(AuthorizedObjectMixin, self).get_context_data(**kwargs)
@@ -173,7 +208,7 @@ class AuthorizedObjectMixin(object):
 
     def get_object(self, queryset=None):
         try:
-            identity = self.get_identity_queryset()
+            identity = self.get_identity_queryset(queryset)
             return resolve_authorized_object(
                 identity,
                 getattr(self.request, 'user', None),
@@ -186,35 +221,49 @@ class AuthorizedObjectMixin(object):
             raise Http404
 
 
+def require_singular_identity(queryset):
+    """Return the only row in ``queryset``, or fail closed.
+
+    Source identity is checked **before** authorization. ``.first()``
+    is not used.
+
+    * 0 rows → ``Http404`` (1 SQL ``[:2]``).
+    * 2+ rows → ``PermissionDenied`` (1 SQL ``[:2]``). Ambiguous
+      identity is never resolved by order or by which row is granted.
+    * 1 row → that instance.
+    """
+    matched = list(queryset[:2])
+    if len(matched) > 1:
+        raise PermissionDenied
+    if not matched:
+        raise Http404
+    return matched[0]
+
+
 def resolve_authorized_object(queryset, principal, operation, **runtime):
-    """Return the authorized row from an identity-filtered queryset.
+    """Authorize the singular row from a consumer-scoped identity queryset.
 
-    ``queryset`` must already identify the candidate row(s) (typically
-    ``pk=``). Authorization is S1 ``filter_authorized``.
+    ``queryset`` is the candidate set **after** application scope and
+    declared identity filters, **before** Trusts authorization. It must
+    already be singular.
 
-    * Unique authorized match → the instance (one SQL when identity is
-      unique).
-    * Unusable principal + existing row → ``PermissionDenied`` (one
-      existence query, no auth ``Exists``).
-    * Existing unauthorized / unknown operation data →
-      ``PermissionDenied`` (combined miss + existence).
-    * Missing row → ``Http404``.
+    * 0 candidates → ``Http404``.
+    * 2+ candidates → ``PermissionDenied`` (not an existential grant).
+    * 1 candidate, unusable principal → ``PermissionDenied`` (the
+      identity query already ran; no auth ``Exists``).
+    * 1 candidate, granted → the instance (identity ``[:2]`` plus
+      ``is_authorized``).
+    * 1 candidate, denied / unknown operation data →
+      ``PermissionDenied``.
     * ``AuthorizationConfigError`` → ``PermissionDenied``.
     """
     try:
+        obj = require_singular_identity(queryset)
         if not principal_is_usable(principal):
-            if queryset.exists():
-                raise PermissionDenied
-            raise Http404
-        authorized = filter_authorized(
-            queryset, principal, operation, **runtime
-        )
-        obj = authorized.first()
-        if obj is not None:
-            return obj
-        if queryset.exists():
             raise PermissionDenied
-        raise Http404
+        if is_authorized(principal, operation, obj, **runtime):
+            return obj
+        raise PermissionDenied
     except AuthorizationConfigError:
         raise PermissionDenied
 
@@ -222,5 +271,6 @@ def resolve_authorized_object(queryset, principal, operation, **runtime):
 __all__ = [
     'AuthorizedObjectMixin',
     'AuthorizedQuerySetMixin',
+    'require_singular_identity',
     'resolve_authorized_object',
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Focused kernel **S4** only against current master (`957c938` / S3 merge). Implements accepted framework-execution-r1+r2+r3 admin / CBV / stub-template surface.

HEAD: `5040985119a2ecbdfb687052aabc8db997377ee1`

Review revision on this head:

- `AuthorizedModelAdmin.get_object()` is **identity-only**. It does not apply `view_operation`. Change-only and delete-only grants reach `has_change_permission` / `has_delete_permission`.
- Source identity is singular **and unsliced** before authorization. `require_singular_identity` / `resolve_authorized_object` reject 2+ candidates (403) and never pick `.first()`. A pre-sliced `ambiguous[:1]` is `AuthorizationConfigError` on the helper and 403 on `resolve_authorized_object`.
- `get_identity_base_queryset()` is the unauthorized consumer scope (`queryset` or default manager). Out of application scope → 404; in scope but Trusts-denied → 403.
- `query_pk_and_slug` applies both request values.

## What this ships

- `trusts.admin.AuthorizedModelAdmin` configured by operation data (`list_operation` / `view_operation` / `change_operation` / `delete_operation`)
- `trusts.views.AuthorizedQuerySetMixin` and `AuthorizedObjectMixin` for list/detail/update-style CBVs
- `require_singular_identity` + `resolve_authorized_object` (S1 `is_authorized` / `filter_authorized`; no second walker)
- Stub templates under `trusts/authorized_*.html` with `template_name` / loader override points
- Isolated tests + `migrates.md` record (change 48–49)

List querysets use S1 `filter_authorized` **before** pagination. Object decisions agree with that queryset when the hook's operation matches. `AuthorizationConfigError` is 403 / False at this boundary. Unusable principals deny. Active superuser does not bypass registered object policy.

Add is fail-closed. No framework URL patterns. No FK/form queryset helper. Zero team URLs, forms, `auth/group_*` templates, and product ModelAdmins stay in `django-trusts-zero`.

## Query matrix (honest)

| Path | SQL |
| --- | ---: |
| Authorized list (`get_queryset` / unpaginated CBV) | 1 |
| Paginated CBV list (count + page) | 2, both on the authorized queryset |
| Admin `get_object` (PK identity; no view ceiling) | 1 (`[:2]`) |
| Admin missing PK | 1 → `None` |
| CBV granted unique object | 2 (identity `[:2]` + `is_authorized`) |
| CBV existing unauthorized / unknown operation | 2 → 403 |
| CBV missing unique identity | 1 → 404 |
| Ambiguous slug/candidates (one or both granted) | 1 (`[:2]`) → 403 |
| Pre-sliced candidate queryset (`ambiguous[:1]`) | 0 → config error / 403 |
| Missing URL identity | 0 → 404 |
| Unusable principal + existing singular object | 1 identity, no auth `Exists` → 403 |
| Consumer scope excluding an authorized row | 1 → 404 |

No per-row permission checks.

## Local matrix

- `python -m tests.runtests` 479 OK (1 expected failure)
- `python -m tests.runtests_custom` 7 OK
- `manage.py check` default + custom OK

## Out of scope

- django-trusts-zero
- S5 checks cleanup
- gh-permissions#1
- #17
- Does **not** close #47

Package version remains `1.0.0.dev0`.

r? @chatforthomas

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49b97b77-2b7f-46aa-8941-f60d8db19849?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49b97b77-2b7f-46aa-8941-f60d8db19849&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

