### PR TITLE
Public require_configured_terminal for Zero #3 compatibility façades

### DIFF
--- a/migrates.md
+++ b/migrates.md
@@ -2720,7 +2720,11 @@ required by Zero #3 compatibility façades. Version remains
 **1.0.0.dev0**. This PR does **not** close
 [#47](https://github.com/django-trusts/django-trusts/issues/47) and does
 **not** resume [#17](https://github.com/django-trusts/django-trusts/issues/17).
-Existing S1 runtime entry-point behavior is unchanged.
+Existing S1 runtime entry-point behavior is unchanged. The companion pin
+is the stable Zero `main` merge of
+[django-trusts-zero#4](https://github.com/django-trusts/django-trusts-zero/pull/4)
+(`e7bbd1acf74c058224d6505005694395ec8baf03`), not the reviewed PR-branch
+tip (`80523d9a52f98ef7429f1a6eb8922e2348ff54af`).
 
 ## No change to these public call sites
 
@@ -2764,7 +2768,6 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - example#7
 - Closing #47
 - Package publish / version bump
-- Landing kernel `master` with a PR-only Zero pin
 
 ## Migration-bot checklist
 
@@ -2772,6 +2775,7 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Pass a valid Django model class as `expected_model` (concrete or proxy). Do not pass a model instance, a non-model class, or a raw object.
 - [ ] Translate `AuthorizationConfigError` only where a compatibility façade requires a historical exception type (Zero maps it to `AuthorizationPathError`). Direct kernel callers keep `AuthorizationConfigError`.
 - [ ] Existing runtime entry-point behavior is unchanged (`is_authorized`, `filter_authorized`, scope siblings, `require_*`).
+- [ ] Pair with merged Zero #4 on `main` (`scripts/zero-companion.pin` is `e7bbd1acf74c058224d6505005694395ec8baf03`).
 - [ ] Run `python -m tests.runtests` (includes `tests.core.test_require_configured_terminal`).
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #47 or resume #17 from this PR.

--- a/migrates.md
+++ b/migrates.md
@@ -2713,3 +2713,66 @@ Unchanged. `scripts/verify-legacy-upgrade.py` still expects
 - [ ] Do not close #47 from this PR.
 - [ ] Do not treat Zero / GH / Windows acceptance as complete because the kernel surface exists.
 
+# Public `require_configured_terminal` (Zero #3 compatibility façades, 1.0.0.dev0)
+
+This record covers the narrowly public terminal-validation surface
+required by Zero #3 compatibility façades. Version remains
+**1.0.0.dev0**. This PR does **not** close
+[#47](https://github.com/django-trusts/django-trusts/issues/47) and does
+**not** resume [#17](https://github.com/django-trusts/django-trusts/issues/17).
+Existing S1 runtime entry-point behavior is unchanged.
+
+## No change to these public call sites
+
+- S1 `is_authorized` / `require_authorized` / `filter_authorized` /
+  `authorized_q` and the scope-origin siblings
+- S2 `ObjectAuthorizationBackend` / `ObjectAuthorizationModelBackend`
+- S3 `trusts.decorators.require_authorized` / `P` / `K` / `G` / `O`
+- S4 `AuthorizedModelAdmin` / CBV mixins / stub templates
+- S5 kernel checks (`trusts.E006` / `E007` / `E008`)
+- Package version `1.0.0.dev0`
+
+## Changes
+
+### 52. `trusts.runtime.require_configured_terminal` is public; `_require_instance` is removed
+
+| | |
+| --- | --- |
+| Previous | Terminal instance checks lived on private `trusts.runtime._require_instance`. That name was not in `__all__`. A malformed `expected_model` (model instance, non-model class, or raw object) could escape as `AttributeError` from `_same_model`. |
+| New | Public `require_configured_terminal(value, expected_model, what)` in `__all__`. `_require_instance` is gone from the runtime module. `expected_model` is validated first and must be a Django model class (concrete or proxy). Malformed expected terminals raise `AuthorizationConfigError`. Comparison still uses `_meta.concrete_model`, so a proxy class matches its concrete instance and the reverse. |
+| Replacement | Import `require_configured_terminal` from `trusts.runtime`. Do not import `_require_instance`. |
+| Affected | Zero `require_configured_requester` / `require_configured_operation` compatibility façades. Direct S1 callers that already passed a configured model class are unchanged. |
+| Authorization | Existing runtime entry points keep the same fail-closed rule (reject model class, raw PK, wrong concrete model) and the same allow/deny results. This is a public spelling plus a complete fail-closed contract, not a permission-model change. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m tests.runtests
+```
+
+No Trusts schema migration.
+
+## Upgrade of a representative legacy database
+
+Unchanged. `scripts/verify-legacy-upgrade.py` still expects
+`{0001_initial, 0002_trustgroup}` on label `trusts`.
+
+## Out of scope (unchanged)
+
+- django-trusts#17 / Windows
+- example#7
+- Closing #47
+- Package publish / version bump
+- Landing kernel `master` with a PR-only Zero pin
+
+## Migration-bot checklist
+
+- [ ] Use `trusts.runtime.require_configured_terminal`. Never import `_require_instance`.
+- [ ] Pass a valid Django model class as `expected_model` (concrete or proxy). Do not pass a model instance, a non-model class, or a raw object.
+- [ ] Translate `AuthorizationConfigError` only where a compatibility façade requires a historical exception type (Zero maps it to `AuthorizationPathError`). Direct kernel callers keep `AuthorizationConfigError`.
+- [ ] Existing runtime entry-point behavior is unchanged (`is_authorized`, `filter_authorized`, scope siblings, `require_*`).
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_require_configured_terminal`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #47 or resume #17 from this PR.
+

--- a/scripts/zero-companion.pin
+++ b/scripts/zero-companion.pin
@@ -2,11 +2,9 @@
 # publish Zero metadata. Override with DJANGO_TRUSTS_ZERO_REPO,
 # DJANGO_TRUSTS_ZERO_REF, or DJANGO_TRUSTS_ZERO_SRC (already-cloned tree).
 # `ref` must be a 40-char commit SHA (not a cursor/ branch name).
-# TEMPORARY PR proof only: django-trusts-zero#4 / #3 implementation SHA.
-# After Zero #4 merges to main against this kernel head, replace `ref`
-# with that stable main merge SHA and rerun kernel CI before merging
-# this kernel PR. Do not land kernel master with a PR-only Zero pin.
+# Stable Zero main merge of django-trusts-zero#4 / #3
+# (e7bbd1acf74c058224d6505005694395ec8baf03).
 repo=https://github.com/django-trusts/django-trusts-zero.git
-ref=038896b3a3461719ce8d377e4ff5a68b1286eb76
+ref=e7bbd1acf74c058224d6505005694395ec8baf03
 expected_version=2.0.0.dev0
 required_dist=django-trusts

--- a/scripts/zero-companion.pin
+++ b/scripts/zero-companion.pin
@@ -2,8 +2,10 @@
 # publish Zero metadata. Override with DJANGO_TRUSTS_ZERO_REPO,
 # DJANGO_TRUSTS_ZERO_REF, or DJANGO_TRUSTS_ZERO_SRC (already-cloned tree).
 # `ref` must be a 40-char commit SHA (not a cursor/ branch name).
-# Paired with django-trusts-zero#4 / #3 review-fix head until that PR
-# merges to main.
+# TEMPORARY PR proof only: django-trusts-zero#4 / #3 implementation SHA.
+# After Zero #4 merges to main against this kernel head, replace `ref`
+# with that stable main merge SHA and rerun kernel CI before merging
+# this kernel PR. Do not land kernel master with a PR-only Zero pin.
 repo=https://github.com/django-trusts/django-trusts-zero.git
 ref=038896b3a3461719ce8d377e4ff5a68b1286eb76
 expected_version=2.0.0.dev0

--- a/scripts/zero-companion.pin
+++ b/scripts/zero-companion.pin
@@ -1,10 +1,10 @@
 # Authoritative django-trusts-zero pairing. This kernel repository must not
 # publish Zero metadata. Override with DJANGO_TRUSTS_ZERO_REPO,
 # DJANGO_TRUSTS_ZERO_REF, or DJANGO_TRUSTS_ZERO_SRC (already-cloned tree).
-# `ref` must be a stable 40-char commit on django-trusts-zero `main`
-# (merge of https://github.com/django-trusts/django-trusts-zero/pull/2),
-# not an ephemeral PR branch.
+# `ref` must be a 40-char commit SHA (not a cursor/ branch name).
+# Paired with django-trusts-zero#4 / #3 review-fix head until that PR
+# merges to main.
 repo=https://github.com/django-trusts/django-trusts-zero.git
-ref=d694866e7475f20b7bf568c378ed21dcebb56abf
+ref=038896b3a3461719ce8d377e4ff5a68b1286eb76
 expected_version=2.0.0.dev0
 required_dist=django-trusts

--- a/tests/core/test_require_configured_terminal.py
+++ b/tests/core/test_require_configured_terminal.py
@@ -17,6 +17,14 @@ from trusts.runtime import (
 from tests.models import S1Account, S1Operation, S1Organization, S1Repository
 
 
+class S1AccountProxy(S1Account):
+    """Proxy of the S1 requester. Same concrete model as ``S1Account``."""
+
+    class Meta:
+        proxy = True
+        app_label = S1Account._meta.app_label
+
+
 class RequireConfiguredTerminalTest(TransactionTestCase):
     reset_sequences = True
 
@@ -52,6 +60,46 @@ class RequireConfiguredTerminalTest(TransactionTestCase):
         with self.assertRaises(AuthorizationConfigError) as ctx:
             require_configured_terminal(self.account, S1Operation, 'operation')
         self.assertIn('operation', str(ctx.exception))
+
+    def test_require_configured_terminal_accepts_proxy_and_concrete(self):
+        proxy_account = S1AccountProxy(pk=self.account.pk, name=self.account.name)
+        self.assertIs(
+            require_configured_terminal(self.account, S1AccountProxy, 'requester'),
+            self.account,
+        )
+        self.assertIs(
+            require_configured_terminal(proxy_account, S1Account, 'requester'),
+            proxy_account,
+        )
+        self.assertIs(
+            require_configured_terminal(proxy_account, S1AccountProxy, 'requester'),
+            proxy_account,
+        )
+
+    def test_require_configured_terminal_rejects_malformed_expected_model(self):
+        class NotAModel(object):
+            pass
+
+        malformed = (
+            self.account,
+            object,
+            NotAModel,
+            1,
+            'S1Account',
+            None,
+        )
+        for expected_model in malformed:
+            with self.assertRaises(AuthorizationConfigError) as ctx:
+                require_configured_terminal(
+                    self.account, expected_model, 'requester',
+                )
+            self.assertIsInstance(ctx.exception, AuthorizationConfigError)
+            self.assertIn('Django model class', str(ctx.exception))
+            self.assertNotIsInstance(ctx.exception, AttributeError)
+
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(1, object, 'requester')
+        self.assertIn('Django model class', str(ctx.exception))
 
     def test_require_configured_terminal_is_public_export(self):
         import trusts.runtime as runtime_mod

--- a/tests/core/test_require_configured_terminal.py
+++ b/tests/core/test_require_configured_terminal.py
@@ -22,7 +22,7 @@ class S1AccountProxy(S1Account):
 
     class Meta:
         proxy = True
-        app_label = 'tests'
+        app_label = S1Account._meta.app_label
 
 
 class RequireConfiguredTerminalTest(TransactionTestCase):
@@ -61,30 +61,45 @@ class RequireConfiguredTerminalTest(TransactionTestCase):
             require_configured_terminal(self.account, S1Operation, 'operation')
         self.assertIn('operation', str(ctx.exception))
 
-    def test_require_configured_terminal_rejects_malformed_expected_model(self):
-        cases = (
-            self.account,
-            object,
-            object(),
-            1,
-            'S1Account',
-        )
-        for expected in cases:
-            with self.assertRaises(AuthorizationConfigError) as ctx:
-                require_configured_terminal(self.account, expected, 'requester')
-            self.assertIn('Django model class', str(ctx.exception))
-            self.assertNotIsInstance(ctx.exception, AttributeError)
-
-    def test_require_configured_terminal_accepts_proxy_expected_model(self):
+    def test_require_configured_terminal_accepts_proxy_and_concrete(self):
+        proxy_account = S1AccountProxy(pk=self.account.pk, name=self.account.name)
         self.assertIs(
             require_configured_terminal(self.account, S1AccountProxy, 'requester'),
             self.account,
         )
-        proxied = S1AccountProxy.objects.get(pk=self.account.pk)
         self.assertIs(
-            require_configured_terminal(proxied, S1Account, 'requester'),
-            proxied,
+            require_configured_terminal(proxy_account, S1Account, 'requester'),
+            proxy_account,
         )
+        self.assertIs(
+            require_configured_terminal(proxy_account, S1AccountProxy, 'requester'),
+            proxy_account,
+        )
+
+    def test_require_configured_terminal_rejects_malformed_expected_model(self):
+        class NotAModel(object):
+            pass
+
+        malformed = (
+            self.account,
+            object,
+            NotAModel,
+            1,
+            'S1Account',
+            None,
+        )
+        for expected_model in malformed:
+            with self.assertRaises(AuthorizationConfigError) as ctx:
+                require_configured_terminal(
+                    self.account, expected_model, 'requester',
+                )
+            self.assertIsInstance(ctx.exception, AuthorizationConfigError)
+            self.assertIn('Django model class', str(ctx.exception))
+            self.assertNotIsInstance(ctx.exception, AttributeError)
+
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(1, object, 'requester')
+        self.assertIn('Django model class', str(ctx.exception))
 
     def test_require_configured_terminal_is_public_export(self):
         import trusts.runtime as runtime_mod

--- a/tests/core/test_require_configured_terminal.py
+++ b/tests/core/test_require_configured_terminal.py
@@ -22,7 +22,7 @@ class S1AccountProxy(S1Account):
 
     class Meta:
         proxy = True
-        app_label = S1Account._meta.app_label
+        app_label = 'tests'
 
 
 class RequireConfiguredTerminalTest(TransactionTestCase):
@@ -61,45 +61,30 @@ class RequireConfiguredTerminalTest(TransactionTestCase):
             require_configured_terminal(self.account, S1Operation, 'operation')
         self.assertIn('operation', str(ctx.exception))
 
-    def test_require_configured_terminal_accepts_proxy_and_concrete(self):
-        proxy_account = S1AccountProxy(pk=self.account.pk, name=self.account.name)
+    def test_require_configured_terminal_rejects_malformed_expected_model(self):
+        cases = (
+            self.account,
+            object,
+            object(),
+            1,
+            'S1Account',
+        )
+        for expected in cases:
+            with self.assertRaises(AuthorizationConfigError) as ctx:
+                require_configured_terminal(self.account, expected, 'requester')
+            self.assertIn('Django model class', str(ctx.exception))
+            self.assertNotIsInstance(ctx.exception, AttributeError)
+
+    def test_require_configured_terminal_accepts_proxy_expected_model(self):
         self.assertIs(
             require_configured_terminal(self.account, S1AccountProxy, 'requester'),
             self.account,
         )
+        proxied = S1AccountProxy.objects.get(pk=self.account.pk)
         self.assertIs(
-            require_configured_terminal(proxy_account, S1Account, 'requester'),
-            proxy_account,
+            require_configured_terminal(proxied, S1Account, 'requester'),
+            proxied,
         )
-        self.assertIs(
-            require_configured_terminal(proxy_account, S1AccountProxy, 'requester'),
-            proxy_account,
-        )
-
-    def test_require_configured_terminal_rejects_malformed_expected_model(self):
-        class NotAModel(object):
-            pass
-
-        malformed = (
-            self.account,
-            object,
-            NotAModel,
-            1,
-            'S1Account',
-            None,
-        )
-        for expected_model in malformed:
-            with self.assertRaises(AuthorizationConfigError) as ctx:
-                require_configured_terminal(
-                    self.account, expected_model, 'requester',
-                )
-            self.assertIsInstance(ctx.exception, AuthorizationConfigError)
-            self.assertIn('Django model class', str(ctx.exception))
-            self.assertNotIsInstance(ctx.exception, AttributeError)
-
-        with self.assertRaises(AuthorizationConfigError) as ctx:
-            require_configured_terminal(1, object, 'requester')
-        self.assertIn('Django model class', str(ctx.exception))
 
     def test_require_configured_terminal_is_public_export(self):
         import trusts.runtime as runtime_mod

--- a/tests/core/test_require_configured_terminal.py
+++ b/tests/core/test_require_configured_terminal.py
@@ -1,0 +1,64 @@
+"""Public terminal-validation surface for Zero compatibility façades.
+
+``require_configured_terminal`` is the narrowly public kernel API that
+replaces ``_require_instance``. Zero ``require_configured_requester`` /
+``require_configured_operation`` call it and translate
+``AuthorizationConfigError`` to ``AuthorizationPathError``.
+"""
+
+import inspect
+
+from django.test import TransactionTestCase
+
+from trusts.runtime import (
+    AuthorizationConfigError,
+    require_configured_terminal,
+)
+from tests.models import S1Account, S1Operation, S1Organization, S1Repository
+
+
+class RequireConfiguredTerminalTest(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        super(RequireConfiguredTerminalTest, self).setUp()
+        self.org = S1Organization.objects.create(name='acme')
+        self.account = S1Account.objects.create(name='pat')
+        self.repo = S1Repository.objects.create(
+            organization=self.org, title='repo',
+        )
+        self.read = S1Operation.objects.create(code='read')
+
+    def test_require_configured_terminal_accepts_matching_instance(self):
+        self.assertIs(
+            require_configured_terminal(self.account, S1Account, 'requester'),
+            self.account,
+        )
+        self.assertIs(
+            require_configured_terminal(self.read, S1Operation, 'operation'),
+            self.read,
+        )
+
+    def test_require_configured_terminal_rejects_class_pk_and_wrong_model(self):
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(S1Account, S1Account, 'requester')
+        self.assertIn('model class', str(ctx.exception))
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(self.account.pk, S1Account, 'requester')
+        self.assertIn('primary key', str(ctx.exception).lower())
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(self.repo, S1Account, 'requester')
+        self.assertIn('requester', str(ctx.exception))
+        with self.assertRaises(AuthorizationConfigError) as ctx:
+            require_configured_terminal(self.account, S1Operation, 'operation')
+        self.assertIn('operation', str(ctx.exception))
+
+    def test_require_configured_terminal_is_public_export(self):
+        import trusts.runtime as runtime_mod
+        self.assertIn('require_configured_terminal', runtime_mod.__all__)
+        self.assertFalse(
+            inspect.getsource(require_configured_terminal).lstrip().startswith('def _')
+        )
+        self.assertNotIn('_require_instance', runtime_mod.__all__)
+        self.assertTrue(hasattr(runtime_mod, 'require_configured_terminal'))
+        self.assertFalse(hasattr(runtime_mod, '_require_instance'))

--- a/tests/core/test_zero_path.py
+++ b/tests/core/test_zero_path.py
@@ -48,10 +48,10 @@ def _backend_source():
 
 
 class ZeroComposeConsumerSourceTest(TestCase):
-    def test_permitted_uses_compose_not_parallel_join(self):
+    def test_permitted_uses_filter_authorized_not_parallel_join(self):
         source = inspect.getsource(ContentQuerySet.permitted)
-        self.assertIn('compose_zero_path', source)
-        self.assertIn('grant_q', source)
+        self.assertIn('filter_authorized', source)
+        self.assertNotIn('compose_zero_path', source)
         self.assertNotIn('trust_grant_q', source)
         self.assertNotIn('Context.scope_path', source)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -31,6 +31,7 @@ NORMAL_SUITE = [
     'tests.core.test_path',
     'tests.core.test_gh_vocab',
     'tests.core.test_s1_kernel',
+    'tests.core.test_require_configured_terminal',
     'tests.core.test_s2_backend',
     'tests.core.test_s3_decorators',
     'tests.core.test_s4_admin_views',

--- a/trusts/runtime.py
+++ b/trusts/runtime.py
@@ -87,15 +87,35 @@ def _same_model(left, right):
     return left._meta.concrete_model is right._meta.concrete_model
 
 
+def _configured_terminal_model(expected_model, what):
+    """Require a Django model class for the configured terminal.
+
+    Concrete and proxy model classes are accepted. A model instance,
+    non-model class, or raw object is ``AuthorizationConfigError``, not
+    an ``AttributeError`` from ``_same_model``.
+    """
+    if isinstance(expected_model, type):
+        meta = getattr(expected_model, '_meta', None)
+        if meta is not None and getattr(meta, 'concrete_model', None) is not None:
+            return expected_model
+    raise AuthorizationConfigError(
+        'configured %s model must be a Django model class, not %r.' % (
+            what, expected_model,
+        )
+    )
+
+
 def require_configured_terminal(value, expected_model, what):
     """Fail closed unless ``value`` is an instance of ``expected_model``.
 
+    ``expected_model`` must be a Django model class (concrete or proxy).
     Rejects model classes, raw primary keys, and wrong concrete models so
     Django cannot coerce a colliding PK. Raises
     :class:`AuthorizationConfigError`. Compatibility façades (Zero
     ``require_configured_requester`` / ``require_configured_operation``)
     call this public surface and may translate the exception type.
     """
+    expected_model = _configured_terminal_model(expected_model, what)
     if isinstance(value, type):
         raise AuthorizationConfigError(
             '%s must be a %s instance, not a model class.' % (

--- a/trusts/runtime.py
+++ b/trusts/runtime.py
@@ -87,7 +87,15 @@ def _same_model(left, right):
     return left._meta.concrete_model is right._meta.concrete_model
 
 
-def _require_instance(value, expected_model, what):
+def require_configured_terminal(value, expected_model, what):
+    """Fail closed unless ``value`` is an instance of ``expected_model``.
+
+    Rejects model classes, raw primary keys, and wrong concrete models so
+    Django cannot coerce a colliding PK. Raises
+    :class:`AuthorizationConfigError`. Compatibility façades (Zero
+    ``require_configured_requester`` / ``require_configured_operation``)
+    call this public surface and may translate the exception type.
+    """
     if isinstance(value, type):
         raise AuthorizationConfigError(
             '%s must be a %s instance, not a model class.' % (
@@ -120,7 +128,7 @@ def principal_is_usable(principal):
     the ordinary denial path. A model with none of those attributes
     (for example a custom account) is usable. ``None`` and raw PKs have
     no flags and are still configuration errors via
-    :func:`_require_instance`.
+    :func:`require_configured_terminal`.
     """
     if getattr(principal, 'is_anonymous', None) is True:
         return False
@@ -144,7 +152,7 @@ def _prepare_resource(resource, context, trustee, names):
         requester_model = trustee_registry.requester_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(resource, resource.__class__, 'resource')
+    require_configured_terminal(resource, resource.__class__, 'resource')
     try:
         path = compose(
             resource.__class__, None, context=context_registry,
@@ -162,7 +170,7 @@ def _prepare_scope(scope_obj, trustee, names):
         scope_model = trustee_registry.scope_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(scope_obj, scope_model, 'scope')
+    require_configured_terminal(scope_obj, scope_model, 'scope')
     try:
         path = compose_scope(
             scope_obj.__class__, None, trustee=trustee_registry, names=names,
@@ -184,7 +192,7 @@ def _prepare_operation(operation, trustee_registry):
         operation_model = trustee_registry.operation_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    return _require_instance(operation, operation_model, 'operation')
+    return require_configured_terminal(operation, operation_model, 'operation')
 
 
 def _deny_empty(queryset):
@@ -198,7 +206,7 @@ def is_authorized(principal, operation, resource, context=None, trustee=None, na
     path, trustee_registry, requester_model = _prepare_resource(
         resource, context, trustee, names,
     )
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.row_is_granted(resource, principal, operation)
@@ -230,7 +238,7 @@ def filter_authorized(queryset, principal, operation, context=None, trustee=None
         requester_model = trustee_registry.requester_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     try:
         path = compose(
             queryset.model, None, context=context_registry,
@@ -255,7 +263,7 @@ def authorized_q(resource_model, principal, operation, context=None, trustee=Non
         requester_model = trustee_registry.requester_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     try:
         path = compose(
             resource_model, None, context=context_registry,
@@ -277,7 +285,7 @@ def is_scope_authorized(principal, operation, scope_obj, trustee=None, names=Non
     path, trustee_registry, requester_model = _prepare_scope(
         scope_obj, trustee, names,
     )
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     operation = _prepare_operation(operation, trustee_registry)
     try:
         return path.row_is_granted(scope_obj, principal, operation)
@@ -307,7 +315,7 @@ def filter_authorized_scope(queryset, principal, operation, trustee=None, names=
         requester_model = trustee_registry.requester_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     try:
         path = compose_scope(
             queryset.model, None, trustee=trustee_registry, names=names,
@@ -330,7 +338,7 @@ def authorized_scope_q(scope_model, principal, operation, trustee=None, names=No
         requester_model = trustee_registry.requester_model()
     except TrusteeRegistrationError as exc:
         _wrap_path_error(exc)
-    _require_instance(principal, requester_model, 'requester')
+    require_configured_terminal(principal, requester_model, 'requester')
     try:
         path = compose_scope(
             scope_model, None, trustee=trustee_registry, names=names,
@@ -355,5 +363,6 @@ __all__ = [
     'is_scope_authorized',
     'principal_is_usable',
     'require_authorized',
+    'require_configured_terminal',
     'require_scope_authorized',
 ]


### PR DESCRIPTION
Focused kernel companion for [django-trusts-zero#3](https://github.com/django-trusts/django-trusts-zero/issues/3) / [django-trusts-zero#4](https://github.com/django-trusts/django-trusts-zero/pull/4). Addresses Chat review 5161589593 on this same #3 dependency. Does **not** resume [#17](https://github.com/django-trusts/django-trusts/issues/17) or close [#47](https://github.com/django-trusts/django-trusts/issues/47). Version remains `1.0.0.dev0`.

## Heads

| Tree | SHA |
| --- | --- |
| This kernel PR | `429bc75a633f6bc874fada8b3bd8e295fb0b4e12` |
| Stable Zero `main` merge of #4 | [`e7bbd1acf74c058224d6505005694395ec8baf03`](https://github.com/django-trusts/django-trusts-zero/commit/e7bbd1acf74c058224d6505005694395ec8baf03) |
| Zero #4 reviewed PR tip (not the pin) | [`80523d9a52f98ef7429f1a6eb8922e2348ff54af`](https://github.com/django-trusts/django-trusts-zero/commit/80523d9a52f98ef7429f1a6eb8922e2348ff54af) |
| Kernel base | [`4d09045db0094cc40811af87c7783fa8f85acd90`](https://github.com/django-trusts/django-trusts/commit/4d09045db0094cc40811af87c7783fa8f85acd90) (S5 merge) |

`scripts/zero-companion.pin` now pins the **stable Zero `main` merge** `e7bbd1acf74c058224d6505005694395ec8baf03` (merge commit of Zero #4; not the reviewed branch tip `80523d9…`). The temporary PR-only `038896b…` pin is gone.

## Review 5161589593 (addressed)

1. **Fail-closed `expected_model`.** `require_configured_terminal` validates/normalizes the expected terminal first (`_configured_terminal_model`). A model instance, non-model class, `None`, or raw object raises `AuthorizationConfigError` (not `AttributeError`). Concrete/proxy comparison still uses `_meta.concrete_model`.
2. **`migrates.md` entry.** Records the public spelling, removal of `_require_instance`, old/new `expected_model` behavior, the migration-bot checklist, and the stable Zero `main` pin.
3. **Companion pin.** Replaced with Zero `main` merge `e7bbd1ac…` after Chat merged Zero #4.

## CI

Green on this exact head: [run 34424738693](https://github.com/django-trusts/django-trusts/actions/runs/34424738693) (package + tests 3.12/3.13/3.14 against pinned Zero `e7bbd1ac`).

## What this ships

- Public `trusts.runtime.require_configured_terminal(value, expected_model, what)` in `__all__`
- `_require_instance` removed from the runtime module
- Focused tests: accept instance; reject class/PK/wrong model; reject malformed `expected_model`; concrete/proxy match; public export
- `ZeroComposeConsumerSourceTest` asserts `filter_authorized` (not `compose_zero_path`)

## Out of scope

- django-trusts#17 / Windows
- example#7
- Closing #47
- Package publish / version bump

r? @chatforthomas