### PR TITLE
Support same-root registrations and trailing-reverse content paths (#65)

### DIFF
--- a/docs/core-registry.md
+++ b/docs/core-registry.md
@@ -1,39 +1,79 @@
 # TrustsRegistry (internal development primitive)
 
-Additive registration and projection surface for issues #57 and #60.
+Additive registration and projection surface for issues #57, #60, and #65.
 Import from `trusts.core`. This slice does **not** re-export a
 process-global registry from `trusts`.
 
 `TrustsRegistry` is instantiable and isolated. `Ref(Model)` names a
 permission-bearing relation root; attribute access builds a root-relative
 path, including ordinary field names such as `root` and `path`. `register`
-accepts those refs, validates them through Django `_meta` (zero SQL), and
-stores one immutable `RegisteredRelation` per root. Inspect the inferred
-root and paths on that record, not on `Ref`.
+accepts those refs, validates them through Django `_meta` and each hop's
+`get_path_info()` (zero SQL), and stores an immutable `RegisteredRelation`.
+Inspect the inferred root, full path, lookup, and target field on that
+record, not on `Ref`.
 
 ```python
 from trusts.core import Ref, TrustsRegistry
 
-j = Ref(DocumentGrant)
+j = Ref(FolderGrant)
 registry = TrustsRegistry()
-record = registry.register(
-    content=j.document,
+registry.register(
+    content=j.folder,
+    user=j.user,
+    permission=j.permission,
+)
+registry.register(
+    content=j.folder.documents,
     user=j.user,
     permission=j.permission,
 )
 ```
 
-This slice supports only direct single-valued forward relations (the
-accepted DocumentGrant mock). Multi-valued, reverse, and generic foreign
-key paths raise `TrustsConfigurationError`. `condition` may be omitted or
-`None`; any other value is not supported yet.
+One root may store more than one record when the content terminals differ
+(`Folder` and `Document` above). `registry.records` is global insertion
+order. `records_for_root(root)` returns that root's ordered tuple and
+raises `TrustsConfigurationError` when the root is absent. There is no
+`get(root)`: a single record would be ambiguous.
+
+Exact duplicate normalized registration raises. The same root plus the
+same content terminal with a different path or different user/permission
+paths is an explicit conflict. Same-root multiple paths to one content
+model are unsupported; this slice does not invent precedence. Different
+roots remain supported.
+
+User and permission refs remain one direct single-valued hop. A content
+path may be that same direct hop, or one or more forward single-valued
+hops followed by exactly one final reverse one-to-many hop.
+
+These shapes raise `TrustsConfigurationError` during `register`:
+
+- reverse relations before the final hop, or a reverse as the only hop
+- reverse one-to-one
+- many-to-many
+- generic foreign keys/relations
+- anything after the final reverse hop
+- multi-hop all-forward content (no trailing reverse)
+- arbitrary multi-valued chains
+- composite / multi-column correlation (`get_path_info()` must yield
+  exactly one `PathInfo` with exactly one target field)
+
+`condition` may be omitted or `None`; any other value is not supported yet.
+
+Each hop's terminal model, complete root-relative lookup
+(`'__'.join(path)`, for example `folder__documents`), and outer comparison
+field come from resolved path metadata. Correlation does not assume `pk`,
+does not assume the terminal field lives on the root, and does not
+hand-code forward versus reverse identity. A non-primary
+`ForeignKey(..., to_field=...)` still uses that target field (`#64`).
 
 ## One plan, three projections
 
-`plan_for` compiles every applicable `RegisteredRelation` into one
-`RelationPlan`. Root selection, field correlation, and `EXISTS` assembly
-live in that plan. The three development projections only change the
-terminal:
+`plan_for` selects applicable records by content/user/permission terminal
+and compiles them into one `RelationPlan`. Root selection, field
+correlation, and `EXISTS` assembly live in that plan. Bindings and
+`EXISTS` use the complete stored lookup. `OuterRef` uses the last hop's
+single target `attname`. The three development projections only change
+the terminal:
 
 ```python
 registry.permissions_for(user, document)
@@ -50,6 +90,12 @@ registry.filter_authorized(Document.objects.all(), user, permission)
   the same predicate to each candidate content row. Filtering happens in
   SQL before pagination or aggregation.
 
+`RelationPlan.content_exists(user, permission)` is the shared
+content-`EXISTS` predicate. `filter_content` / `filter_authorized`
+consume that same object. A later reader may OR it with another predicate
+on the original candidate queryset; do not filter trustee rows first and
+then try to restore another branch.
+
 Multiple applicable relation roots combine by SQL `OR`. Duplicate grant
 rows do not duplicate permission or content results. An unregistered
 content model fails closed: empty enumeration, `False`, and
@@ -58,13 +104,9 @@ content model fails closed: empty enumeration, `False`, and
 Callers pass model instances for `user`, `content`, and `permission`.
 This slice does not accept codename strings or dotted permission syntax.
 
-Registered relations may target a unique field other than the related
-model's primary key (`ForeignKey(..., to_field=...)`). Correlation reads
-that target field from Django `_meta` and builds `OuterRef` against it,
-not an assumed `pk`. `RelationPlan` projection methods require
-model-instance bindings; a supplied `None` or other non-instance value
-raises `TrustsConfigurationError` and is never omitted from the
-predicate.
+`RelationPlan` projection methods require model-instance bindings; a
+supplied `None` or other non-instance value raises
+`TrustsConfigurationError` and is never omitted from the predicate.
 
 This primitive does not change historical authorization results or add a
 database schema. See [../migrates.md](../migrates.md).

--- a/migrates.md
+++ b/migrates.md
@@ -912,6 +912,75 @@ validation.
 - Codename strings, dotted permission syntax, or heterogeneous
   permission-terminal normalization
 
+---
+
+# Same-root registrations and trailing-reverse content paths (issue #65)
+
+This record covers the additive ``trusts.core`` same-root and
+bounded content-path extension. Version remains **1.0.0.dev0**. It
+closes the #65 slice (isolated mocks only). It does **not** migrate
+historical models, start Child H, or change authorization results.
+There is **no schema or Django migration change**.
+
+## Decision
+
+One permission-bearing root may store several normalized
+``RegisteredRelation`` rows when they terminate on different content
+models. A content path may be the existing direct single-valued hop or
+one or more forward single-valued hops followed by exactly one final
+reverse one-to-many hop. User and permission paths stay direct.
+Bindings and ``EXISTS`` use the complete root-relative lookup and the
+last hop's single path-info target field.
+
+## No change to these public call sites
+
+- `User.has_perm` / ``ContentQuerySet.permitted`` signatures
+- ``Content`` / ``Junction`` registration and ``class_prepared`` dispatch
+- Authentication-backend composition
+- Package version `1.0.0.dev0`
+- Database schema and Trusts migrations (`0001_initial`, `0002_trustgroup`)
+
+## Changes
+
+### 30. Same-root records and trailing-reverse content paths (new, additive)
+
+| | |
+| --- | --- |
+| Previous (#57 / #60 / §29) | ``_by_root`` stored one record per root. ``get(root)`` returned that record. A second different registration for the same root was always a conflict. Content, user, and permission paths were one direct single-valued hop. ``content_field`` was the last segment on the root. ``OuterRef`` was resolved by looking up that field on the root. |
+| New | ``_by_root[root]`` is an insertion-ordered list. ``records_for_root(root)`` returns that tuple and raises when absent. ``get(root)`` is removed. Exact duplicates still raise. Same root plus the same content terminal with a different registration is still a conflict. Same root plus different content terminals is allowed. Content may also be ``(forward single-valued)+`` then one final reverse one-to-many. Each hop is resolved with ``get_path_info()``: exactly one ``PathInfo`` and exactly one target field, or the path is rejected. Stored ``*_field`` is the full ``'__'.join(path)`` lookup; ``*_target`` is the last hop's target ``attname``. ``RelationPlan.content_exists`` is the one content-``EXISTS`` surface; ``filter_authorized`` consumes it. |
+| Replacement | None for existing callers. Isolated ``register`` / ``plan_for`` / projection call sites stay the same. Use ``records_for_root`` instead of ``get``. Register a trailing-reverse content path when the terminal is not a field on the root. |
+| Affected | Isolated ``trusts.core`` development callers. Direct one-hop registrations keep the same lookup (``document``) and #64 target-field ``OuterRef``. |
+| Authorization | Unchanged for historical Trusts. No schema or migration. |
+
+Rejected during ``register`` (zero SQL): reverse before the final hop;
+reverse as the only hop; reverse one-to-one; many-to-many; generic
+foreign keys; anything after the final reverse; multi-hop all-forward
+content; arbitrary multi-valued chains; composite / multi-column
+correlation.
+
+Migration-bot checklist:
+
+- [ ] Do not apply a new Trusts migration; none was added.
+- [ ] Import ``TrustsRegistry`` / ``RelationPlan`` from ``trusts.core``, not ``trusts``.
+- [ ] Do not call ``registry.get(root)``; use ``records_for_root(root)`` or ``plan_for``.
+- [ ] Same-root second paths to one content model are conflicts, not precedence.
+- [ ] Leave historical ``Content`` / ``Junction`` authorization alone.
+- [ ] Leave package version at ``1.0.0.dev0``.
+
+## Schema
+
+No change. The same-root and trailing-reverse extension adds no model
+and no migration. Query construction remains lazy.
+
+## Out of scope (not acceptance criteria)
+
+- Historical model registration, package-owned registry lifecycle, or
+  reader migration (Child H / #62)
+- Junction reverse-then-forward, group M2M, custom ``fieldlookup``
+  chains, or parent hierarchy
+- Process-global registry or ``trusts`` package re-export
+- ``condition`` representation
+
 
 
 

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -1,11 +1,12 @@
 """Isolated registration and common authorization-plan compiler.
 
 ``TrustsRegistry`` validates root-relative ``Ref`` paths through Django
-model ``_meta`` and stores one immutable record per relation. The same
-registered records compile into one correlated relation plan. Three
-projections change only the terminal: permission enumeration, object
-authorization (SQL ``EXISTS`` membership over that enumeration), and
-authorized-content filtering.
+model ``_meta`` and stores immutable records. More than one normalized
+registration may share one permission-bearing root when they terminate
+on different content models. The same registered records compile into
+one correlated relation plan. Three projections change only the
+terminal: permission enumeration, object authorization (SQL ``EXISTS``
+membership over that enumeration), and authorized-content filtering.
 
 Import from ``trusts.core``. This slice does not re-export a process-global
 registry from ``trusts``.
@@ -41,11 +42,13 @@ def _classify_field(field):
         return 'gfk'
     if not getattr(field, 'is_relation', False):
         return 'scalar'
-    if getattr(field, 'many_to_many', False) or getattr(field, 'one_to_many', False):
-        return 'multi'
-    if getattr(field, 'auto_created', False) and not getattr(field, 'concrete', False):
-        return 'reverse'
+    if getattr(field, 'many_to_many', False):
+        return 'm2m'
     if getattr(field, 'one_to_one', False) and not getattr(field, 'concrete', False):
+        return 'reverse_o2o'
+    if getattr(field, 'one_to_many', False):
+        return 'reverse_o2m'
+    if getattr(field, 'auto_created', False) and not getattr(field, 'concrete', False):
         return 'reverse'
     related = getattr(field, 'related_model', None)
     if related is None:
@@ -57,19 +60,98 @@ def _path_text(path):
     return '.'.join(path)
 
 
-def _terminal_model(field):
+def _lookup_text(path):
+    return '__'.join(path)
+
+
+def _materialize_related_model(field):
+    """Resolve a still-string ``remote_field.model`` through the app registry.
+
+    Isolated ``ForeignKey(settings.AUTH_USER_MODEL)`` fields keep a string
+    until Django's lazy related-class hook runs. Path information needs the
+    model class. ``apps.get_model`` is metadata only (zero SQL).
+    """
+    remote = getattr(field, 'remote_field', None)
+    if remote is None:
+        return
+    model = getattr(remote, 'model', None)
+    if _is_model_class(model):
+        return
     related = getattr(field, 'related_model', None)
+    if isinstance(related, str) or related is None:
+        label = related if isinstance(related, str) else model
+        if isinstance(label, str):
+            try:
+                related = django_apps.get_model(label)
+            except (LookupError, ValueError):
+                return
     if _is_model_class(related):
-        return related
-    if isinstance(related, str):
         try:
-            return django_apps.get_model(related)
-        except (LookupError, ValueError):
-            return None
-    return None
+            remote.model = related
+        except (AttributeError, TypeError):
+            return
 
 
-def _resolve_direct_path(root, path, role):
+def _resolved_hop(field, role, path):
+    """Resolve one hop from Django path information.
+
+    Requires exactly one ``PathInfo`` and exactly one target field.
+    Terminal model and outer comparison field come from that metadata.
+    """
+    _materialize_related_model(field)
+    getter = getattr(field, 'get_path_info', None)
+    if not callable(getter):
+        raise TrustsConfigurationError(
+            '%s path %r has no resolvable path information.'
+            % (role, _path_text(path))
+        )
+    infos = getter()
+    if infos is None:
+        infos = ()
+    infos = tuple(infos)
+    if len(infos) != 1:
+        raise TrustsConfigurationError(
+            '%s path %r does not resolve to exactly one relation hop; '
+            'composite and multi-join relations are not supported.'
+            % (role, _path_text(path))
+        )
+    info = infos[0]
+    target_fields = getattr(info, 'target_fields', None) or ()
+    if len(target_fields) != 1:
+        raise TrustsConfigurationError(
+            '%s path %r exposes %s target fields; composite and '
+            'multi-column correlation are not supported.'
+            % (role, _path_text(path), len(target_fields))
+        )
+    to_opts = getattr(info, 'to_opts', None)
+    related = None
+    if to_opts is not None:
+        related = getattr(to_opts, 'concrete_model', None) or getattr(
+            to_opts, 'model', None
+        )
+    if not _is_model_class(related):
+        raise TrustsConfigurationError(
+            '%s path %r does not terminate on a model.'
+            % (role, _path_text(path))
+        )
+    target = target_fields[0]
+    attname = getattr(target, 'attname', None)
+    if not attname:
+        raise TrustsConfigurationError(
+            '%s path %r does not expose one supported target field.'
+            % (role, _path_text(path))
+        )
+    return related._meta.concrete_model, attname
+
+
+def _resolve_path(root, path, role, *, trailing_reverse=False):
+    """Validate a root-relative path and return lookup metadata.
+
+    User and permission paths remain one direct single-valued hop.
+    A content path may be that same direct hop, or one or more forward
+    single-valued hops followed by exactly one final reverse
+    one-to-many hop.
+    """
     if not path:
         raise TrustsConfigurationError(
             '%s must be a non-empty root-relative path from %s.'
@@ -77,9 +159,13 @@ def _resolve_direct_path(root, path, role):
         )
 
     current = root
-    field = None
     related = None
+    target_attname = None
+    saw_reverse = False
+    n = len(path)
+
     for index, name in enumerate(path):
+        is_last = index == n - 1
         try:
             field = current._meta.get_field(name)
         except FieldDoesNotExist:
@@ -91,20 +177,14 @@ def _resolve_direct_path(root, path, role):
         kind = _classify_field(field)
         if kind == 'scalar':
             raise TrustsConfigurationError(
-                '%s path %r traverses scalar field %r on %s; only direct '
+                '%s path %r traverses scalar field %r on %s; only '
                 'single-valued relations are supported.'
                 % (role, _path_text(path), name, current._meta.label)
             )
-        if kind == 'multi':
+        if kind == 'm2m':
             raise TrustsConfigurationError(
-                '%s path %r uses multi-valued field %r on %s; multi-valued '
-                'and reverse traversals are not supported.'
-                % (role, _path_text(path), name, current._meta.label)
-            )
-        if kind == 'reverse':
-            raise TrustsConfigurationError(
-                '%s path %r uses reverse relation %r on %s; multi-valued '
-                'and reverse traversals are not supported.'
+                '%s path %r uses multi-valued field %r on %s; many-to-many '
+                'and other multi-valued traversals are not supported.'
                 % (role, _path_text(path), name, current._meta.label)
             )
         if kind == 'gfk':
@@ -113,23 +193,56 @@ def _resolve_direct_path(root, path, role):
                 'foreign keys are not supported.'
                 % (role, _path_text(path), name, current._meta.label)
             )
-
-        related = _terminal_model(field)
-        if not _is_model_class(related):
+        if kind == 'reverse_o2o':
             raise TrustsConfigurationError(
-                '%s path %r does not terminate on a model.'
-                % (role, _path_text(path))
+                '%s path %r uses reverse one-to-one relation %r on %s; '
+                'reverse one-to-one traversals are not supported.'
+                % (role, _path_text(path), name, current._meta.label)
             )
-        if index != len(path) - 1:
+        if kind in ('reverse_o2m', 'reverse'):
+            allowed_final = (
+                trailing_reverse
+                and is_last
+                and index > 0
+                and kind == 'reverse_o2m'
+            )
+            if not allowed_final:
+                if not is_last:
+                    raise TrustsConfigurationError(
+                        '%s path %r uses reverse relation %r on %s before '
+                        'the final hop; reverse relations are only '
+                        'supported as the final content hop.'
+                        % (role, _path_text(path), name, current._meta.label)
+                    )
+                raise TrustsConfigurationError(
+                    '%s path %r uses reverse relation %r on %s; multi-valued '
+                    'and reverse traversals are not supported.'
+                    % (role, _path_text(path), name, current._meta.label)
+                )
+            saw_reverse = True
+        elif kind != 'single':
+            raise TrustsConfigurationError(
+                '%s path %r uses unsupported field %r on %s.'
+                % (role, _path_text(path), name, current._meta.label)
+            )
+
+        related, target_attname = _resolved_hop(field, role, path)
+        if not is_last:
             current = related
 
-    if len(path) != 1:
+    if n != 1 and not saw_reverse:
+        if trailing_reverse:
+            raise TrustsConfigurationError(
+                '%s path %r is not a direct single-valued relation or a '
+                'forward path ending in one reverse one-to-many.'
+                % (role, _path_text(path))
+            )
         raise TrustsConfigurationError(
             '%s path %r is not a direct single-valued relation; only '
             'direct paths are supported.'
             % (role, _path_text(path))
         )
-    return tuple(path), related, field.name
+    return tuple(path), related, _lookup_text(path), target_attname
 
 
 def _require_ref(value, role):
@@ -198,18 +311,26 @@ class Ref(object):
 
 @dataclass(frozen=True, slots=True)
 class RegisteredRelation:
-    """Immutable normalized record for one permission-bearing relation."""
+    """Immutable normalized record for one permission-bearing relation.
+
+    ``*_field`` is the complete root-relative Django lookup
+    (``'__'.join(path)``). ``*_target`` is the last hop's single
+    comparison field (``attname``), taken from resolved path metadata.
+    """
 
     root: type
     content_path: tuple
     content_model: type
     content_field: str
+    content_target: str
     user_path: tuple
     user_model: type
     user_field: str
+    user_target: str
     permission_path: tuple
     permission_model: type
     permission_field: str
+    permission_target: str
     condition: None = None
 
 
@@ -217,6 +338,12 @@ _BINDING_FIELDS = {
     'user': 'user_field',
     'content': 'content_field',
     'permission': 'permission_field',
+}
+
+_TARGET_ATTRS = {
+    'user_field': 'user_target',
+    'content_field': 'content_target',
+    'permission_field': 'permission_target',
 }
 
 
@@ -235,23 +362,6 @@ def _require_instance(value, role):
             '%s must be a model instance, not %r.' % (role, value)
         )
     return value
-
-
-def _outer_ref_for_relation(root, field_name):
-    """Build ``OuterRef`` for the relation's actual target field.
-
-    Direct ``ForeignKey(..., to_field=...)`` and other single-valued
-    relations may target a unique field other than the related model's
-    primary key. Correlation must use that field, not assumed ``pk``.
-    """
-    field = root._meta.get_field(field_name)
-    target = getattr(field, 'target_field', None)
-    if target is None:
-        raise TrustsConfigurationError(
-            'Cannot correlate %s.%s; relation has no target field.'
-            % (root._meta.label, field_name)
-        )
-    return OuterRef(target.attname)
 
 
 def _content_model(content):
@@ -273,6 +383,9 @@ class RelationPlan:
 
     Root selection, field correlation, and ``EXISTS`` assembly live here.
     Projection methods only choose the outer terminal or wrap ``exists()``.
+    Bindings and correlation use the complete stored lookup, not only the
+    last path segment. ``OuterRef`` uses the last hop's resolved target
+    field, which need not live on the root and is not assumed to be ``pk``.
     """
 
     records: tuple
@@ -289,8 +402,9 @@ class RelationPlan:
         parts = []
         for record in self.records:
             terminal = getattr(record, terminal_field_attr)
+            target = getattr(record, _TARGET_ATTRS[terminal_field_attr])
             inner = self._bound_root_qs(record, **bindings).filter(
-                **{terminal: _outer_ref_for_relation(record.root, terminal)}
+                **{terminal: OuterRef(target)}
             )
             parts.append(Exists(inner))
         if not parts:
@@ -298,6 +412,21 @@ class RelationPlan:
         if len(parts) == 1:
             return parts[0]
         return reduce(or_, parts)
+
+    def content_exists(self, user, permission):
+        """Candidate-row ``EXISTS`` correlating content through this plan.
+
+        Later readers may OR this predicate with another predicate on the
+        same incoming queryset. ``filter_content`` consumes this same
+        object; there is no second content-correlation builder.
+        """
+        user = _require_instance(user, 'user')
+        permission = _require_instance(permission, 'permission')
+        if not self.records:
+            return None
+        return self._correlated_exists(
+            'content_field', user=user, permission=permission,
+        )
 
     def permissions(self, user, content):
         """Distinct permission rows for ``(user, content)``."""
@@ -328,13 +457,9 @@ class RelationPlan:
 
     def filter_content(self, queryset, user, permission):
         """Lazy queryset of candidate rows correlated to the same plan."""
-        user = _require_instance(user, 'user')
-        permission = _require_instance(permission, 'permission')
-        if not self.records:
+        exists = self.content_exists(user, permission)
+        if exists is None:
             return queryset.none()
-        exists = self._correlated_exists(
-            'content_field', user=user, permission=permission,
-        )
         return queryset.filter(exists).distinct()
 
 
@@ -343,7 +468,8 @@ class TrustsRegistry(object):
 
     Create a new instance per isolated context. There is no process-global
     singleton in this slice. ``register`` performs zero SQL. Projection
-    methods compile one shared plan from stored records.
+    methods compile one shared plan from stored records. One root may
+    store several records when they terminate on different content models.
     """
 
     def __init__(self):
@@ -354,9 +480,13 @@ class TrustsRegistry(object):
     def records(self):
         return tuple(self._order)
 
-    def get(self, root):
+    def records_for_root(self, root):
+        """Insertion-ordered records registered for ``root``.
+
+        Raises ``TrustsConfigurationError`` when the root is absent.
+        """
         try:
-            return self._by_root[root]
+            return tuple(self._by_root[root])
         except KeyError:
             raise TrustsConfigurationError(
                 'No registration for %r.' % (getattr(root, '__name__', root),)
@@ -365,11 +495,11 @@ class TrustsRegistry(object):
     def register(self, *, content, user, permission, condition=None):
         """Register one permission-bearing relation from root-relative refs.
 
-        Duplicate registration of the same root with an identical normalized
-        record raises ``TrustsConfigurationError``. A second registration of
-        the same root with a different normalized record is a conflict and
-        also raises ``TrustsConfigurationError``. Both outcomes are
-        deterministic: the first stored record is left unchanged.
+        Exact duplicate normalized registration raises
+        ``TrustsConfigurationError``. The same root plus the same content
+        terminal with a different registration is a conflict and also
+        raises. The same root may register different content terminals.
+        Both error outcomes leave stored records unchanged.
         """
         if condition is not None:
             raise TrustsConfigurationError(
@@ -388,14 +518,14 @@ class TrustsRegistry(object):
             )
         root = roots[0]
 
-        content_path, content_model, content_field = _resolve_direct_path(
-            root, content_ref._path, 'content'
+        content_path, content_model, content_field, content_target = _resolve_path(
+            root, content_ref._path, 'content', trailing_reverse=True,
         )
-        user_path, user_model, user_field = _resolve_direct_path(
+        user_path, user_model, user_field, user_target = _resolve_path(
             root, user_ref._path, 'user'
         )
-        permission_path, permission_model, permission_field = _resolve_direct_path(
-            root, permission_ref._path, 'permission'
+        permission_path, permission_model, permission_field, permission_target = (
+            _resolve_path(root, permission_ref._path, 'permission')
         )
 
         record = RegisteredRelation(
@@ -403,27 +533,39 @@ class TrustsRegistry(object):
             content_path=content_path,
             content_model=content_model,
             content_field=content_field,
+            content_target=content_target,
             user_path=user_path,
             user_model=user_model,
             user_field=user_field,
+            user_target=user_target,
             permission_path=permission_path,
             permission_model=permission_model,
             permission_field=permission_field,
+            permission_target=permission_target,
             condition=None,
         )
 
-        existing = self._by_root.get(root)
-        if existing is not None:
-            if existing == record:
-                raise TrustsConfigurationError(
-                    'Duplicate registration for %s.' % root._meta.label
-                )
-            raise TrustsConfigurationError(
-                'Conflicting registration for %s: existing %r, new %r.'
-                % (root._meta.label, existing, record)
-            )
-
-        self._by_root[root] = record
+        existing_rows = self._by_root.get(root)
+        if existing_rows:
+            for existing in existing_rows:
+                if existing == record:
+                    raise TrustsConfigurationError(
+                        'Duplicate registration for %s.' % root._meta.label
+                    )
+                if existing.content_model is record.content_model:
+                    raise TrustsConfigurationError(
+                        'Conflicting registration for %s content terminal '
+                        '%s: existing %r, new %r.'
+                        % (
+                            root._meta.label,
+                            record.content_model._meta.label,
+                            existing,
+                            record,
+                        )
+                    )
+            existing_rows.append(record)
+        else:
+            self._by_root[root] = [record]
         self._order.append(record)
         return record
 
@@ -487,7 +629,10 @@ class TrustsRegistry(object):
         ).has_permission(user, content, permission)
 
     def filter_authorized(self, queryset, user, permission):
-        """Lazy queryset of rows ``user`` holds ``permission`` on."""
+        """Lazy queryset of rows ``user`` holds ``permission`` on.
+
+        Consumes ``RelationPlan.content_exists`` through ``filter_content``.
+        """
         if not isinstance(queryset, QuerySet):
             raise TrustsConfigurationError(
                 'filter_authorized requires a QuerySet, not %r.' % (queryset,)

--- a/trusts/test_issue57.py
+++ b/trusts/test_issue57.py
@@ -4,8 +4,7 @@ Registration only. Does not exercise object authorization, authorized-content
 filtering, permission enumeration, backends, conditions, or compatibility.
 """
 
-import re
-from pathlib import Path
+import types
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -367,19 +366,36 @@ class TrustsRegistryTest(SimpleTestCase):
         self.assertIsNone(getattr(trusts, 'TrustsRegistry', None))
         self.assertIsNone(getattr(trusts, 'RegisteredRelation', None))
 
-    def test_core_module_does_not_name_historical_types(self):
-        source = Path(__import__('trusts.core', fromlist=['core']).__file__).read_text()
-        forbidden = (
-            r'\bTrust\b',
-            r'\bContent\b',
-            r'\bJunction\b',
-            r'\bTrustUserPermission\b',
-            r'\bTrustGroupPermission\b',
-            r'\bGroup\b',
-            r'\bRole\b',
+    def test_core_module_has_no_historical_import_or_global(self):
+        import trusts.core as core
+
+        forbidden = {
+            'Trust',
+            'Content',
+            'Junction',
+            'TrustUserPermission',
+            'TrustGroupPermission',
+            'Group',
+            'Role',
+        }
+        self.assertFalse(forbidden.intersection(vars(core)))
+
+        imported = {
+            value.__name__
+            for value in vars(core).values()
+            if isinstance(value, types.ModuleType)
+        }
+        self.assertTrue(
+            all(
+                name == 'trusts.core' or not name.startswith('trusts.')
+                for name in imported
+            ),
+            imported,
         )
-        for pattern in forbidden:
-            self.assertIsNone(
-                re.search(pattern, source),
-                'trusts/core.py must not name %s' % pattern,
-            )
+        for value in vars(core).values():
+            module = getattr(value, '__module__', None)
+            if isinstance(module, str):
+                self.assertFalse(
+                    module.startswith('trusts.') and module != 'trusts.core',
+                    module,
+                )

--- a/trusts/test_issue57.py
+++ b/trusts/test_issue57.py
@@ -110,7 +110,10 @@ class TrustsRegistryTest(SimpleTestCase):
         self.assertIs(record.permission_model, Permission)
         self.assertEqual(record.permission_field, 'permission')
         self.assertIsNone(record.condition)
-        self.assertIs(registry.get(DocumentGrant), record)
+        self.assertEqual(record.content_target, Document._meta.pk.attname)
+        self.assertEqual(record.user_target, User._meta.pk.attname)
+        self.assertEqual(record.permission_target, Permission._meta.pk.attname)
+        self.assertEqual(registry.records_for_root(DocumentGrant), (record,))
         self.assertEqual(registry.records, (record,))
 
     def test_all_refs_share_the_same_root(self):
@@ -297,7 +300,7 @@ class TrustsRegistryTest(SimpleTestCase):
         with self.assertRaisesRegex(TrustsConfigurationError, r'Duplicate'):
             _register(registry, DocumentGrant)
         self.assertEqual(registry.records, (first,))
-        self.assertIs(registry.get(DocumentGrant), first)
+        self.assertEqual(registry.records_for_root(DocumentGrant), (first,))
 
         with self.assertRaisesRegex(TrustsConfigurationError, r'Conflicting'):
             _register(registry, DocumentGrant, content_attr='alt_document')

--- a/trusts/test_issue60.py
+++ b/trusts/test_issue60.py
@@ -5,9 +5,8 @@ authorization, and authorized-content filtering. Ordinary test-only
 models; no historical Trusts types required.
 """
 
-import re
+import types
 from contextlib import contextmanager
-from pathlib import Path
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -514,22 +513,39 @@ class TrustsRegistryProjectionTest(TransactionTestCase):
         self.assertIsNone(getattr(trusts, 'TrustsRegistry', None))
         self.assertIsNone(getattr(trusts, 'RelationPlan', None))
 
-    def test_core_module_does_not_name_historical_types(self):
-        source = Path(__import__('trusts.core', fromlist=['core']).__file__).read_text()
-        forbidden = (
-            r'\bTrust\b',
-            r'\bContent\b',
-            r'\bJunction\b',
-            r'\bTrustUserPermission\b',
-            r'\bTrustGroupPermission\b',
-            r'\bGroup\b',
-            r'\bRole\b',
+    def test_core_module_has_no_historical_import_or_global(self):
+        import trusts.core as core
+
+        forbidden = {
+            'Trust',
+            'Content',
+            'Junction',
+            'TrustUserPermission',
+            'TrustGroupPermission',
+            'Group',
+            'Role',
+        }
+        self.assertFalse(forbidden.intersection(vars(core)))
+
+        imported = {
+            value.__name__
+            for value in vars(core).values()
+            if isinstance(value, types.ModuleType)
+        }
+        self.assertTrue(
+            all(
+                name == 'trusts.core' or not name.startswith('trusts.')
+                for name in imported
+            ),
+            imported,
         )
-        for pattern in forbidden:
-            self.assertIsNone(
-                re.search(pattern, source),
-                'trusts/core.py must not name %s' % pattern,
-            )
+        for value in vars(core).values():
+            module = getattr(value, '__module__', None)
+            if isinstance(module, str):
+                self.assertFalse(
+                    module.startswith('trusts.') and module != 'trusts.core',
+                    module,
+                )
 
     def test_instances_are_isolated(self):
         left = self._registry()

--- a/trusts/test_issue65.py
+++ b/trusts/test_issue65.py
@@ -4,9 +4,8 @@ Isolated Folder / Document / FolderGrant mocks only. No historical Trusts
 types, backends, managers, or queryset readers.
 """
 
-import re
+import types
 from contextlib import contextmanager
-from pathlib import Path
 from unittest.mock import patch
 
 from django.conf import settings
@@ -388,22 +387,39 @@ class TrustsRegistrySameRootRegistrationTest(SimpleTestCase):
         self.assertIsNone(getattr(trusts, 'TrustsRegistry', None))
         self.assertIsNone(getattr(trusts, 'RelationPlan', None))
 
-    def test_core_module_does_not_name_historical_types(self):
-        source = Path(__import__('trusts.core', fromlist=['core']).__file__).read_text()
-        forbidden = (
-            r'\bTrust\b',
-            r'\bContent\b',
-            r'\bJunction\b',
-            r'\bTrustUserPermission\b',
-            r'\bTrustGroupPermission\b',
-            r'\bGroup\b',
-            r'\bRole\b',
+    def test_core_module_has_no_historical_import_or_global(self):
+        import trusts.core as core
+
+        forbidden = {
+            'Trust',
+            'Content',
+            'Junction',
+            'TrustUserPermission',
+            'TrustGroupPermission',
+            'Group',
+            'Role',
+        }
+        self.assertFalse(forbidden.intersection(vars(core)))
+
+        imported = {
+            value.__name__
+            for value in vars(core).values()
+            if isinstance(value, types.ModuleType)
+        }
+        self.assertTrue(
+            all(
+                name == 'trusts.core' or not name.startswith('trusts.')
+                for name in imported
+            ),
+            imported,
         )
-        for pattern in forbidden:
-            self.assertIsNone(
-                re.search(pattern, source),
-                'trusts/core.py must not name %s' % pattern,
-            )
+        for value in vars(core).values():
+            module = getattr(value, '__module__', None)
+            if isinstance(module, str):
+                self.assertFalse(
+                    module.startswith('trusts.') and module != 'trusts.core',
+                    module,
+                )
 
 
 @isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')

--- a/trusts/test_issue65.py
+++ b/trusts/test_issue65.py
@@ -1,0 +1,795 @@
+"""Same-root registrations and trailing-reverse content paths (issue #65).
+
+Isolated Folder / Document / FolderGrant mocks only. No historical Trusts
+types, backends, managers, or queryset readers.
+"""
+
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection, models
+from django.db.models import ForeignObject, Q
+from django.db.models.query import QuerySet
+from django.test import SimpleTestCase, TransactionTestCase
+from django.test.utils import isolate_apps
+
+from trusts.core import (
+    Ref,
+    RelationPlan,
+    TrustsConfigurationError,
+    TrustsRegistry,
+)
+
+
+def _folder_models():
+    """FolderGrant.folder → Folder ← Document.folder (documents reverse)."""
+
+    class Folder(models.Model):
+        title = models.CharField(max_length=200)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    class Document(models.Model):
+        folder = models.ForeignKey(
+            Folder, related_name='documents', on_delete=models.CASCADE,
+        )
+        alt_folder = models.ForeignKey(
+            Folder, related_name='alt_documents', on_delete=models.CASCADE,
+        )
+        title = models.CharField(max_length=200)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    User = get_user_model()
+
+    class FolderGrant(models.Model):
+        folder = models.ForeignKey(Folder, on_delete=models.CASCADE)
+        user = models.ForeignKey(User, on_delete=models.CASCADE)
+        permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    class DocumentPermit(models.Model):
+        document = models.ForeignKey(Document, on_delete=models.CASCADE)
+        user = models.ForeignKey(User, on_delete=models.CASCADE)
+        permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    return Folder, Document, FolderGrant, DocumentPermit
+
+
+def _register_folder_paths(registry, FolderGrant):
+    j = Ref(FolderGrant)
+    folder_rec = registry.register(
+        content=j.folder, user=j.user, permission=j.permission,
+    )
+    document_rec = registry.register(
+        content=j.folder.documents, user=j.user, permission=j.permission,
+    )
+    return folder_rec, document_rec
+
+
+@contextmanager
+def _tables(*model_classes):
+    with connection.schema_editor() as editor:
+        for model in model_classes:
+            editor.create_model(model)
+    try:
+        yield
+    finally:
+        with connection.schema_editor() as editor:
+            for model in reversed(model_classes):
+                editor.delete_model(model)
+
+
+def _perm(codename):
+    ct, _created = ContentType.objects.get_or_create(
+        app_label='trusts_tests', model='document',
+    )
+    permission, _created = Permission.objects.get_or_create(
+        content_type=ct,
+        codename=codename,
+        defaults={'name': codename},
+    )
+    return permission
+
+
+def _pks(rows):
+    return {row.pk for row in rows}
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class TrustsRegistrySameRootRegistrationTest(SimpleTestCase):
+    def test_same_root_different_content_terminals_are_stored_in_order(self):
+        Folder, Document, FolderGrant, _permit = _folder_models()
+        registry = TrustsRegistry()
+        folder_rec, document_rec = _register_folder_paths(registry, FolderGrant)
+
+        self.assertEqual(folder_rec.content_path, ('folder',))
+        self.assertEqual(folder_rec.content_field, 'folder')
+        self.assertIs(folder_rec.content_model, Folder)
+        self.assertEqual(folder_rec.content_target, Folder._meta.pk.attname)
+
+        self.assertEqual(document_rec.content_path, ('folder', 'documents'))
+        self.assertEqual(document_rec.content_field, 'folder__documents')
+        self.assertIs(document_rec.content_model, Document)
+        self.assertEqual(document_rec.content_target, Document._meta.pk.attname)
+
+        self.assertEqual(registry.records, (folder_rec, document_rec))
+        self.assertEqual(
+            registry.records_for_root(FolderGrant),
+            (folder_rec, document_rec),
+        )
+        plan_folder = registry.plan_for(Folder)
+        plan_document = registry.plan_for(Document)
+        self.assertEqual(plan_folder.records, (folder_rec,))
+        self.assertEqual(plan_document.records, (document_rec,))
+
+    def test_records_for_root_raises_when_absent(self):
+        Folder, _document, FolderGrant, DocumentPermit = _folder_models()
+        registry = TrustsRegistry()
+        with self.assertRaisesRegex(TrustsConfigurationError, r'No registration'):
+            registry.records_for_root(FolderGrant)
+        j = Ref(FolderGrant)
+        registry.register(content=j.folder, user=j.user, permission=j.permission)
+        with self.assertRaisesRegex(TrustsConfigurationError, r'No registration'):
+            registry.records_for_root(DocumentPermit)
+        self.assertFalse(hasattr(registry, 'get'))
+
+    def test_global_insertion_order_with_interleaved_roots(self):
+        Folder, Document, FolderGrant, DocumentPermit = _folder_models()
+        registry = TrustsRegistry()
+        j = Ref(FolderGrant)
+        k = Ref(DocumentPermit)
+        first = registry.register(
+            content=j.folder, user=j.user, permission=j.permission,
+        )
+        second = registry.register(
+            content=k.document, user=k.user, permission=k.permission,
+        )
+        third = registry.register(
+            content=j.folder.documents, user=j.user, permission=j.permission,
+        )
+        self.assertEqual(registry.records, (first, second, third))
+        self.assertEqual(registry.records_for_root(FolderGrant), (first, third))
+        self.assertEqual(registry.records_for_root(DocumentPermit), (second,))
+        self.assertEqual(registry.plan_for(Document).records, (second, third))
+
+    def test_exact_duplicate_raises_without_mutating_records(self):
+        _folder, _document, FolderGrant, _permit = _folder_models()
+        registry = TrustsRegistry()
+        first, second = _register_folder_paths(registry, FolderGrant)
+        stored = registry.records
+        j = Ref(FolderGrant)
+        with self.assertRaisesRegex(TrustsConfigurationError, r'Duplicate'):
+            registry.register(
+                content=j.folder, user=j.user, permission=j.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'Duplicate'):
+            registry.register(
+                content=j.folder.documents, user=j.user, permission=j.permission,
+            )
+        self.assertEqual(registry.records, stored)
+        self.assertEqual(registry.records, (first, second))
+
+    def test_same_root_same_content_terminal_is_conflict(self):
+        _folder, _document, FolderGrant, _permit = _folder_models()
+        registry = TrustsRegistry()
+        first, second = _register_folder_paths(registry, FolderGrant)
+        j = Ref(FolderGrant)
+        with self.assertRaisesRegex(TrustsConfigurationError, r'Conflicting'):
+            registry.register(
+                content=j.folder.alt_documents,
+                user=j.user,
+                permission=j.permission,
+            )
+        self.assertEqual(registry.records, (first, second))
+        self.assertEqual(second.content_path, ('folder', 'documents'))
+
+    def test_unsupported_shapes_fail_during_registration_without_sql(self):
+        Folder, Document, FolderGrant, _permit = _folder_models()
+
+        class Tag(models.Model):
+            name = models.CharField(max_length=20)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Owner(models.Model):
+            name = models.CharField(max_length=20)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class FolderExtra(models.Model):
+            title = models.CharField(max_length=40)
+            owner = models.ForeignKey(Owner, on_delete=models.CASCADE)
+            tags = models.ManyToManyField(Tag)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Profile(models.Model):
+            folder = models.OneToOneField(
+                FolderExtra, related_name='profile', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class ExtraGrant(models.Model):
+            folder = models.ForeignKey(FolderExtra, on_delete=models.CASCADE)
+            user = models.ForeignKey(
+                settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+            )
+            permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+            tags = models.ManyToManyField(Tag)
+            content_type = models.ForeignKey(
+                ContentType, on_delete=models.CASCADE,
+            )
+            object_id = models.PositiveIntegerField()
+            target = GenericForeignKey('content_type', 'object_id')
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class ExtraNote(models.Model):
+            grant = models.ForeignKey(
+                ExtraGrant, related_name='notes', on_delete=models.CASCADE,
+            )
+            title = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Pair(models.Model):
+            left = models.IntegerField()
+            right = models.IntegerField()
+
+            class Meta:
+                app_label = 'trusts_tests'
+                unique_together = ('left', 'right')
+
+        class PairGrant(models.Model):
+            left = models.IntegerField()
+            right = models.IntegerField()
+            pair = ForeignObject(
+                Pair,
+                on_delete=models.CASCADE,
+                from_fields=('left', 'right'),
+                to_fields=('left', 'right'),
+                related_name='grants',
+            )
+            user = models.ForeignKey(
+                settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+            )
+            permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        registry = TrustsRegistry()
+        j = Ref(FolderGrant)
+        extra = Ref(ExtraGrant)
+        pair = Ref(PairGrant)
+
+        with self.assertRaisesRegex(TrustsConfigurationError, r'reverse'):
+            registry.register(
+                content=extra.notes,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'before the final hop'):
+            registry.register(
+                content=j.folder.documents.alt_folder,
+                user=j.user,
+                permission=j.permission,
+            )
+        with self.assertRaisesRegex(
+            TrustsConfigurationError, r'reverse one-to-one',
+        ):
+            registry.register(
+                content=extra.folder.profile,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'multi-valued'):
+            registry.register(
+                content=extra.tags,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'multi-valued'):
+            registry.register(
+                content=extra.folder.tags,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(
+            TrustsConfigurationError, r'generic foreign key',
+        ):
+            registry.register(
+                content=extra.target,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'before the final hop'):
+            registry.register(
+                content=j.folder.documents.title,
+                user=j.user,
+                permission=j.permission,
+            )
+        with self.assertRaisesRegex(
+            TrustsConfigurationError, r'forward path ending',
+        ):
+            registry.register(
+                content=extra.folder.owner,
+                user=extra.user,
+                permission=extra.permission,
+            )
+        with self.assertRaisesRegex(
+            TrustsConfigurationError, r'composite|target fields',
+        ):
+            registry.register(
+                content=pair.pair,
+                user=pair.user,
+                permission=pair.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'direct'):
+            registry.register(
+                content=extra.folder,
+                user=extra.folder.owner,
+                permission=extra.permission,
+            )
+        self.assertEqual(registry.records, ())
+
+    def test_user_and_permission_remain_direct_single_valued(self):
+        _folder, _document, FolderGrant, _permit = _folder_models()
+        registry = TrustsRegistry()
+        j = Ref(FolderGrant)
+        with self.assertRaisesRegex(TrustsConfigurationError, r'direct|reverse'):
+            registry.register(
+                content=j.folder,
+                user=j.folder.documents,
+                permission=j.permission,
+            )
+        with self.assertRaisesRegex(TrustsConfigurationError, r'direct|reverse'):
+            registry.register(
+                content=j.folder,
+                user=j.user,
+                permission=j.folder.documents,
+            )
+        self.assertEqual(registry.records, ())
+
+    def test_no_historical_model_is_required(self):
+        Folder, Document, FolderGrant, DocumentPermit = _folder_models()
+        for model in (Folder, Document, FolderGrant, DocumentPermit):
+            names = {cls.__name__ for cls in model.__mro__}
+            self.assertNotIn('Trust', names)
+            self.assertNotIn('Content', names)
+            self.assertNotIn('Junction', names)
+        self.assertEqual(FolderGrant.__module__, __name__)
+        self.assertEqual(Document.__module__, __name__)
+
+    def test_package_surface_does_not_reexport_registry(self):
+        import trusts
+        self.assertIsNone(getattr(trusts, 'TrustsRegistry', None))
+        self.assertIsNone(getattr(trusts, 'RelationPlan', None))
+
+    def test_core_module_does_not_name_historical_types(self):
+        source = Path(__import__('trusts.core', fromlist=['core']).__file__).read_text()
+        forbidden = (
+            r'\bTrust\b',
+            r'\bContent\b',
+            r'\bJunction\b',
+            r'\bTrustUserPermission\b',
+            r'\bTrustGroupPermission\b',
+            r'\bGroup\b',
+            r'\bRole\b',
+        )
+        for pattern in forbidden:
+            self.assertIsNone(
+                re.search(pattern, source),
+                'trusts/core.py must not name %s' % pattern,
+            )
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class TrustsRegistryTrailingReverseProjectionTest(TransactionTestCase):
+    def setUp(self):
+        (
+            self.Folder,
+            self.Document,
+            self.FolderGrant,
+            self.DocumentPermit,
+        ) = _folder_models()
+        self._table_cm = _tables(
+            self.Folder,
+            self.Document,
+            self.FolderGrant,
+            self.DocumentPermit,
+        )
+        self._table_cm.__enter__()
+        User = get_user_model()
+        self.alice = User.objects.create_user(username='alice', password='x')
+        self.bob = User.objects.create_user(username='bob', password='x')
+        self.read = _perm('read_document')
+        self.write = _perm('write_document')
+        self.folder_a = self.Folder.objects.create(title='A')
+        self.folder_b = self.Folder.objects.create(title='B')
+        self.doc_a1 = self.Document.objects.create(
+            folder=self.folder_a, alt_folder=self.folder_b, title='A1',
+        )
+        self.doc_a2 = self.Document.objects.create(
+            folder=self.folder_a, alt_folder=self.folder_b, title='A2',
+        )
+        self.doc_b1 = self.Document.objects.create(
+            folder=self.folder_b, alt_folder=self.folder_a, title='B1',
+        )
+        self.registry = TrustsRegistry()
+        self.folder_rec, self.document_rec = _register_folder_paths(
+            self.registry, self.FolderGrant,
+        )
+
+    def tearDown(self):
+        self._table_cm.__exit__(None, None, None)
+
+    def test_grant_authorizes_matching_documents_and_denies_unrelated(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        self.FolderGrant.objects.create(
+            folder=self.folder_b, user=self.bob, permission=self.write,
+        )
+
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.folder_a)),
+            {self.read.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.doc_a1)),
+            {self.read.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.doc_a2)),
+            {self.read.pk},
+        )
+        self.assertEqual(
+            list(self.registry.permissions_for(self.alice, self.doc_b1)),
+            [],
+        )
+        self.assertEqual(
+            list(self.registry.permissions_for(self.alice, self.folder_b)),
+            [],
+        )
+        self.assertTrue(
+            self.registry.has_permission(self.alice, self.folder_a, self.read),
+        )
+        self.assertTrue(
+            self.registry.has_permission(self.alice, self.doc_a1, self.read),
+        )
+        self.assertTrue(
+            self.registry.has_permission(self.alice, self.doc_a2, self.read),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.alice, self.doc_b1, self.read),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.alice, self.doc_a1, self.write),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.bob, self.doc_a1, self.read),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.bob, self.folder_a, self.read),
+        )
+        self.assertTrue(
+            self.registry.has_permission(self.bob, self.doc_b1, self.write),
+        )
+
+    def test_three_projections_agree_for_folder_and_document(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        self.FolderGrant.objects.create(
+            folder=self.folder_b, user=self.alice, permission=self.write,
+        )
+
+        expected_folders = [
+            folder for folder in self.Folder.objects.order_by('pk')
+            if self.registry.has_permission(self.alice, folder, self.read)
+        ]
+        expected_docs = [
+            document for document in self.Document.objects.order_by('pk')
+            if self.registry.has_permission(self.alice, document, self.read)
+        ]
+        folder_qs = self.registry.filter_authorized(
+            self.Folder.objects.order_by('pk'), self.alice, self.read,
+        )
+        document_qs = self.registry.filter_authorized(
+            self.Document.objects.order_by('pk'), self.alice, self.read,
+        )
+        self.assertEqual(expected_folders, [self.folder_a])
+        self.assertEqual(expected_docs, [self.doc_a1, self.doc_a2])
+        with self.assertNumQueries(1):
+            self.assertEqual(list(folder_qs), expected_folders)
+        with self.assertNumQueries(1):
+            self.assertEqual(list(document_qs), expected_docs)
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.folder_a)),
+            {self.read.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.doc_a1)),
+            {self.read.pk},
+        )
+        self.assertNotIn(
+            self.write.pk,
+            _pks(self.registry.permissions_for(self.alice, self.doc_a1)),
+        )
+
+    def test_authorized_content_is_lazy_set_based_and_one_query(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        with self.assertNumQueries(0):
+            qs = self.registry.filter_authorized(
+                self.Document.objects.all(), self.alice, self.read,
+            )
+            plan = self.registry.plan_for(
+                self.Document.objects.all(),
+                user=self.alice,
+                permission=self.read,
+            )
+            enumerated = self.registry.permissions_for(self.alice, self.doc_a1)
+            exists = plan.content_exists(self.alice, self.read)
+        self.assertIsInstance(qs, QuerySet)
+        self.assertIsInstance(plan, RelationPlan)
+        self.assertIsInstance(enumerated, QuerySet)
+        self.assertIsNotNone(exists)
+        with self.assertNumQueries(1):
+            self.assertEqual(_pks(qs), {self.doc_a1.pk, self.doc_a2.pk})
+        page = self.registry.filter_authorized(
+            self.Document.objects.order_by('pk'), self.alice, self.read,
+        )[:1]
+        with self.assertNumQueries(1):
+            self.assertEqual(list(page), [self.doc_a1])
+
+    def test_filter_authorized_consumes_content_exists(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        plan = self.registry.plan_for(
+            self.Document.objects.all(),
+            user=self.alice,
+            permission=self.read,
+        )
+        with patch.object(RelationPlan, 'content_exists', wraps=plan.content_exists) as exists:
+            list(plan.filter_content(
+                self.Document.objects.all(), self.alice, self.read,
+            ))
+        self.assertEqual(exists.call_count, 1)
+
+        terminals = []
+        original = RelationPlan._correlated_exists
+
+        def spy(self, terminal_field_attr, **bindings):
+            terminals.append(terminal_field_attr)
+            return original(self, terminal_field_attr, **bindings)
+
+        with patch.object(RelationPlan, '_correlated_exists', spy):
+            list(plan.permissions(self.alice, self.doc_a1))
+            plan.has_permission(self.alice, self.doc_a1, self.read)
+            list(plan.filter_content(
+                self.Document.objects.all(), self.alice, self.read,
+            ))
+        self.assertEqual(
+            terminals,
+            ['permission_field', 'permission_field', 'content_field'],
+        )
+
+    def test_content_exists_ors_on_the_original_candidate_queryset(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        plan = self.registry.plan_for(
+            self.Document, user=self.alice, permission=self.read,
+        )
+        exists = plan.content_exists(self.alice, self.read)
+        # Stand-in for a later reader OR-ing another predicate on the
+        # original candidate queryset (must not filter-then-OR).
+        combined = self.Document.objects.order_by('pk').filter(
+            Q(exists) | Q(pk=self.doc_b1.pk),
+        )
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                list(combined),
+                [self.doc_a1, self.doc_a2, self.doc_b1],
+            )
+        trustee_only = self.registry.filter_authorized(
+            self.Document.objects.order_by('pk'), self.alice, self.read,
+        )
+        self.assertEqual(list(trustee_only), [self.doc_a1, self.doc_a2])
+
+    def test_second_root_ors_for_the_same_document_terminal(self):
+        j = Ref(self.DocumentPermit)
+        self.registry.register(
+            content=j.document, user=j.user, permission=j.permission,
+        )
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        self.DocumentPermit.objects.create(
+            document=self.doc_b1, user=self.alice, permission=self.write,
+        )
+
+        self.assertTrue(
+            self.registry.has_permission(self.alice, self.doc_a1, self.read),
+        )
+        self.assertTrue(
+            self.registry.has_permission(self.alice, self.doc_b1, self.write),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.alice, self.doc_a1, self.write),
+        )
+        self.assertEqual(
+            _pks(self.registry.filter_authorized(
+                self.Document.objects.all(), self.alice, self.read,
+            )),
+            {self.doc_a1.pk, self.doc_a2.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.filter_authorized(
+                self.Document.objects.all(), self.alice, self.write,
+            )),
+            {self.doc_b1.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.doc_a1)),
+            {self.read.pk},
+        )
+        self.assertEqual(
+            _pks(self.registry.permissions_for(self.alice, self.doc_b1)),
+            {self.write.pk},
+        )
+        sql = str(self.registry.filter_authorized(
+            self.Document.objects.all(), self.alice, self.read,
+        ).query).upper()
+        self.assertIn('EXISTS', sql)
+        self.assertIn(' OR ', sql)
+
+    def test_shared_row_correlation_does_not_combine_split_facts(self):
+        self.FolderGrant.objects.create(
+            folder=self.folder_a, user=self.alice, permission=self.read,
+        )
+        self.FolderGrant.objects.create(
+            folder=self.folder_b, user=self.alice, permission=self.write,
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.alice, self.doc_a1, self.write),
+        )
+        self.assertFalse(
+            self.registry.has_permission(self.alice, self.doc_b1, self.read),
+        )
+        self.assertEqual(
+            _pks(self.registry.filter_authorized(
+                self.Document.objects.all(), self.alice, self.write,
+            )),
+            {self.doc_b1.pk},
+        )
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class TrustsRegistryToFieldHopTest(TransactionTestCase):
+    def test_to_field_on_forward_hop_retains_correlation(self):
+        User = get_user_model()
+
+        class CodedFolder(models.Model):
+            code = models.SlugField(unique=True)
+            title = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class CodedDocument(models.Model):
+            folder = models.ForeignKey(
+                CodedFolder, related_name='documents', on_delete=models.CASCADE,
+            )
+            title = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class CodedGrant(models.Model):
+            folder = models.ForeignKey(
+                CodedFolder, to_field='code', on_delete=models.CASCADE,
+            )
+            user = models.ForeignKey(User, on_delete=models.CASCADE)
+            permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        with _tables(CodedFolder, CodedDocument, CodedGrant):
+            registry = TrustsRegistry()
+            j = Ref(CodedGrant)
+            folder_rec = registry.register(
+                content=j.folder, user=j.user, permission=j.permission,
+            )
+            document_rec = registry.register(
+                content=j.folder.documents, user=j.user, permission=j.permission,
+            )
+            self.assertEqual(folder_rec.content_target, 'code')
+            self.assertEqual(document_rec.content_field, 'folder__documents')
+            self.assertEqual(
+                document_rec.content_target, CodedDocument._meta.pk.attname,
+            )
+            self.assertNotEqual(document_rec.content_target, 'code')
+
+            alice = User.objects.create_user(username='alice-tf', password='x')
+            bob = User.objects.create_user(username='bob-tf', password='x')
+            read = _perm('read_coded')
+            write = _perm('write_coded')
+            folder_alpha = CodedFolder.objects.create(code='alpha', title='A')
+            folder_beta = CodedFolder.objects.create(code='beta', title='B')
+            self.assertNotEqual(folder_alpha.pk, 'alpha')
+            doc_a1 = CodedDocument.objects.create(folder=folder_alpha, title='A1')
+            doc_a2 = CodedDocument.objects.create(folder=folder_alpha, title='A2')
+            doc_b1 = CodedDocument.objects.create(folder=folder_beta, title='B1')
+            CodedGrant.objects.create(
+                folder=folder_alpha, user=alice, permission=read,
+            )
+
+            self.assertEqual(
+                _pks(registry.permissions_for(alice, folder_alpha)),
+                {read.pk},
+            )
+            self.assertEqual(
+                list(registry.permissions_for(alice, folder_beta)),
+                [],
+            )
+            self.assertTrue(registry.has_permission(alice, folder_alpha, read))
+            self.assertFalse(registry.has_permission(alice, folder_beta, read))
+            self.assertTrue(registry.has_permission(alice, doc_a1, read))
+            self.assertTrue(registry.has_permission(alice, doc_a2, read))
+            self.assertFalse(registry.has_permission(alice, doc_b1, read))
+            self.assertFalse(registry.has_permission(bob, doc_a1, read))
+            self.assertFalse(registry.has_permission(alice, doc_a1, write))
+
+            folder_sql = str(registry.filter_authorized(
+                CodedFolder.objects.order_by('pk'), alice, read,
+            ).query).lower()
+            self.assertIn('exists', folder_sql)
+            self.assertIn('code', folder_sql)
+            document_sql = str(registry.filter_authorized(
+                CodedDocument.objects.order_by('pk'), alice, read,
+            ).query).lower()
+            self.assertIn('exists', document_sql)
+            self.assertIn('folder', document_sql)
+
+            with self.assertNumQueries(1):
+                self.assertEqual(
+                    list(registry.filter_authorized(
+                        CodedFolder.objects.order_by('pk'), alice, read,
+                    )),
+                    [folder_alpha],
+                )
+            with self.assertNumQueries(1):
+                self.assertEqual(
+                    list(registry.filter_authorized(
+                        CodedDocument.objects.order_by('pk'), alice, read,
+                    )),
+                    [doc_a1, doc_a2],
+                )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #65. Parent #56 / historical checkpoint #62. Predecessor #64 / PR #63, merged to `dev` as `dd7d1395389920db22d3c3584a25c3ddccd4b140`.

Sole implementation baton for the generic Child G slice. Branched from current `dev`. This PR head: `4bc7c321e6d36f920ce8693e45f5eec8acae857f`.

## Changes

1. **Same-root registrations.** `_by_root[root]` is an insertion-ordered list. `records_for_root(root)` returns that tuple and raises when absent. `get(root)` is removed. Exact duplicates raise without mutating stored records. Same root plus the same content terminal with a different registration is an explicit conflict. Same root plus different content terminals is allowed. `registry.records` stays global insertion order. `plan_for` still selects by content/user/permission terminal; multiple applicable records still SQL `OR`.

2. **Bounded content path.** Direct single-valued content remains. Additionally: `(forward single-valued)+` then exactly one final reverse one-to-many. User and permission stay direct. Every hop is resolved with `_meta.get_field` + `get_path_info()`: exactly one `PathInfo` and exactly one target field, or the path is rejected. Stored `*_field` is the full `'__'.join(path)` lookup; `*_target` is the last hop's target `attname`. `#64` `to_field` behavior is retained. String-related models (isolated `AUTH_USER_MODEL`) are materialized through the app registry before path info (zero SQL).

3. **One content-Exists surface.** `RelationPlan.content_exists(user, permission)` is the shared content-correlation predicate. `filter_content` / `filter_authorized` consume it. A later reader can OR that predicate with another predicate on the original candidate queryset.

Rejected at `register` (zero SQL): reverse before the final hop; reverse as the only hop; reverse one-to-one; M2M; GFK; anything after the final reverse; multi-hop all-forward content; arbitrary multi-valued chains; composite / multi-column correlation.

## Review follow-up

Replaced `test_core_module_does_not_name_historical_types` (raw `core.py` regex scan) with `test_core_module_has_no_historical_import_or_global`: module globals, imported module names, and bound-object `__module__` must stay off historical `trusts.*` surfaces. Isolated-model MRO proof is unchanged. Unused `Path` / `re` imports removed. Same replacement in the #57 / #60 copies so a comment cannot trip a source-text scan.

## Mock proof

Isolated `FolderGrant.folder → Folder ← Document.folder` (`documents` reverse). One `FolderGrant` root registers both `j.folder` and `j.folder.documents`. A second independent `DocumentPermit` root still ORs onto Document.

## Docs

`docs/core-registry.md` records one-record/direct vs same-root/trailing-reverse, unsupported shapes, and `content_exists`. `migrates.md` §30 records the development-API change. Version stays **1.0.0.dev0**. No schema or Django migration.

## Scope

`trusts/core.py`, `trusts/test_issue57.py`, `trusts/test_issue60.py`, `trusts/test_issue65.py`, `docs/core-registry.md`, `migrates.md` §30. Isolated `TrustsRegistry` only. No process-global or package-owned registry. No package-root re-export. No historical types in `trusts/core.py` or the new tests. Historical models, signals, backends, managers, queryset readers, conditions, mutations, migrations, Zero, examples, Windows ACL, and GH consumers are untouched. Child H / registry lifecycle / reader migration not started.

## Test results

Local, Python 3.12.3 / Django 6.1.1, HEAD `4bc7c321e6d36f920ce8693e45f5eec8acae857f`:

| Check | Result |
| --- | --- |
| `trusts.test_issue65` | 18 tests OK |
| `trusts.test_issue57` | 19 tests OK |
| `trusts.test_issue60` | 20 tests OK |
| focused `#65` + `#57` + `#60` | 57 tests OK |
| `python -m tests.runtests` | 216 tests OK (1 expected failure, historical) |
| `python -m django check --settings=tests.settings` | OK (1 silenced) |
| Trusts migrations | unchanged `{0001_initial, 0002_trustgroup}` |

GitHub Actions on the same HEAD `4bc7c321e6d36f920ce8693e45f5eec8acae857f` (all 4 checks green):

| Check | Result |
| --- | --- |
| tests (Python 3.12) | success |
| tests (Python 3.13) | success |
| tests (Python 3.14) | success |
| package | success |

No authorization result changes. No database schema or migration changes. Historical-model migration not started.

r? @chatforthomas
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5d05256-7908-4d09-9e9f-20d392e9fd2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5d05256-7908-4d09-9e9f-20d392e9fd2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

