### PR TITLE
Correct RelationPlan to_field correlation and fail-closed bindings (#64)

### DIFF
--- a/docs/core-registry.md
+++ b/docs/core-registry.md
@@ -58,5 +58,13 @@ content model fails closed: empty enumeration, `False`, and
 Callers pass model instances for `user`, `content`, and `permission`.
 This slice does not accept codename strings or dotted permission syntax.
 
+Registered relations may target a unique field other than the related
+model's primary key (`ForeignKey(..., to_field=...)`). Correlation reads
+that target field from Django `_meta` and builds `OuterRef` against it,
+not an assumed `pk`. `RelationPlan` projection methods require
+model-instance bindings; a supplied `None` or other non-instance value
+raises `TrustsConfigurationError` and is never omitted from the
+predicate.
+
 This primitive does not change historical authorization results or add a
 database schema. See [../migrates.md](../migrates.md).

--- a/migrates.md
+++ b/migrates.md
@@ -866,9 +866,42 @@ Migration-bot checklist:
 - [ ] Leave historical ``Content`` / ``Junction`` authorization alone.
 - [ ] Leave package version at ``1.0.0.dev0``.
 
+### 29. Common-plan target-field correlation and required bindings (review on #61)
+
+The imported ``trusts.core`` development API from §28 is corrected.
+Version remains **1.0.0.dev0**. There is **no schema or Django
+migration change**. Historical authorization is unchanged.
+
+| | |
+| --- | --- |
+| Previous (#61 / §28) | ``RelationPlan._correlated_exists()`` always used ``OuterRef('pk')``. A valid direct ``ForeignKey(..., to_field='slug')`` (or any unique non-PK target) compared the root FK column to the outer row's primary key. |
+| New | Correlation reads the relation's Django target field (``ForeignKey.target_field`` / ``attname``) and builds ``OuterRef`` against that outer field. |
+| Replacement | Same ``RelationPlan`` / ``plan_for`` / registry projection call sites. Register direct single-valued relations as before; non-PK ``to_field`` now enumerates and filters correctly. |
+| Affected | Isolated ``trusts.core`` development callers that register a FK targeting a unique field other than ``pk``. PK-targeting FKs keep the same SQL meaning. |
+| Authorization | Unchanged for historical Trusts. Corrects mock-plan enumeration/list results for non-PK targets. |
+
+| | |
+| --- | --- |
+| Previous (#61 / §28) | ``_bound_root_qs()`` skipped any binding whose value was ``None``. A direct ``RelationPlan`` call with a missing principal/permission dropped that predicate and could broaden to all matching rows. |
+| New | Required bindings reject ``None`` and other non-model values with ``TrustsConfigurationError``. ``_bound_root_qs()`` and the three projection methods never omit a supplied binding. Nullable grant columns do not make ``None`` a valid binding. |
+| Replacement | Pass model instances for ``user``, ``content``, and ``permission`` on ``RelationPlan.permissions`` / ``has_permission`` / ``filter_content``. Registry wrappers already required instances. |
+| Affected | Direct ``RelationPlan`` / ``plan_for`` projection callers. ``TrustsRegistry`` wrappers already validated instances. |
+| Authorization | Fail closed. A missing binding cannot widen to all rows. |
+
+Migration-bot checklist:
+
+- [ ] Do not apply a new Trusts migration; none was added.
+- [ ] Import ``TrustsRegistry`` / ``RelationPlan`` from ``trusts.core``, not ``trusts``.
+- [ ] Pass model instances into ``RelationPlan`` projections; do not pass ``None``.
+- [ ] If a registered FK uses ``to_field``, expect correlation on that unique field, not ``pk``.
+- [ ] Leave historical ``Content`` / ``Junction`` authorization alone.
+- [ ] Leave package version at ``1.0.0.dev0``.
+
 ## Schema
 
-No change. The plan compiler adds no model and no migration.
+No change. The plan compiler adds no model and no migration. The §29
+corrections change only ``trusts.core`` query construction and binding
+validation.
 
 ## Out of scope (not acceptance criteria)
 

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -237,6 +237,23 @@ def _require_instance(value, role):
     return value
 
 
+def _outer_ref_for_relation(root, field_name):
+    """Build ``OuterRef`` for the relation's actual target field.
+
+    Direct ``ForeignKey(..., to_field=...)`` and other single-valued
+    relations may target a unique field other than the related model's
+    primary key. Correlation must use that field, not assumed ``pk``.
+    """
+    field = root._meta.get_field(field_name)
+    target = getattr(field, 'target_field', None)
+    if target is None:
+        raise TrustsConfigurationError(
+            'Cannot correlate %s.%s; relation has no target field.'
+            % (root._meta.label, field_name)
+        )
+    return OuterRef(target.attname)
+
+
 def _content_model(content):
     if isinstance(content, QuerySet):
         return content.model._meta.concrete_model
@@ -264,8 +281,7 @@ class RelationPlan:
     def _bound_root_qs(self, record, **bindings):
         filters = {}
         for role, value in bindings.items():
-            if value is None:
-                continue
+            _require_instance(value, role)
             filters[getattr(record, _BINDING_FIELDS[role])] = value
         return record.root._default_manager.filter(**filters)
 
@@ -274,7 +290,7 @@ class RelationPlan:
         for record in self.records:
             terminal = getattr(record, terminal_field_attr)
             inner = self._bound_root_qs(record, **bindings).filter(
-                **{terminal: OuterRef('pk')}
+                **{terminal: _outer_ref_for_relation(record.root, terminal)}
             )
             parts.append(Exists(inner))
         if not parts:
@@ -285,6 +301,8 @@ class RelationPlan:
 
     def permissions(self, user, content):
         """Distinct permission rows for ``(user, content)``."""
+        user = _require_instance(user, 'user')
+        content = _require_instance(content, 'content')
         if not self.records or self.permission_model is None:
             return ()
         exists = self._correlated_exists(
@@ -294,6 +312,9 @@ class RelationPlan:
 
     def has_permission(self, user, content, permission):
         """SQL ``EXISTS`` membership of ``permission`` in ``permissions()``."""
+        user = _require_instance(user, 'user')
+        content = _require_instance(content, 'content')
+        permission = _require_instance(permission, 'permission')
         if not self.records or self.permission_model is None:
             return False
         if permission._meta.concrete_model is not self.permission_model:
@@ -307,6 +328,8 @@ class RelationPlan:
 
     def filter_content(self, queryset, user, permission):
         """Lazy queryset of candidate rows correlated to the same plan."""
+        user = _require_instance(user, 'user')
+        permission = _require_instance(permission, 'permission')
         if not self.records:
             return queryset.none()
         exists = self._correlated_exists(

--- a/trusts/test_issue60.py
+++ b/trusts/test_issue60.py
@@ -5,10 +5,10 @@ authorization, and authorized-content filtering. Ordinary test-only
 models; no historical Trusts types required.
 """
 
-import inspect
 import re
 from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -394,33 +394,50 @@ class TrustsRegistryProjectionTest(TransactionTestCase):
         self.DocumentGrant.objects.create(
             document=self.doc_a, user=self.alice, permission=self.read,
         )
-        registry_src = inspect.getsource(TrustsRegistry.has_permission)
-        plan_src = inspect.getsource(RelationPlan.has_permission)
-        registry_body = registry_src.split('"""', 2)[-1]
-        plan_body = plan_src.split('"""', 2)[-1]
-        self.assertNotIn('permissions_for', registry_body)
-        self.assertNotIn('list(', plan_body)
-        self.assertNotIn('permissions_for', plan_body)
-        self.assertNotIn('for ', plan_body)
-
-        from django.test.utils import CaptureQueriesContext
-        with CaptureQueriesContext(connection) as captured:
-            self.assertTrue(
-                registry.has_permission(self.alice, self.doc_a, self.read),
-            )
+        with patch.object(RelationPlan, 'permissions') as permissions:
+            from django.test.utils import CaptureQueriesContext
+            with CaptureQueriesContext(connection) as captured:
+                self.assertTrue(
+                    registry.has_permission(self.alice, self.doc_a, self.read),
+                )
+        permissions.assert_not_called()
         self.assertEqual(len(captured.captured_queries), 1)
         self.assertIn('EXISTS', captured.captured_queries[0]['sql'].upper())
 
     def test_three_projections_share_one_plan_builder(self):
-        for name in ('permissions_for', 'has_permission', 'filter_authorized'):
-            source = inspect.getsource(getattr(TrustsRegistry, name))
-            self.assertIn('plan_for', source)
-        plan_source = inspect.getsource(RelationPlan)
-        self.assertIn('_correlated_exists', plan_source)
-        self.assertIn('_bound_root_qs', plan_source)
-        for name in ('permissions', 'has_permission', 'filter_content'):
-            method = inspect.getsource(getattr(RelationPlan, name))
-            self.assertIn('_correlated_exists', method)
+        registry = self._registry()
+        self.DocumentGrant.objects.create(
+            document=self.doc_a, user=self.alice, permission=self.read,
+        )
+        with patch.object(registry, 'plan_for', wraps=registry.plan_for) as plan_for:
+            list(registry.permissions_for(self.alice, self.doc_a))
+            registry.has_permission(self.alice, self.doc_a, self.read)
+            list(registry.filter_authorized(
+                self.Document.objects.all(), self.alice, self.read,
+            ))
+        self.assertEqual(plan_for.call_count, 3)
+
+        plan = registry.plan_for(
+            self.doc_a, user=self.alice, permission=self.read,
+        )
+        with patch.object(
+            plan, '_correlated_exists', wraps=plan._correlated_exists,
+        ) as correlated:
+            list(plan.permissions(self.alice, self.doc_a))
+            plan.has_permission(self.alice, self.doc_a, self.read)
+            list(plan.filter_content(
+                self.Document.objects.all(), self.alice, self.read,
+            ))
+        self.assertEqual(correlated.call_count, 3)
+        self.assertEqual(
+            correlated.call_args_list[0].args[0], 'permission_field',
+        )
+        self.assertEqual(
+            correlated.call_args_list[1].args[0], 'permission_field',
+        )
+        self.assertEqual(
+            correlated.call_args_list[2].args[0], 'content_field',
+        )
 
     def test_configured_user_model_uses_registered_terminal_metadata(self):
         User = get_user_model()
@@ -549,4 +566,156 @@ class TrustsRegistryProjectionTest(TransactionTestCase):
         with self.assertRaisesRegex(TrustsConfigurationError, r'QuerySet'):
             registry.filter_authorized(
                 [self.doc_a], self.alice, self.read,
+            )
+
+    def test_non_pk_to_field_correlates_both_projection_directions(self):
+        User = get_user_model()
+
+        class SlugDocument(models.Model):
+            slug = models.SlugField(unique=True)
+            title = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class ActionCode(models.Model):
+            code = models.CharField(max_length=40, unique=True)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class SlugGrant(models.Model):
+            document = models.ForeignKey(
+                SlugDocument, to_field='slug', on_delete=models.CASCADE,
+            )
+            user = models.ForeignKey(User, on_delete=models.CASCADE)
+            permission = models.ForeignKey(
+                ActionCode, to_field='code', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        with _tables(SlugDocument, ActionCode, SlugGrant):
+            registry = TrustsRegistry()
+            _register(registry, SlugGrant)
+            doc_alpha = SlugDocument.objects.create(slug='alpha', title='A')
+            doc_beta = SlugDocument.objects.create(slug='beta', title='B')
+            read = ActionCode.objects.create(code='read')
+            write = ActionCode.objects.create(code='write')
+            self.assertNotEqual(doc_alpha.pk, 'alpha')
+            self.assertNotEqual(read.pk, 'read')
+            SlugGrant.objects.create(
+                document=doc_alpha, user=self.alice, permission=read,
+            )
+            SlugGrant.objects.create(
+                document=doc_beta, user=self.bob, permission=write,
+            )
+
+            self.assertEqual(
+                _pks(registry.permissions_for(self.alice, doc_alpha)),
+                {read.pk},
+            )
+            self.assertEqual(
+                list(registry.permissions_for(self.alice, doc_beta)),
+                [],
+            )
+            self.assertTrue(
+                registry.has_permission(self.alice, doc_alpha, read),
+            )
+            self.assertFalse(
+                registry.has_permission(self.alice, doc_alpha, write),
+            )
+            self.assertFalse(
+                registry.has_permission(self.alice, doc_beta, read),
+            )
+            enumerated = registry.permissions_for(self.alice, doc_alpha)
+            perm_sql = str(enumerated.query).lower()
+            self.assertIn('exists', perm_sql)
+            self.assertIn('code', perm_sql)
+            authorized = registry.filter_authorized(
+                SlugDocument.objects.order_by('pk'), self.alice, read,
+            )
+            sql = str(authorized.query).lower()
+            self.assertIn('exists', sql)
+            self.assertIn('slug', sql)
+            with self.assertNumQueries(1):
+                self.assertEqual(list(authorized), [doc_alpha])
+            self.assertEqual(
+                list(registry.filter_authorized(
+                    SlugDocument.objects.all(), self.alice, write,
+                )),
+                [],
+            )
+
+    def test_none_binding_is_rejected_and_does_not_broaden(self):
+        User = get_user_model()
+
+        class OptionalGrant(models.Model):
+            document = models.ForeignKey(
+                self.Document, on_delete=models.CASCADE,
+            )
+            user = models.ForeignKey(
+                User, on_delete=models.CASCADE, null=True,
+            )
+            permission = models.ForeignKey(
+                Permission, on_delete=models.CASCADE, null=True,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        with _tables(OptionalGrant):
+            registry = TrustsRegistry()
+            _register(registry, OptionalGrant)
+            OptionalGrant.objects.create(
+                document=self.doc_a, user=self.alice, permission=self.read,
+            )
+            OptionalGrant.objects.create(
+                document=self.doc_b, user=None, permission=self.read,
+            )
+            OptionalGrant.objects.create(
+                document=self.doc_c, user=self.alice, permission=None,
+            )
+            OptionalGrant.objects.create(
+                document=self.doc_a, user=self.bob, permission=self.write,
+            )
+            plan = registry.plan_for(self.Document)
+            candidates = self.Document.objects.order_by('pk')
+
+            with self.assertRaisesRegex(TrustsConfigurationError, r'user'):
+                list(plan.permissions(None, self.doc_a))
+            with self.assertRaisesRegex(TrustsConfigurationError, r'content'):
+                list(plan.permissions(self.alice, None))
+            with self.assertRaisesRegex(TrustsConfigurationError, r'permission'):
+                plan.has_permission(self.alice, self.doc_a, None)
+            with self.assertRaisesRegex(TrustsConfigurationError, r'user'):
+                list(plan.filter_content(candidates, None, self.read))
+            with self.assertRaisesRegex(TrustsConfigurationError, r'permission'):
+                list(plan.filter_content(candidates, self.alice, None))
+            with self.assertRaisesRegex(TrustsConfigurationError, r'user'):
+                list(plan.permissions('alice', self.doc_a))
+
+            self.assertEqual(
+                _pks(plan.permissions(self.alice, self.doc_a)),
+                {self.read.pk},
+            )
+            self.assertTrue(
+                plan.has_permission(self.alice, self.doc_a, self.read),
+            )
+            self.assertFalse(
+                plan.has_permission(self.alice, self.doc_b, self.read),
+            )
+            self.assertFalse(
+                plan.has_permission(self.alice, self.doc_c, self.read),
+            )
+            self.assertEqual(
+                _pks(plan.filter_content(candidates, self.alice, self.read)),
+                {self.doc_a.pk},
+            )
+            self.assertEqual(
+                _pks(registry.filter_authorized(
+                    candidates, self.alice, self.read,
+                )),
+                {self.doc_a.pk},
             )

--- a/trusts/test_issue60.py
+++ b/trusts/test_issue60.py
@@ -420,23 +420,22 @@ class TrustsRegistryProjectionTest(TransactionTestCase):
         plan = registry.plan_for(
             self.doc_a, user=self.alice, permission=self.read,
         )
-        with patch.object(
-            plan, '_correlated_exists', wraps=plan._correlated_exists,
-        ) as correlated:
+        terminals = []
+        original = RelationPlan._correlated_exists
+
+        def spy(self, terminal_field_attr, **bindings):
+            terminals.append(terminal_field_attr)
+            return original(self, terminal_field_attr, **bindings)
+
+        with patch.object(RelationPlan, '_correlated_exists', spy):
             list(plan.permissions(self.alice, self.doc_a))
             plan.has_permission(self.alice, self.doc_a, self.read)
             list(plan.filter_content(
                 self.Document.objects.all(), self.alice, self.read,
             ))
-        self.assertEqual(correlated.call_count, 3)
         self.assertEqual(
-            correlated.call_args_list[0].args[0], 'permission_field',
-        )
-        self.assertEqual(
-            correlated.call_args_list[1].args[0], 'permission_field',
-        )
-        self.assertEqual(
-            correlated.call_args_list[2].args[0], 'content_field',
+            terminals,
+            ['permission_field', 'permission_field', 'content_field'],
         )
 
     def test_configured_user_model_uses_registered_terminal_metadata(self):


### PR DESCRIPTION
Closes #64. Continues #60. Follow-up to merged PR #61 (`9e1fa88aec869598eb0e3d09ae708659e0a11a63`). Addresses chatforthomas CHANGES_REQUESTED on that review (https://github.com/django-trusts/django-trusts/pull/61#pullrequestreview-5172390767) as required correctness fixes on the already-merged common plan.

Sole corrective baton for #64. Branched from `dev` tip `d3072a38c70ee182eb7672d550914446ce7980d8` (the #61 merge). This PR head: `ef32226792165c492ef22eb195ffbcef3434a2b4`.

## Fixes

1. **Correlate to the relation target field, not assumed `pk`.**
   `RelationPlan._correlated_exists()` builds `OuterRef` from Django `_meta` (`ForeignKey.target_field` / `attname`). Direct `ForeignKey(..., to_field='slug')` and other unique-field relations compare the root FK column to that outer field.

2. **Required bindings never disappear.**
   `_bound_root_qs()` and the three `RelationPlan` projection methods reject `None` and other non-model values with `TrustsConfigurationError`. A missing principal/permission cannot broaden to all rows, including when the grant column is nullable.

3. **No source-text spelling tests.**
   Dropped `inspect.getsource` / `'for '` / helper-name string assertions. Kept one-query `EXISTS`, generated `OR`, set parity, and laziness. Common-plan delegation is asserted with `unittest.mock` spies at `plan_for` / `_correlated_exists` / `permissions`.

## Docs

`docs/core-registry.md` notes target-field `OuterRef` and fail-closed bindings. `migrates.md` §29 records the imported development-API change from PK-only correlation and silent `None` drops to target-field correlation and `TrustsConfigurationError`. Version stays **1.0.0.dev0**.

## Scope

`trusts/core.py`, `trusts/test_issue60.py`, `docs/core-registry.md`, and `migrates.md` §29. No historical models, query.py, backends, decorators, managers, conditions, system checks, migrations, django-trusts-zero, example, Windows ACL, or GH permissions. Historical-model migration and issue #62 not started.

## Test results

Local, Python 3.12.3 / Django 6.1.1, HEAD `ef32226792165c492ef22eb195ffbcef3434a2b4`:

| Check | Result |
| --- | --- |
| `trusts.test_issue60` | 20 tests OK |
| `trusts.test_issue57` | 19 tests OK |
| focused `#60` + `#57` | 39 tests OK |
| `python -m tests.runtests` | 198 tests OK (1 expected failure, historical) |
| `python -m django check --settings=tests.settings` | OK (1 silenced) |
| Trusts migrations | unchanged `{0001_initial, 0002_trustgroup}` |

GitHub Actions on the same HEAD (all 4 checks green):

| Check | Result |
| --- | --- |
| tests (Python 3.12) | success |
| tests (Python 3.13) | success |
| tests (Python 3.14) | success |
| package | success |

No authorization result changes. No database schema or migration changes. Historical-model migration not started.

r? @chatforthomas