### PR TITLE
S8: freeze live registries and report detectable missing declarations (#89)

### DIFF
--- a/docs/core-registry.md
+++ b/docs/core-registry.md
@@ -127,10 +127,13 @@ Supported live access is the AppConfig handle API:
 on first read once **that AppConfig's `self.apps.ready`** is true (after
 `Apps.populate`, not during contributor `ready()`). A newly observed
 configured path is frozen before the handle is returned, so a settings
-change cannot expose a writable late registry. Frozen
-`register()` raises `TrustsConfigurationError` before validation or
-mutation; existing records, plans, compilers, and authorization reads
-stay usable.
+change cannot expose a writable late registry. After readiness, the
+`registry` setter also freezes the replacement before storing it, so a
+caller-held reference cannot mutate the live store. Assignment before
+ready stays writable for contributor setup and freezes on the first
+supported post-populate read. Frozen `register()` raises
+`TrustsConfigurationError` before validation or mutation; existing
+records, plans, compilers, and authorization reads stay usable.
 
 Isolated `TrustsRegistry()` instances are a different surface. They do
 not inspect Django's global readiness, never auto-freeze, and stay

--- a/docs/core-registry.md
+++ b/docs/core-registry.md
@@ -119,11 +119,35 @@ The live store is `trusts.apps.AppConfig.registries[path]`, one
 `TrustsRegistry` per configured Trusts-derived `AUTHENTICATION_BACKENDS`
 path. `ready()` does not replace the store or an existing registry
 object. With one Trusts path, `config.registry` is a compatibility alias
-of that exact object. Isolated tests still construct their own
-`TrustsRegistry()`. External applications contribute declarations in
-their own `AppConfig.ready()` through `configured_backend()` (an exact
-path is required when several Trusts backends are listed). Trusts does
-not import or discover `tests.Category`.
+of that exact object.
+
+Supported live access is the AppConfig handle API:
+`configured_backend(path)`, `configured_handles()`, and the one-path
+`registry` alias. Each surface returns the stored object and freezes it
+on first read once **that AppConfig's `self.apps.ready`** is true (after
+`Apps.populate`, not during contributor `ready()`). A newly observed
+configured path is frozen before the handle is returned, so a settings
+change cannot expose a writable late registry. Frozen
+`register()` raises `TrustsConfigurationError` before validation or
+mutation; existing records, plans, compilers, and authorization reads
+stay usable.
+
+Isolated `TrustsRegistry()` instances are a different surface. They do
+not inspect Django's global readiness, never auto-freeze, and stay
+writable after `apps.ready` unless the owner calls `freeze()`. Internal
+tests may swap a standalone instance into the live store for isolation;
+hosts must not treat `registries[path]` as a contributor route. External
+applications contribute declarations in their own `AppConfig.ready()`
+through `configured_backend()` (an exact path is required when several
+Trusts backends are listed). Trusts does not import or discover
+`tests.Category`.
+
+`trusts.E003` reports already-loaded concrete, non-proxy, non-abstract
+`Content` subclasses and `Junction` subclasses whose
+`get_content_model()` has no covering record on any valid configured
+handle. Coverage on one handle is enough. Manual dependents that are
+neither Content nor Junction are outside E003 and fail closed at
+runtime. The check issues zero SQL and does not register.
 
 `ContentQuerySet.permitted` is a thin aggregate caller. It ORs each
 applicable handle compiler's complete predicate (`trusts.core.granted`)

--- a/migrates.md
+++ b/migrates.md
@@ -1802,7 +1802,7 @@ creates authorization.
 | | |
 | --- | --- |
 | Previous | Live AppConfig-owned path-scoped registries stayed writable for the process lifetime. A late `register()` after `Apps.populate` could still mutate authorization plans. Isolated `TrustsRegistry()` instances were already independent. |
-| New | `TrustsRegistry.freeze()` / `.frozen` are instance-owned. Supported live handle reads freeze the stored object once that AppConfig's `self.apps.ready` is true. `register()` on that frozen instance raises `TrustsConfigurationError` before validation or mutation and leaves records unchanged. Standalone `TrustsRegistry()` instances stay writable unless explicitly frozen. |
+| New | `TrustsRegistry.freeze()` / `.frozen` are instance-owned. Supported live handle reads freeze the stored object once that AppConfig's `self.apps.ready` is true. The one-path `registry` setter freezes a replacement before storing it after readiness, so a caller-held reference cannot mutate late. Assignment before ready stays writable and freezes on the first supported post-populate read. `register()` on that frozen instance raises `TrustsConfigurationError` before validation or mutation and leaves records unchanged. Standalone `TrustsRegistry()` instances stay writable unless explicitly frozen. |
 | Replacement | Hosts contribute from their own `AppConfig.ready()` through `configured_backend()` / `configured_handles()` / the one-path `registry` alias. Do not use `registries[path]` as a contributor route. |
 | Affected | Late `register()` after populate. Existing declared terminals keep the same authorization results. |
 | Authorization | Frozen plans still project. Undeclared terminals stay false / empty / none. A late write cannot add authorization after freeze. |

--- a/migrates.md
+++ b/migrates.md
@@ -1733,6 +1733,135 @@ projections remain **1 SQL**, independent of candidate count.
   redesign; #54
 - Zero; GH; example #7; Windows #17
 
+---
+
+# Freeze live registries and report detectable missing declarations (issue #89 / S8)
+
+This record covers the S8 freeze of AppConfig-owned path-scoped
+registries and the `trusts.E003` missing-declaration check. Version
+remains **1.0.0.dev0**. It closes the #89 / #69 r2 S8 slice, the final
+#69 implementation slice. Standalone `TrustsRegistry()` instances stay
+independent. There is **no schema or Django migration change**.
+
+Parent design: #69 r2 (accepted). Predecessor #87 / PR #88 merged to
+`dev` as `df9b51858047566574f378c3df2b648fb386fd4e`.
+
+## Decision
+
+Live AppConfig-owned registries freeze after Django application
+population so authorization plans cannot mutate late. Freeze is
+instance-owned (`TrustsRegistry.freeze()` / `.frozen`).
+`register()` on that exact frozen instance raises
+`TrustsConfigurationError` before validation or mutation. Existing
+records, plans, compilers, and authorization reads stay usable.
+
+A standalone `TrustsRegistry()` does not inspect Django's global
+readiness and never auto-freezes. It stays writable after global
+`apps.ready` unless its owner calls `freeze()`. Frozen state is not
+process-global, class-global, inferred from Django's global
+`apps.ready`, or shared across registry objects.
+
+Freeze is owned by `trusts.apps.AppConfig` for the existing objects in
+its path-scoped `registries` store. `ready()` does not replace those
+objects. Every supported live access surface —
+`configured_backend(path)`, `configured_handles()`, and the one-path
+`registry` alias — returns the same stored object and freezes it on
+first read when **that AppConfig's `self.apps.ready`** is true. During
+`Apps.populate`, external contributors run in their own `ready()` while
+that Apps instance is not yet ready, so declarations remain writable
+regardless of `INSTALLED_APPS` order. After population, a newly
+ensured/configured live path is frozen before exposure.
+
+Re-entering a package or host contributor after freeze is a sentinel
+no-op when that contributor already donated to the exact registry. A
+genuinely new, failed, or partial late contribution raises.
+
+`trusts.E003` reports structurally detectable missing Content/Junction
+declarations from already-loaded models. It does not import host
+modules, does not infer manual dependents, and issues **0 SQL**.
+Undeclared manual dependents continue to fail closed at runtime with no
+E003 row. Silencing E003 suppresses only the early diagnostic and never
+creates authorization.
+
+## No change to these public call sites
+
+- `User.has_perm` / `User.has_perms` / `get_all_permissions` /
+  `get_group_permissions` signatures
+- `ContentQuerySet.permitted` signature and documented Category /
+  Ticket / Trust results
+- `filter_by_user_content_perm` / `filter_by_user_perm` signatures
+  and create-under-Trust grant (`trust_grant_q` on Trust rows)
+- Condition registry APIs and E001/E002/W001/E004 checks
+- Package version `1.0.0.dev0`
+- Database schema and Trusts migrations (`0001_initial`, `0002_trustgroup`)
+
+## Changes
+
+### 43. Live registries freeze after populate
+
+| | |
+| --- | --- |
+| Previous | Live AppConfig-owned path-scoped registries stayed writable for the process lifetime. A late `register()` after `Apps.populate` could still mutate authorization plans. Isolated `TrustsRegistry()` instances were already independent. |
+| New | `TrustsRegistry.freeze()` / `.frozen` are instance-owned. Supported live handle reads freeze the stored object once that AppConfig's `self.apps.ready` is true. `register()` on that frozen instance raises `TrustsConfigurationError` before validation or mutation and leaves records unchanged. Standalone `TrustsRegistry()` instances stay writable unless explicitly frozen. |
+| Replacement | Hosts contribute from their own `AppConfig.ready()` through `configured_backend()` / `configured_handles()` / the one-path `registry` alias. Do not use `registries[path]` as a contributor route. |
+| Affected | Late `register()` after populate. Existing declared terminals keep the same authorization results. |
+| Authorization | Frozen plans still project. Undeclared terminals stay false / empty / none. A late write cannot add authorization after freeze. |
+
+Failure behavior: every register attempt after freeze (valid, duplicate,
+conflicting, malformed) raises with records unchanged. Same-contributor
+re-entry against the exact frozen registry is a sentinel no-op. A new
+or partial late contribution raises without setting that contribution's
+sentinel.
+
+### 44. `trusts.E003` detectable-domain check
+
+| | |
+| --- | --- |
+| Previous | Missing Content/Junction declarations were fail-closed only at authorization time. `trusts.E003` was reserved. |
+| New | A Django model system check walks `apps.get_models()` and reports each concrete, non-proxy, non-abstract `Content` subclass with no covering relation-plan record on any valid configured Trusts handle, and each concrete, non-proxy, non-abstract `Junction` subclass whose `get_content_model()` has no covering record on any valid handle. Coverage on one exact handle is enough. A malformed Junction content-model contract is a deterministic diagnostic, not a `manage.py check` crash. The check performs 0 SQL and does not call `registry.register`. |
+| Replacement | Contribute an explicit AppConfig `Ref` on the intended exact backend path. Silencing `trusts.E003` hides only this diagnostic. |
+| Affected | Early diagnostics for undeclared Content/Junction models. Manual dependents such as ReceiptImage / ReceiptImageMeta stay outside E003. |
+| Authorization | E003 never creates a grant. Undeclared manual dependents remain false / empty / none at runtime. |
+
+## Host AppConfig timing
+
+Contribute during the host `AppConfig.ready()` while `Apps.populate`
+has not set `ready`. After populate, the first supported live handle
+read freezes the stored registry. Re-entry is safe only as a sentinel
+no-op against the exact registry already donated to.
+
+## Rollback
+
+Remove AppConfig-owned freezing and the `trusts.E003` check only.
+S1–S7 explicit registrations and static-registry deletion remain.
+
+## Migration-bot checklist
+
+- [ ] Do not apply a new Trusts migration; none was added.
+- [ ] Move host `register()` calls into `AppConfig.ready()` on the
+      intended exact backend path via `configured_backend()`.
+- [ ] Do not contribute through `registries[path]` after populate.
+- [ ] Treat a frozen `register()` as a configuration error, not a
+      partial write.
+- [ ] Address `trusts.E003` by declaring the Content/Junction terminal.
+      Do not expect E003 for arbitrary manual dependents.
+- [ ] Silencing `trusts.E003` does not authorize the missing terminal.
+- [ ] Leave package version at `1.0.0.dev0`.
+
+## Schema
+
+No change. S8 adds no model and no Django migration. Query
+construction remains lazy. Supported grant / all-match / enumeration
+projections remain **1 SQL**, independent of candidate count. E003
+issues **0 SQL**.
+
+## Out of scope (not acceptance criteria)
+
+- Condition-registry redesign; callback relocation; group/role
+  redesign; #54
+- Backend/module extraction; graph/CTE/inheritance feature
+- Zero; GH; example #7; Windows #17
+
 
 
 

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -115,6 +115,21 @@ def override_apps_ready(ready, apps_registry=None):
         target.ready = was
 
 
+def isolate_live_registry(config, registry, path=None):
+    """Swap a standalone registry into the live store without freezing.
+
+    Test isolation only. Not a host contributor route. The public
+    ``registry`` setter freezes after ``Apps.ready``; this writes the
+    path-scoped dict directly. The first supported handle read after
+    ready still freezes the stored object.
+    """
+    if path is None:
+        paths = config._configured_trusts_paths()
+        path = paths[0]
+    config.registries[path] = registry
+    return registry
+
+
 def install_writable_registry(config, path, contribute=None):
     """Install a standalone registry on a live path for test isolation.
 

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from django.apps import AppConfig
 
 
@@ -90,3 +92,50 @@ class TestsConfig(AppConfig):
                 permission=j.permission,
             )
             self._trusts_tup_group_registry_id = registry
+
+
+@contextmanager
+def override_apps_ready(ready, apps_registry=None):
+    """Temporarily set ``Apps.ready`` so tests can simulate populate.
+
+    Contributor ``ready()`` methods run while that Apps instance is not
+    yet ready. Isolation tests that re-enter a host or package
+    AppConfig after Django has finished populate must restore this
+    window; they must not treat ``registries[path]`` as a live
+    contributor route.
+    """
+    from django.apps import apps as django_apps
+
+    target = django_apps if apps_registry is None else apps_registry
+    was = target.ready
+    target.ready = ready
+    try:
+        yield
+    finally:
+        target.ready = was
+
+
+def install_writable_registry(config, path, contribute=None):
+    """Install a standalone registry on a live path for test isolation.
+
+    Callers register on the standalone instance *before* the first
+    supported handle read after ``Apps.ready``. The live store is not a
+    public contributor API.
+    """
+    from trusts.core import TrustsRegistry
+
+    registry = TrustsRegistry()
+    if contribute is not None:
+        contribute(registry)
+    config.registries[path] = registry
+    return registry
+
+
+def forget_models(*model_classes):
+    """Drop dynamically created models from the default Apps registry."""
+    from django.apps import apps as django_apps
+
+    all_models = django_apps.all_models
+    for model in model_classes:
+        all_models[model._meta.app_label].pop(model._meta.model_name, None)
+    django_apps.clear_cache()

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -137,5 +137,21 @@ def forget_models(*model_classes):
 
     all_models = django_apps.all_models
     for model in model_classes:
-        all_models[model._meta.app_label].pop(model._meta.model_name, None)
+        app_models = all_models.get(model._meta.app_label, {})
+        app_models.pop(model._meta.model_name, None)
+        for name, existing in list(app_models.items()):
+            if existing is model:
+                app_models.pop(name, None)
     django_apps.clear_cache()
+
+
+def clone_writable_registry(registry):
+    """Copy records onto a new unfrozen registry for test isolation."""
+    from trusts.core import TrustsRegistry
+
+    cloned = TrustsRegistry()
+    cloned._by_root = {
+        root: list(rows) for root, rows in registry._by_root.items()
+    }
+    cloned._order = list(registry._order)
+    return cloned

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -172,6 +172,14 @@ class AppConfig(DjangoAppConfig):
                 'registry alias needs exactly one configured Trusts path; '
                 'got %r' % (paths,)
             )
+        # After populate, the compatibility setter is a live surface:
+        # it must not install a writable registry. Freeze the replacement
+        # before storing so a caller-held reference cannot mutate late.
+        # Assignment before ready stays writable for contributor setup.
+        if self._apps_instance_ready():
+            freeze = getattr(value, 'freeze', None)
+            if callable(freeze):
+                freeze()
         self.registries[paths[0]] = value
 
     def _trust_as_content_already_donated(self, path, registry):

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -58,6 +58,18 @@ class AppConfig(DjangoAppConfig):
             )
         return tuple(paths)
 
+    def _apps_instance_ready(self):
+        """True when *this* AppConfig's Apps instance has finished populate.
+
+        Uses ``self.apps.ready``, not Django's global ``apps`` object and
+        not ``apps_ready``. A manually constructed AppConfig with no
+        bound Apps stays unready. During ``Apps.populate`` phase 3,
+        contributor ``ready()`` methods run while this flag is still
+        false.
+        """
+        apps_registry = getattr(self, 'apps', None)
+        return bool(apps_registry is not None and apps_registry.ready)
+
     def _ensure(self, path):
         from trusts.core import TrustsRegistry
 
@@ -65,11 +77,20 @@ class AppConfig(DjangoAppConfig):
             self.registries[path] = TrustsRegistry()
         return self.registries[path]
 
+    def _exposed_registry(self, path):
+        """Return the stored registry; freeze on first live read after ready."""
+        registry = self._ensure(path)
+        if self._apps_instance_ready():
+            registry.freeze()
+        return registry
+
     def configured_backend(self, path=None):
         """Return a handle for one exact configured Trusts path.
 
         With one Trusts path, ``path`` may be omitted. With zero or
         several, omission fails loud. An unconfigured path fails loud.
+        After this AppConfig's Apps instance is ready, the stored
+        registry is frozen before the handle is returned.
         """
         from django.utils.module_loading import import_string
 
@@ -90,7 +111,7 @@ class AppConfig(DjangoAppConfig):
         cls = import_string(path)
         return BackendHandle(
             path=path,
-            registry=self._ensure(path),
+            registry=self._exposed_registry(path),
             compiler=compiler_for_class(cls),
         )
 
@@ -139,7 +160,7 @@ class AppConfig(DjangoAppConfig):
                 'registry alias needs exactly one configured Trusts path; '
                 'got %r' % (paths,)
             )
-        return self._ensure(paths[0])
+        return self._exposed_registry(paths[0])
 
     @registry.setter
     def registry(self, value):
@@ -197,7 +218,9 @@ class AppConfig(DjangoAppConfig):
         from trusts import checks as _trusts_checks  # noqa: F401
 
         # S3a: ensure one registry per configured Trusts path. Re-entry
-        # must not replace self.registries or any stored object.
+        # must not replace self.registries or any stored object. Freeze
+        # is applied by the supported handle surfaces after this Apps
+        # instance is ready, not by replacing stored objects here.
         paths = self._configured_trusts_paths()
         for path in paths:
             self._ensure(path)

--- a/trusts/checks.py
+++ b/trusts/checks.py
@@ -1,4 +1,5 @@
-"""Django system checks for permission conditions and query compilers.
+"""Django system checks for permission conditions, missing declarations,
+and query compilers.
 
 Model-aware semantic validation (field names, traversal, multi-valued
 relations, operand types) and the legacy-callback policy are reported as
@@ -15,11 +16,12 @@ under ``manage.py check``.
 from django.core import checks as django_checks
 
 from trusts.conditions import PermissionConditionError, validate_expression
-from trusts.models import Content, legacy_permission_callbacks_allowed
+from trusts.models import Content, Junction, legacy_permission_callbacks_allowed
 
 
 CHECK_ID_INVALID_EXPR = 'trusts.E001'
 CHECK_ID_LEGACY_CALLBACK = 'trusts.E002'
+CHECK_ID_MISSING_DECLARATION = 'trusts.E003'
 CHECK_ID_MISSING_COMPILER = 'trusts.E004'
 CHECK_ID_LEGACY_CALLBACK_WARNING = 'trusts.W001'
 
@@ -87,10 +89,9 @@ def check_query_compilers(app_configs, **kwargs):
     """Every Trusts-derived AUTHENTICATION_BACKENDS path must be query-capable.
 
     Imports listed mixin classes and resolves ``query_compiler`` without
-    constructing a backend instance. Zero SQL. ``trusts.E003`` stays
-    reserved for S8 freeze. Silencing ``trusts.E004`` hides only this
-    diagnostic; ``ContentQuerySet.permitted()`` still raises and does
-    not fall back or omit the broken route.
+    constructing a backend instance. Zero SQL. Silencing ``trusts.E004``
+    hides only this diagnostic; ``ContentQuerySet.permitted()`` still
+    raises and does not fall back or omit the broken route.
     """
     from django.conf import settings
     from django.utils.module_loading import import_string
@@ -124,6 +125,143 @@ def check_query_compilers(app_configs, **kwargs):
                 obj=cls,
                 id=CHECK_ID_MISSING_COMPILER,
             ))
+    return messages
+
+
+_E003_HINT = (
+    'Contribute an explicit AppConfig Ref on the intended exact backend '
+    'path. Silencing trusts.E003 suppresses only this diagnostic; it '
+    'never creates authorization.'
+)
+
+
+def _is_concrete_model(model):
+    opts = getattr(model, '_meta', None)
+    if opts is None:
+        return False
+    return not opts.abstract and not opts.proxy
+
+
+def _covered_content_models(config):
+    """Content terminals that already have a plan record on any valid handle.
+
+    Path-scoped: coverage on one configured valid Trusts handle is
+    enough. Does not register, does not invent union authority, and
+    does not require every backend to hold the declaration.
+    """
+    from trusts.core import TrustsCompilerError, TrustsConfigurationError
+
+    covered = set()
+    try:
+        paths = config._configured_trusts_paths()
+    except TrustsConfigurationError:
+        return covered
+    for path in paths:
+        try:
+            handle = config.configured_backend(path)
+        except (TrustsConfigurationError, TrustsCompilerError):
+            continue
+        for record in handle.registry.records:
+            covered.add(record.content_model)
+    return covered
+
+
+def _junction_content_model(model):
+    """Return the Junction content model or a CheckMessage for a bad contract."""
+    try:
+        content_model = model.get_content_model()
+    except Exception as exc:
+        return None, django_checks.Error(
+            'Junction %s has a malformed content-model contract: %s'
+            % (_model_label(model), exc),
+            hint=_E003_HINT,
+            obj=model,
+            id=CHECK_ID_MISSING_DECLARATION,
+        )
+    opts = getattr(content_model, '_meta', None)
+    if opts is None:
+        return None, django_checks.Error(
+            'Junction %s has a malformed content-model contract: '
+            'get_content_model() did not return a Django model.'
+            % _model_label(model),
+            hint=_E003_HINT,
+            obj=model,
+            id=CHECK_ID_MISSING_DECLARATION,
+        )
+    return opts.concrete_model, None
+
+
+@django_checks.register(django_checks.Tags.models)
+def check_missing_declarations(app_configs, **kwargs):
+    """Report structurally detectable missing Content/Junction declarations.
+
+    Walks already-loaded models from the default Apps registry. Does not
+    import host modules, does not call ``registry.register``, and issues
+    zero SQL. ``app_configs`` is ignored so a subset
+    ``manage.py check trusts`` still reports project models. Abstract
+    and proxy models are excluded. Manual dependents that are neither
+    Content nor Junction are outside this domain.
+
+    Silencing ``trusts.E003`` hides only this diagnostic; undeclared
+    terminals still fail closed at runtime.
+    """
+    from django.apps import apps as django_apps
+
+    if not django_apps.is_installed('trusts'):
+        return []
+
+    config = django_apps.get_app_config('trusts')
+    covered = _covered_content_models(config)
+    messages = []
+    seen = set()
+
+    for model in django_apps.get_models():
+        if not _is_concrete_model(model):
+            continue
+        if issubclass(model, Content):
+            terminal = model._meta.concrete_model
+            if terminal in covered:
+                continue
+            key = ('content', model)
+            if key in seen:
+                continue
+            seen.add(key)
+            messages.append(django_checks.Error(
+                'Content model %s has no covering relation-plan record '
+                'on any configured Trusts handle.' % _model_label(model),
+                hint=_E003_HINT,
+                obj=model,
+                id=CHECK_ID_MISSING_DECLARATION,
+            ))
+            continue
+        if issubclass(model, Junction):
+            content_model, error = _junction_content_model(model)
+            if error is not None:
+                key = ('junction-malformed', model)
+                if key in seen:
+                    continue
+                seen.add(key)
+                messages.append(error)
+                continue
+            if content_model in covered:
+                continue
+            key = ('junction', model)
+            if key in seen:
+                continue
+            seen.add(key)
+            messages.append(django_checks.Error(
+                'Junction %s targets %s, which has no covering '
+                'relation-plan record on any configured Trusts handle.'
+                % (_model_label(model), _model_label(content_model)),
+                hint=_E003_HINT,
+                obj=model,
+                id=CHECK_ID_MISSING_DECLARATION,
+            ))
+
+    messages.sort(key=lambda message: (
+        getattr(getattr(message.obj, '_meta', None), 'label', ''),
+        message.msg,
+    ))
     return messages
 
 

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -772,11 +772,27 @@ class TrustsRegistry(object):
     singleton in this slice. ``register`` performs zero SQL. Projection
     methods compile one shared plan from stored records. One root may
     store several records when they terminate on different content models.
+
+    Frozen state is instance-owned. ``freeze()`` is idempotent.
+    ``register`` on that exact frozen instance raises
+    ``TrustsConfigurationError`` before validation or mutation. Existing
+    records, plans, compilers, and authorization reads stay usable.
+    A standalone ``TrustsRegistry()`` never inspects Django readiness
+    and never auto-freezes.
     """
 
     def __init__(self):
         self._by_root = {}
         self._order = []
+        self._frozen = False
+
+    @property
+    def frozen(self):
+        return self._frozen
+
+    def freeze(self):
+        """Seal this instance against further ``register`` writes."""
+        self._frozen = True
 
     @property
     def records(self):
@@ -802,7 +818,15 @@ class TrustsRegistry(object):
         terminal with a different registration is a conflict and also
         raises. The same root may register different content terminals.
         Both error outcomes leave stored records unchanged.
+
+        A frozen instance raises ``TrustsConfigurationError`` before
+        validation or mutation. This method does not inspect Django's
+        global ``apps.ready``.
         """
+        if self._frozen:
+            raise TrustsConfigurationError(
+                'Cannot register on a frozen TrustsRegistry.'
+            )
         if condition is not None:
             raise TrustsConfigurationError(
                 'condition is not supported; omit it or pass None.'

--- a/trusts/test_issue29.py
+++ b/trusts/test_issue29.py
@@ -40,6 +40,7 @@ from trusts.tests import (
     get_or_create_root_user,
     reload_test_users,
 )
+from tests.apps import forget_models
 from tests.models import AutoAdminCategory, Ticket
 
 
@@ -198,6 +199,7 @@ class PermissionConditionCheckTest(ConditionRegistryIsolationMixin, TestCase):
         for message in errors:
             self.assertIsInstance(message, Error)
             self.assertIn('fail closed', message.hint)
+        forget_models(ImportTimeBadTicket)
 
     def test_multiple_dynamic_errors_are_aggregated(self):
         u, p, o = condition_refs()

--- a/trusts/test_issue67.py
+++ b/trusts/test_issue67.py
@@ -19,7 +19,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig, override_apps_ready
+from tests.apps import TestsConfig, isolate_live_registry, override_apps_ready
 import tests as tests_module
 from tests.models import Category, Ticket
 from trusts.apps import AppConfig as TrustsAppConfig
@@ -175,7 +175,7 @@ class ContributorIdempotenceTest(SimpleTestCase):
         isolated.register(
             content=other.category, user=other.user, permission=other.permission,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             contributor.ready()
@@ -197,7 +197,7 @@ class ContributorIdempotenceTest(SimpleTestCase):
             user=j.permission,
             permission=j.entity,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             with self.assertRaises(TrustsConfigurationError):
@@ -215,7 +215,7 @@ class ContributorIdempotenceTest(SimpleTestCase):
         new_apps = apps
         original = self.live_trusts.registry
         try:
-            self.live_trusts.registry = new_trusts.registry
+            isolate_live_registry(self.live_trusts, new_trusts.registry)
             contributor = _new_contributor(new_apps)
             with override_apps_ready(False):
                 contributor.ready()

--- a/trusts/test_issue67.py
+++ b/trusts/test_issue67.py
@@ -19,7 +19,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig
+from tests.apps import TestsConfig, override_apps_ready
 import tests as tests_module
 from tests.models import Category, Ticket
 from trusts.apps import AppConfig as TrustsAppConfig
@@ -177,7 +177,8 @@ class ContributorIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_group_registry_id, isolated)
@@ -198,8 +199,9 @@ class ContributorIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        with self.assertRaises(TrustsConfigurationError):
-            contributor.ready()
+        with override_apps_ready(False):
+            with self.assertRaises(TrustsConfigurationError):
+                contributor.ready()
         self.assertIsNone(
             getattr(contributor, '_trusts_tup_category_registry_id', None)
         )
@@ -215,7 +217,8 @@ class ContributorIdempotenceTest(SimpleTestCase):
         try:
             self.live_trusts.registry = new_trusts.registry
             contributor = _new_contributor(new_apps)
-            contributor.ready()
+            with override_apps_ready(False):
+                contributor.ready()
             self.assertIs(
                 contributor._trusts_tup_category_registry_id,
                 new_trusts.registry,

--- a/trusts/test_issue70.py
+++ b/trusts/test_issue70.py
@@ -18,7 +18,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig
+from tests.apps import TestsConfig, isolate_live_registry
 import tests as tests_module
 from tests.models import Category, Ticket
 from trusts.apps import AppConfig as TrustsAppConfig
@@ -194,7 +194,7 @@ class TrustContributionIdempotenceTest(SimpleTestCase):
 
     def test_swapped_live_registry_receives_declaration_again(self):
         isolated = TrustsRegistry()
-        self.live.registry = isolated
+        isolate_live_registry(self.live, isolated)
         self.live.ready()
         self.assertIs(self.live._trusts_tup_trust_registry_id, isolated)
         self.assertIs(self.live.registry, isolated)

--- a/trusts/test_issue72.py
+++ b/trusts/test_issue72.py
@@ -19,7 +19,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig, override_apps_ready
+from tests.apps import TestsConfig, isolate_live_registry, override_apps_ready
 import tests as tests_module
 from tests.models import Category, Organization, Ticket
 from trusts.apps import AppConfig as TrustsAppConfig
@@ -150,7 +150,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
 
     def test_category_sentinel_does_not_complete_ticket(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         contributor._trusts_tup_category_registry_id = isolated
         with override_apps_ready(False):
@@ -175,7 +175,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         isolated.register(
             content=other.ticket, user=other.user, permission=other.permission,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             contributor.ready()
@@ -203,7 +203,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
             user=j.permission,
             permission=j.entity,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             with self.assertRaises(TrustsConfigurationError):
@@ -230,7 +230,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         self.assertEqual(new_trusts.registry.records, ())
         original = self.live_trusts.registry
         try:
-            self.live_trusts.registry = new_trusts.registry
+            isolate_live_registry(self.live_trusts, new_trusts.registry)
             contributor = _new_contributor(apps)
             with override_apps_ready(False):
                 contributor.ready()
@@ -267,7 +267,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
 
     def test_declaration_uses_meta_reverse_not_contents(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         remote = Ticket._meta.get_field('trust').remote_field
         self.assertFalse(hasattr(Content, '_contents'))
@@ -290,7 +290,7 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
 
     def test_swapped_live_registry_receives_declaration_again(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         with override_apps_ready(False):
             self.live_contributor.ready()
         self.assertIs(self.live_contributor._trusts_tup_ticket_registry_id, isolated)

--- a/trusts/test_issue72.py
+++ b/trusts/test_issue72.py
@@ -19,7 +19,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig
+from tests.apps import TestsConfig, override_apps_ready
 import tests as tests_module
 from tests.models import Category, Organization, Ticket
 from trusts.apps import AppConfig as TrustsAppConfig
@@ -153,7 +153,8 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
         contributor._trusts_tup_category_registry_id = isolated
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_group_registry_id, isolated)
@@ -176,7 +177,8 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_group_registry_id, isolated)
@@ -203,16 +205,18 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        with self.assertRaises(TrustsConfigurationError):
-            contributor.ready()
+        with override_apps_ready(False):
+            with self.assertRaises(TrustsConfigurationError):
+                contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIsNone(
             getattr(contributor, '_trusts_tup_ticket_registry_id', None)
         )
         self.assertEqual(len(isolated.records), 2)
         self.assertEqual(len(_category_rows(isolated)), 1)
-        with self.assertRaises(TrustsConfigurationError):
-            contributor.ready()
+        with override_apps_ready(False):
+            with self.assertRaises(TrustsConfigurationError):
+                contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIsNone(
             getattr(contributor, '_trusts_tup_ticket_registry_id', None)
@@ -228,7 +232,8 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         try:
             self.live_trusts.registry = new_trusts.registry
             contributor = _new_contributor(apps)
-            contributor.ready()
+            with override_apps_ready(False):
+                contributor.ready()
             self.assertIs(
                 contributor._trusts_tup_ticket_registry_id,
                 new_trusts.registry,
@@ -269,7 +274,8 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
         with patch.object(
             remote, 'get_accessor_name', wraps=remote.get_accessor_name,
         ) as accessor:
-            contributor.ready()
+            with override_apps_ready(False):
+                contributor.ready()
         accessor.assert_called()
         rev = remote.get_accessor_name()
         self.assertEqual(len(_ticket_rows(isolated)), 1)
@@ -285,7 +291,8 @@ class TicketContributionIdempotenceTest(SimpleTestCase):
     def test_swapped_live_registry_receives_declaration_again(self):
         isolated = TrustsRegistry()
         self.live_trusts.registry = isolated
-        self.live_contributor.ready()
+        with override_apps_ready(False):
+            self.live_contributor.ready()
         self.assertIs(self.live_contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIs(
             self.live_contributor._trusts_tup_category_registry_id, isolated,

--- a/trusts/test_issue75.py
+++ b/trusts/test_issue75.py
@@ -16,7 +16,7 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig
+from tests.apps import TestsConfig, install_writable_registry, override_apps_ready
 from tests.backends import (
     HostTrustModelBackend,
     MalformedCompilerBackend,
@@ -231,7 +231,8 @@ class PathScopedRegistryStoreTest(_RegistryRestoreMixin, SimpleTestCase):
         isolated = TrustsRegistry()
         self.live.registry = isolated
         self.assertIs(self.live.registries[CONCRETE], isolated)
-        self.live.ready()
+        with override_apps_ready(False):
+            self.live.ready()
         self.assertIs(self.live._trusts_tup_trust_registry_id, isolated)
         self.assertEqual(len(_trust_rows(isolated)), 1)
 
@@ -306,9 +307,9 @@ class IsolatedAppsPathStoreTest(SimpleTestCase):
 class ContributionPathTest(_RegistryRestoreMixin, SimpleTestCase):
     def test_explicit_path_contribution_writes_one_registry(self):
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            mixin = install_writable_registry(self.live, MIXIN)
+            _contribute_category(mixin)
             handle_b = self.live.configured_backend(MIXIN)
-            self.assertEqual(_category_rows(handle_b.registry), [])
-            _contribute_category(handle_b.registry)
             self.assertEqual(len(_category_rows(handle_b.registry)), 1)
             handle_a = self.live.configured_backend(CONCRETE)
             self.assertEqual(len(_category_rows(handle_a.registry)), 1)
@@ -378,7 +379,8 @@ class ContributionPathTest(_RegistryRestoreMixin, SimpleTestCase):
             self.live.ready()
             isolated = TrustsRegistry()
             self.live.registries[HOST] = isolated
-            self.live.ready()
+            with override_apps_ready(False):
+                self.live.ready()
             self.assertIs(self.live.registries[HOST], isolated)
             self.assertEqual(len(_trust_rows(isolated)), 1)
 
@@ -418,8 +420,8 @@ class CompilerProtocolTest(_RegistryRestoreMixin, SimpleTestCase):
 
     def test_raising_compiler_propagates(self):
         with override_settings(AUTHENTICATION_BACKENDS=(RAISING,)):
+            install_writable_registry(self.live, RAISING, _contribute_category)
             handle = self.live.configured_backend()
-            _contribute_category(handle.registry)
             with self.assertRaises(RuntimeError) as ctx:
                 granted(
                     (handle,), Category, User(),
@@ -557,8 +559,8 @@ class TwoPathAuthorizationTest(_RegistryRestoreMixin, TestCase):
         self._reload()
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
             self.live.registries[CONCRETE] = TrustsRegistry()
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             handle_a = self.live.configured_backend(CONCRETE)
             self.assertFalse(handle_a.registry.plan_for(Category).records)
             self.assertTrue(handle_b.registry.plan_for(Category).records)
@@ -574,8 +576,8 @@ class TwoPathAuthorizationTest(_RegistryRestoreMixin, TestCase):
 
     def test_grant_through_neither(self):
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             self.assertFalse(
                 Category.objects.permitted(self.change_code, self.alice).exists()
             )
@@ -590,8 +592,8 @@ class TwoPathAuthorizationTest(_RegistryRestoreMixin, TestCase):
         enable_local_group_grant(self.trust_b, alice_group, self.change)
         self._reload()
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             handle_a = self.live.configured_backend(CONCRETE)
             qs = Category.objects.all()
             pred_a = _evaluate(handle_a, qs, self.alice, self.change)
@@ -620,8 +622,8 @@ class TwoPathAuthorizationTest(_RegistryRestoreMixin, TestCase):
         self.change.group_set.remove(self.carol_group)
         self._reload()
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             qs = Category.objects.all()
             handle_a = self.live.configured_backend(CONCRETE)
             pred_a = _evaluate(handle_a, qs, self.carol, self.change)
@@ -646,11 +648,10 @@ class TwoPathAuthorizationTest(_RegistryRestoreMixin, TestCase):
         ).save()
         self._reload()
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
-            self.live.registries[CONCRETE] = TrustsRegistry()
+            install_writable_registry(self.live, CONCRETE, _contribute_category)
+            install_writable_registry(self.live, MIXIN, _contribute_ticket)
             handle_a = self.live.configured_backend(CONCRETE)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_a.registry)
-            _contribute_ticket(handle_b.registry)
             self.assertTrue(handle_a.registry.plan_for(Category).records)
             self.assertFalse(handle_a.registry.plan_for(Ticket).records)
             self.assertFalse(handle_b.registry.plan_for(Category).records)
@@ -698,8 +699,8 @@ class CompilerIsolationTest(_RegistryRestoreMixin, TestCase):
             TrustUserPermission.objects.filter(entity=self.carol).exists()
         )
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             handle_a = self.live.configured_backend(CONCRETE)
             qs = Category.objects.all()
             pred_a = _evaluate(handle_a, qs, self.carol, self.change)
@@ -714,8 +715,8 @@ class CompilerIsolationTest(_RegistryRestoreMixin, TestCase):
 
     def test_mixin_only_alone_denies_historical_group(self):
         with override_settings(AUTHENTICATION_BACKENDS=(MIXIN,)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle = self.live.configured_backend()
-            _contribute_category(handle.registry)
             self.assertIsInstance(handle.compiler, PlanQueryCompiler)
             self.assertFalse(handle.registry.plan_for(Trust).records)
             qs = Category.objects.all()
@@ -729,8 +730,8 @@ class CompilerIsolationTest(_RegistryRestoreMixin, TestCase):
 
     def test_raising_compiler_is_not_caught_by_aggregate(self):
         with override_settings(AUTHENTICATION_BACKENDS=(RAISING,)):
+            install_writable_registry(self.live, RAISING, _contribute_category)
             handle = self.live.configured_backend()
-            _contribute_category(handle.registry)
             with self.assertRaises(RuntimeError):
                 list(Category.objects.permitted(self.change_code, self.carol))
 

--- a/trusts/test_issue75.py
+++ b/trusts/test_issue75.py
@@ -16,7 +16,12 @@ from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import isolate_apps
 
-from tests.apps import TestsConfig, install_writable_registry, override_apps_ready
+from tests.apps import (
+    TestsConfig,
+    install_writable_registry,
+    isolate_live_registry,
+    override_apps_ready,
+)
 from tests.backends import (
     HostTrustModelBackend,
     MalformedCompilerBackend,
@@ -229,7 +234,7 @@ class PathScopedRegistryStoreTest(_RegistryRestoreMixin, SimpleTestCase):
 
     def test_swapped_registry_identity_receives_declaration_again(self):
         isolated = TrustsRegistry()
-        self.live.registry = isolated
+        isolate_live_registry(self.live, isolated, CONCRETE)
         self.assertIs(self.live.registries[CONCRETE], isolated)
         with override_apps_ready(False):
             self.live.ready()

--- a/trusts/test_issue77.py
+++ b/trusts/test_issue77.py
@@ -15,6 +15,7 @@ from django.db import connection, models
 from django.db.models.query import QuerySet
 from django.test import TestCase, TransactionTestCase, override_settings
 
+from tests.apps import install_writable_registry
 from tests.backends import GroupOnlyBackend, MixinOnlyBackend
 from tests.models import Category, Organization, Ticket, TestGroupJunction
 from trusts.backends import HistoricalGroupQueryCompiler, TrustModelBackend
@@ -346,10 +347,10 @@ class DistributiveLawTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
 
     def test_split_coverage_object_queryset_and_permitted(self):
         with self._two_path():
+            install_writable_registry(self.live, GROUP_ONLY, _contribute_category)
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_a = self.live.configured_backend(GROUP_ONLY)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_a.registry)
-            _contribute_category(handle_b.registry)
             group_only = GroupOnlyBackend()
             mixin = MixinOnlyBackend()
             self.assertTrue(group_only.has_perm(self.alice, self.change_code, self.cat_a))
@@ -378,10 +379,10 @@ class DistributiveLawTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
         ).delete()
         self._reload()
         with self._two_path():
+            install_writable_registry(self.live, GROUP_ONLY, _contribute_category)
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_a = self.live.configured_backend(GROUP_ONLY)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_a.registry)
-            _contribute_category(handle_b.registry)
             qs = Category.objects.filter(pk__in=[self.cat_a.pk, self.cat_b.pk])
             self.assertFalse(self.alice.has_perm(self.change_code, self.cat_a))
             self.assertFalse(self.alice.has_perm(self.change_code, self.cat_b))
@@ -413,8 +414,8 @@ class CompilerIsolationBackendTest(_RegistryRestoreMixin, _UsersMixin, TestCase)
             TrustUserPermission.objects.filter(entity=self.carol).exists()
         )
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             concrete = TrustModelBackend()
             mixin = MixinOnlyBackend()
             self.assertTrue(concrete.has_perm(self.carol, self.change_code, self.cat_a))
@@ -436,8 +437,8 @@ class CompilerIsolationBackendTest(_RegistryRestoreMixin, _UsersMixin, TestCase)
 
     def test_mixin_only_alone_denies_historical_group(self):
         with override_settings(AUTHENTICATION_BACKENDS=(MIXIN,)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle = self.live.configured_backend()
-            _contribute_category(handle.registry)
             mixin = MixinOnlyBackend()
             self.assertFalse(mixin.has_perm(self.carol, self.change_code, self.cat_a))
             self.assertFalse(self.carol.has_perm(self.change_code, self.cat_a))
@@ -465,8 +466,8 @@ class CoordinatorQueryCountTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
 
     def test_coordinator_one_sql_noncoordinator_zero(self):
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             concrete = TrustModelBackend()
             mixin = MixinOnlyBackend()
             self.assertTrue(concrete._is_collection_coordinator())
@@ -484,8 +485,8 @@ class CoordinatorQueryCountTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
 
     def test_reversed_backend_order(self):
         with override_settings(AUTHENTICATION_BACKENDS=(MIXIN, CONCRETE)):
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             concrete = TrustModelBackend()
             mixin = MixinOnlyBackend()
             self.assertTrue(mixin._is_collection_coordinator())
@@ -589,8 +590,8 @@ class CompilerFailureTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
         from tests.backends import RaisingCompilerBackend
 
         with override_settings(AUTHENTICATION_BACKENDS=(RAISING,)):
+            install_writable_registry(self.live, RAISING, _contribute_category)
             handle = self.live.configured_backend()
-            _contribute_category(handle.registry)
             with self.assertRaises(RuntimeError):
                 RaisingCompilerBackend().has_perm(
                     self.alice, self.change_code, self.cat_a,
@@ -724,13 +725,15 @@ class RegisteredOrdinaryModelTest(_RegistryRestoreMixin, _UsersMixin, Transactio
             code = 'trusts_tests.change_memo'
             MemoGrant.objects.create(memo=memo, user=self.alice, permission=change)
             with override_settings(AUTHENTICATION_BACKENDS=(MIXIN,)):
+                isolated = TrustsRegistry()
+                j = Ref(MemoGrant)
+                isolated.register(
+                    content=j.memo, user=j.user, permission=j.permission,
+                )
+                self.live.registries[MIXIN] = isolated
                 handle = self.live.configured_backend()
                 self.assertFalse(handle.historical_fallback)
                 self.assertIsInstance(handle.compiler, PlanQueryCompiler)
-                j = Ref(MemoGrant)
-                handle.registry.register(
-                    content=j.memo, user=j.user, permission=j.permission,
-                )
                 mixin = MixinOnlyBackend()
                 self.assertTrue(mixin.has_perm(self.alice, code, memo))
                 self.assertFalse(mixin.has_perm(self.alice, code, other))

--- a/trusts/test_issue80.py
+++ b/trusts/test_issue80.py
@@ -16,6 +16,7 @@ from django.core.management import call_command
 from django.db.models.query import QuerySet
 from django.test import SimpleTestCase, TestCase, override_settings
 
+from tests.apps import install_writable_registry
 from tests.models import AutoAdminCategory, Category, Organization, Ticket
 from trusts.core import (
     Ref,
@@ -375,9 +376,9 @@ class MultiPathCreateUnderTrustGateTest(
     def test_declaration_on_one_path_supports_but_grant_stays_trust_grant_q(self):
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
             self.live.registries[CONCRETE] = TrustsRegistry()
+            install_writable_registry(self.live, MIXIN, _contribute_category)
             handle_a = self.live.configured_backend(CONCRETE)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_b.registry)
             self.assertFalse(handle_a.registry.plan_for(Category).records)
             self.assertTrue(handle_b.registry.plan_for(Category).records)
             self.assertTrue(any_plan_records((handle_a, handle_b), Category))
@@ -400,11 +401,10 @@ class MultiPathCreateUnderTrustGateTest(
 
     def test_split_terminals_do_not_leak_the_other_path(self):
         with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
-            self.live.registries[CONCRETE] = TrustsRegistry()
+            install_writable_registry(self.live, CONCRETE, _contribute_category)
+            install_writable_registry(self.live, MIXIN, _contribute_ticket)
             handle_a = self.live.configured_backend(CONCRETE)
             handle_b = self.live.configured_backend(MIXIN)
-            _contribute_category(handle_a.registry)
-            _contribute_ticket(handle_b.registry)
             self.assertTrue(handle_a.registry.plan_for(Category).records)
             self.assertFalse(handle_a.registry.plan_for(Ticket).records)
             self.assertFalse(handle_b.registry.plan_for(Category).records)

--- a/trusts/test_issue85.py
+++ b/trusts/test_issue85.py
@@ -20,6 +20,7 @@ from django.test.utils import isolate_apps
 
 from tests.apps import (
     TestsConfig,
+    install_writable_registry,
     junction_content_field,
     junction_group_content_ref,
     override_apps_ready,
@@ -677,8 +678,8 @@ class GroupCompilerIsolationTest(_RegistryRestoreMixin, _UsersMixin, TestCase):
 
     def test_mixin_only_with_plan_gets_trustee_not_historical_group(self):
         with override_settings(AUTHENTICATION_BACKENDS=(MIXIN,)):
+            install_writable_registry(self.live, MIXIN, _contribute_group)
             handle = self.live.configured_backend()
-            _contribute_group(handle.registry)
             mixin = MixinOnlyBackend()
             self.assertTrue(mixin.has_perm(self.alice, self.change_code, self.group))
             self.assertFalse(mixin.has_perm(self.carol, self.change_code, self.group))

--- a/trusts/test_issue85.py
+++ b/trusts/test_issue85.py
@@ -21,6 +21,7 @@ from django.test.utils import isolate_apps
 from tests.apps import (
     TestsConfig,
     install_writable_registry,
+    isolate_live_registry,
     junction_content_field,
     junction_group_content_ref,
     override_apps_ready,
@@ -219,7 +220,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
 
     def test_category_and_ticket_sentinels_do_not_complete_group(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         contributor._trusts_tup_category_registry_id = isolated
         contributor._trusts_tup_ticket_registry_id = isolated
@@ -246,7 +247,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         isolated.register(
             content=other.group, user=other.user, permission=other.permission,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             contributor.ready()
@@ -265,7 +266,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
             user=j.permission,
             permission=j.entity,
         )
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         with override_apps_ready(False):
             with self.assertRaises(TrustsConfigurationError):
@@ -291,7 +292,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         new_trusts = TrustsAppConfig('trusts', trusts)
         original = self.live_registry
         try:
-            self.live_trusts.registry = new_trusts.registry
+            isolate_live_registry(self.live_trusts, new_trusts.registry)
             contributor = _new_contributor(apps)
             with override_apps_ready(False):
                 contributor.ready()
@@ -314,7 +315,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
 
     def test_declaration_is_j1_metadata_derived_and_independent_of_contents(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         contributor = _new_contributor(apps)
         remote = TestGroupJunction._meta.get_field('trust').remote_field
         with patch.object(
@@ -346,7 +347,7 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
 
     def test_swapped_live_registry_receives_declaration_again(self):
         isolated = TrustsRegistry()
-        self.live_trusts.registry = isolated
+        isolate_live_registry(self.live_trusts, isolated)
         with override_apps_ready(False):
             self.live_contributor.ready()
         self.assertIs(self.live_contributor._trusts_tup_group_registry_id, isolated)

--- a/trusts/test_issue85.py
+++ b/trusts/test_issue85.py
@@ -22,6 +22,7 @@ from tests.apps import (
     TestsConfig,
     junction_content_field,
     junction_group_content_ref,
+    override_apps_ready,
 )
 from tests.backends import MixinOnlyBackend
 import tests as tests_module
@@ -221,7 +222,8 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         contributor = _new_contributor(apps)
         contributor._trusts_tup_category_registry_id = isolated
         contributor._trusts_tup_ticket_registry_id = isolated
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_group_registry_id, isolated)
@@ -245,7 +247,8 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_group_registry_id, isolated)
         roots = {record.root for record in isolated.records}
         self.assertEqual(roots, {OtherGroupGrant, TrustUserPermission})
@@ -263,8 +266,9 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         )
         self.live_trusts.registry = isolated
         contributor = _new_contributor(apps)
-        with self.assertRaises(TrustsConfigurationError):
-            contributor.ready()
+        with override_apps_ready(False):
+            with self.assertRaises(TrustsConfigurationError):
+                contributor.ready()
         self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_ticket_registry_id, isolated)
         self.assertIsNone(
@@ -272,8 +276,9 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         )
         self.assertEqual(len(isolated.records), 3)
         self.assertEqual(len(_group_rows(isolated)), 1)
-        with self.assertRaises(TrustsConfigurationError):
-            contributor.ready()
+        with override_apps_ready(False):
+            with self.assertRaises(TrustsConfigurationError):
+                contributor.ready()
         self.assertIsNone(
             getattr(contributor, '_trusts_tup_group_registry_id', None)
         )
@@ -287,7 +292,8 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
         try:
             self.live_trusts.registry = new_trusts.registry
             contributor = _new_contributor(apps)
-            contributor.ready()
+            with override_apps_ready(False):
+                contributor.ready()
             self.assertIs(contributor._trusts_tup_group_registry_id, new_trusts.registry)
             terminals = {
                 record.content_model for record in new_trusts.registry.records
@@ -318,7 +324,8 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
                 wraps=TestGroupJunction.get_content_model,
             ) as content_model:
                 self.assertFalse(hasattr(Content, '_contents'))
-                contributor.ready()
+                with override_apps_ready(False):
+                    contributor.ready()
         accessor.assert_called()
         content_model.assert_called()
         rev, content_name, lookup = _j1_lookup()
@@ -339,7 +346,8 @@ class GroupContributionIdempotenceTest(SimpleTestCase):
     def test_swapped_live_registry_receives_declaration_again(self):
         isolated = TrustsRegistry()
         self.live_trusts.registry = isolated
-        self.live_contributor.ready()
+        with override_apps_ready(False):
+            self.live_contributor.ready()
         self.assertIs(self.live_contributor._trusts_tup_group_registry_id, isolated)
         self.assertEqual(len(_group_rows(isolated)), 1)
         self.assertEqual(len(_category_rows(isolated)), 1)

--- a/trusts/test_issue87.py
+++ b/trusts/test_issue87.py
@@ -18,7 +18,7 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_
 from django.test.utils import isolate_apps
 
 import tests as tests_module
-from tests.apps import forget_models, override_apps_ready
+from tests.apps import clone_writable_registry, forget_models, override_apps_ready
 from tests.backends import MixinOnlyBackend
 from tests.models import Category, TestGroupJunction, Ticket
 from trusts.backends import (
@@ -564,6 +564,8 @@ class DependentAuthorizationTest(_RegistryRestoreMixin, _UsersMixin, Transaction
             for image in extras
         ]
         contributor = _new_dependent_host(apps, self.Receipt)
+        writable = clone_writable_registry(self.live.registries[CONCRETE])
+        self.live.registries[CONCRETE] = writable
         with override_apps_ready(False):
             contributor.ready()
         self.image_code = 'trusts_tests.change_%s' % self.Image._meta.model_name

--- a/trusts/test_issue87.py
+++ b/trusts/test_issue87.py
@@ -18,6 +18,7 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_
 from django.test.utils import isolate_apps
 
 import tests as tests_module
+from tests.apps import forget_models, override_apps_ready
 from tests.backends import MixinOnlyBackend
 from tests.models import Category, TestGroupJunction, Ticket
 from trusts.backends import (
@@ -303,6 +304,7 @@ class LegacyContentRegistryDeletedTest(SimpleTestCase):
         finally:
             Content._conditions.clear()
             Content._conditions.update(before)
+            forget_models(BareNote)
 
     def test_class_prepared_does_not_write_a_content_map(self):
         before = dict(Content._conditions)
@@ -330,6 +332,7 @@ class LegacyContentRegistryDeletedTest(SimpleTestCase):
         finally:
             Content._conditions.clear()
             Content._conditions.update(before)
+            forget_models(IsolatedSheet)
 
     def test_register_junction_does_not_write_a_content_map(self):
         before = dict(Content._conditions)
@@ -359,6 +362,7 @@ class LegacyContentRegistryDeletedTest(SimpleTestCase):
         finally:
             Content._conditions.clear()
             Content._conditions.update(before)
+            forget_models(IsolatedJunction)
 
 
 class ConditionRegistryPreservedTest(_ConditionIsolationMixin, TestCase):
@@ -473,7 +477,8 @@ class DependentHostContributionTest(_RegistryRestoreMixin, SimpleTestCase):
         isolated = TrustsRegistry()
         self.live.registries[CONCRETE] = isolated
         contributor = _new_dependent_host(apps, Receipt)
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.assertIs(contributor._trusts_tup_image_registry_id, isolated)
         self.assertIs(contributor._trusts_tup_meta_registry_id, isolated)
         before = isolated.records
@@ -489,11 +494,13 @@ class DependentHostContributionTest(_RegistryRestoreMixin, SimpleTestCase):
         self.live.registries[CONCRETE] = isolated_meta
         partial = _new_dependent_host(apps, Receipt)
         partial._trusts_tup_image_registry_id = isolated_meta
-        partial.ready()
+        with override_apps_ready(False):
+            partial.ready()
         self.assertIs(partial._trusts_tup_image_registry_id, isolated_meta)
         self.assertIs(partial._trusts_tup_meta_registry_id, isolated_meta)
         self.assertEqual(len(isolated_meta.plan_for(Image).records), 0)
         self.assertEqual(len(isolated_meta.plan_for(Meta).records), 1)
+        forget_models(Receipt, Image, Meta, _orphan)
 
 
 @isolate_apps(
@@ -511,6 +518,7 @@ class IsolatedAppsDoesNotDonateDependentContributionTest(SimpleTestCase):
         contributor.apps = self.isolated_apps
         contributor.holder_model = Receipt
         contributor.ready()
+        forget_models(Receipt, *_rest)
         self.assertFalse(self.isolated_apps.is_installed('trusts'))
         self.assertIsNone(
             getattr(contributor, '_trusts_tup_image_registry_id', None)
@@ -556,7 +564,8 @@ class DependentAuthorizationTest(_RegistryRestoreMixin, _UsersMixin, Transaction
             for image in extras
         ]
         contributor = _new_dependent_host(apps, self.Receipt)
-        contributor.ready()
+        with override_apps_ready(False):
+            contributor.ready()
         self.image_code = 'trusts_tests.change_%s' % self.Image._meta.model_name
         self.meta_code = 'trusts_tests.change_%s' % self.Meta._meta.model_name
         self.orphan_code = 'trusts_tests.change_%s' % self.Orphan._meta.model_name

--- a/trusts/test_issue89.py
+++ b/trusts/test_issue89.py
@@ -314,6 +314,39 @@ class LiveFreezeLifecycleTest(_RegistryRestoreMixin, SimpleTestCase):
         self.assertIs(self.live.configured_backend().registry, first)
         self.assertTrue(first.frozen)
 
+    def test_late_registry_assignment_freezes_replacement(self):
+        replacement = TrustsRegistry()
+        self.assertFalse(replacement.frozen)
+        before = self.live.registries[CONCRETE].records
+        self.live.registry = replacement
+        self.assertTrue(replacement.frozen)
+        self.assertIs(self.live.registries[CONCRETE], replacement)
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            _contribute_category(replacement)
+        self.assertIn('frozen', str(ctx.exception).lower())
+        self.assertEqual(replacement.records, ())
+        self.assertIs(self.live.configured_backend().registry, replacement)
+        self.assertEqual(self.live.registry.records, ())
+        self.assertNotEqual(before, replacement.records)
+
+    def test_assignment_before_ready_stays_writable_then_freezes_on_read(self):
+        replacement = TrustsRegistry()
+        with override_apps_ready(False):
+            self.live.registry = replacement
+            self.assertIs(self.live.registries[CONCRETE], replacement)
+            self.assertFalse(replacement.frozen)
+            _contribute_category(replacement)
+            self.assertFalse(replacement.frozen)
+        self.assertFalse(replacement.frozen)
+        handle = self.live.configured_backend()
+        self.assertIs(handle.registry, replacement)
+        self.assertTrue(replacement.frozen)
+        before = replacement.records
+        with self.assertRaises(TrustsConfigurationError):
+            _contribute_ticket(replacement)
+        self.assertEqual(replacement.records, before)
+        self.assertEqual(len(replacement.plan_for(Category).records), 1)
+
     def test_standalone_appconfig_does_not_auto_freeze(self):
         import trusts
 

--- a/trusts/test_issue89.py
+++ b/trusts/test_issue89.py
@@ -18,6 +18,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 
 from tests.apps import (
     TestsConfig,
+    forget_models,
     install_writable_registry,
     override_apps_ready,
 )
@@ -83,19 +84,30 @@ def _new_contributor(apps_registry):
     return contributor
 
 
-def _forget_models(*model_classes):
-    all_models = apps.all_models
-    for model in model_classes:
-        all_models[model._meta.app_label].pop(model._meta.model_name, None)
-    apps.clear_cache()
-
-
 @contextmanager
 def _dynamic_models(*model_classes):
     try:
         yield model_classes
     finally:
-        _forget_models(*model_classes)
+        forget_models(*model_classes)
+
+
+def _forget_leftover_detectable_models():
+    known = {
+        Category, Ticket, Trust, TestGroupJunction, AutoAdminCategory,
+        ManualAdminCategory, AutoAdminJunction,
+    }
+    leftovers = [
+        model for model in apps.get_models()
+        if model not in known
+        and (
+            (issubclass(model, Content) and model is not Content)
+            or (issubclass(model, Junction) and model is not Junction)
+        )
+        and not model._meta.abstract
+        and not model._meta.proxy
+    ]
+    forget_models(*leftovers)
 
 
 class _RegistryRestoreMixin(object):
@@ -377,7 +389,11 @@ class SentinelAfterFreezeTest(_RegistryRestoreMixin, SimpleTestCase):
         self.assertFalse(isolated.plan_for(Trust).records)
 
 
-class MissingDeclarationCheckTest(_RegistryRestoreMixin, SimpleTestCase):
+class MissingDeclarationCheckTest(_RegistryRestoreMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        _forget_leftover_detectable_models()
+
     def test_declared_terminals_have_no_e003(self):
         messages = _e003()
         self.assertEqual(messages, [])

--- a/trusts/test_issue89.py
+++ b/trusts/test_issue89.py
@@ -1,0 +1,584 @@
+"""S8: freeze live registries and report detectable missing declarations.
+
+Structural and behavioral tests only — no source-token or
+``inspect.getsource`` assertions. Isolated ``TrustsRegistry()``
+instances stay independent of Django readiness.
+"""
+
+from contextlib import contextmanager
+from io import StringIO
+from unittest.mock import patch
+
+from django.apps import apps
+from django.contrib.auth.models import Group, Permission, User
+from django.core.checks import Error, run_checks
+from django.core.management import call_command
+from django.db import models
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from tests.apps import (
+    TestsConfig,
+    install_writable_registry,
+    override_apps_ready,
+)
+import tests as tests_module
+from tests.models import (
+    AutoAdminCategory,
+    AutoAdminJunction,
+    Category,
+    ManualAdminCategory,
+    TestGroupJunction,
+    Ticket,
+)
+from trusts.apps import AppConfig as TrustsAppConfig
+from trusts.checks import (
+    CHECK_ID_MISSING_DECLARATION,
+    CHECK_ID_LEGACY_CALLBACK_WARNING,
+    check_missing_declarations,
+    check_permission_conditions,
+    check_query_compilers,
+)
+from trusts.core import Ref, TrustsConfigurationError, TrustsRegistry
+from trusts.models import Content, Junction, Trust, TrustUserPermission
+
+
+CONCRETE = 'trusts.backends.TrustModelBackend'
+MIXIN = 'tests.backends.MixinOnlyBackend'
+HOST = 'tests.backends.HostTrustModelBackend'
+
+
+def _e003(messages=None):
+    if messages is None:
+        messages = check_missing_declarations(None)
+    return [message for message in messages if message.id == CHECK_ID_MISSING_DECLARATION]
+
+
+def _objs(messages):
+    return {message.obj for message in messages}
+
+
+def _contribute_category(registry):
+    j = Ref(TrustUserPermission)
+    rev = Category._meta.get_field('trust').remote_field.get_accessor_name()
+    registry.register(
+        content=getattr(j.trust, rev),
+        user=j.entity,
+        permission=j.permission,
+    )
+
+
+def _contribute_ticket(registry):
+    j = Ref(TrustUserPermission)
+    rev = Ticket._meta.get_field('trust').remote_field.get_accessor_name()
+    registry.register(
+        content=getattr(j.trust, rev),
+        user=j.entity,
+        permission=j.permission,
+    )
+
+
+def _new_contributor(apps_registry):
+    contributor = TestsConfig('tests', tests_module)
+    contributor.apps = apps_registry
+    return contributor
+
+
+def _forget_models(*model_classes):
+    all_models = apps.all_models
+    for model in model_classes:
+        all_models[model._meta.app_label].pop(model._meta.model_name, None)
+    apps.clear_cache()
+
+
+@contextmanager
+def _dynamic_models(*model_classes):
+    try:
+        yield model_classes
+    finally:
+        _forget_models(*model_classes)
+
+
+class _RegistryRestoreMixin(object):
+    def setUp(self):
+        super().setUp()
+        self.live = apps.get_app_config('trusts')
+        self.saved_registries = dict(self.live.registries)
+        self.saved_trust_sentinel = getattr(
+            self.live, '_trusts_tup_trust_registry_id', None
+        )
+        self.saved_trust_ids = getattr(
+            self.live, '_trusts_tup_trust_registry_ids', None
+        )
+        self.live_contributor = apps.get_app_config('trusts_tests')
+        self.saved_category_sentinel = getattr(
+            self.live_contributor, '_trusts_tup_category_registry_id', None
+        )
+        self.saved_ticket_sentinel = getattr(
+            self.live_contributor, '_trusts_tup_ticket_registry_id', None
+        )
+        self.saved_group_sentinel = getattr(
+            self.live_contributor, '_trusts_tup_group_registry_id', None
+        )
+
+    def tearDown(self):
+        self.live.registries.clear()
+        self.live.registries.update(self.saved_registries)
+        self.live._trusts_tup_trust_registry_id = self.saved_trust_sentinel
+        if self.saved_trust_ids is None:
+            if hasattr(self.live, '_trusts_tup_trust_registry_ids'):
+                delattr(self.live, '_trusts_tup_trust_registry_ids')
+        else:
+            self.live._trusts_tup_trust_registry_ids = self.saved_trust_ids
+        self.live_contributor._trusts_tup_category_registry_id = (
+            self.saved_category_sentinel
+        )
+        self.live_contributor._trusts_tup_ticket_registry_id = (
+            self.saved_ticket_sentinel
+        )
+        self.live_contributor._trusts_tup_group_registry_id = (
+            self.saved_group_sentinel
+        )
+        super().tearDown()
+
+
+class StandaloneFreezeIndependenceTest(SimpleTestCase):
+    def test_standalone_stays_writable_after_global_ready(self):
+        self.assertTrue(apps.ready)
+        first = TrustsRegistry()
+        second = TrustsRegistry()
+        self.assertFalse(first.frozen)
+        self.assertFalse(second.frozen)
+        first.freeze()
+        self.assertTrue(first.frozen)
+        self.assertFalse(second.frozen)
+        _contribute_ticket(second)
+        self.assertEqual(len(second.plan_for(Ticket).records), 1)
+        self.assertFalse(second.frozen)
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            _contribute_ticket(first)
+        self.assertIn('frozen', str(ctx.exception).lower())
+        self.assertEqual(first.records, ())
+
+    def test_freeze_is_idempotent_and_register_does_not_inspect_apps_ready(self):
+        registry = TrustsRegistry()
+        _contribute_category(registry)
+        before = registry.records
+        registry.freeze()
+        registry.freeze()
+        self.assertTrue(registry.frozen)
+        self.assertTrue(apps.ready)
+        with patch.object(apps, 'ready', True):
+            with self.assertRaises(TrustsConfigurationError):
+                _contribute_ticket(registry)
+        self.assertEqual(registry.records, before)
+        self.assertIs(registry.plan_for(Category).records[0], before[0])
+
+
+class RegisterAfterFreezeLeavesRecordsUnchangedTest(SimpleTestCase):
+    def test_valid_duplicate_conflict_and_malformed_all_raise(self):
+        registry = TrustsRegistry()
+        j = Ref(TrustUserPermission)
+        rev = Category._meta.get_field('trust').remote_field.get_accessor_name()
+        registry.register(
+            content=getattr(j.trust, rev),
+            user=j.entity,
+            permission=j.permission,
+        )
+        before = registry.records
+        registry.freeze()
+
+        ticket_rev = Ticket._meta.get_field('trust').remote_field.get_accessor_name()
+        attempts = (
+            dict(
+                content=getattr(j.trust, ticket_rev),
+                user=j.entity,
+                permission=j.permission,
+            ),
+            dict(
+                content=getattr(j.trust, rev),
+                user=j.entity,
+                permission=j.permission,
+            ),
+            dict(
+                content=getattr(j.trust, rev),
+                user=j.permission,
+                permission=j.entity,
+            ),
+            dict(content='not-a-ref', user=j.entity, permission=j.permission),
+        )
+        for kwargs in attempts:
+            with self.assertRaises(TrustsConfigurationError) as ctx:
+                registry.register(**kwargs)
+            self.assertIn('frozen', str(ctx.exception).lower())
+        self.assertEqual(registry.records, before)
+        self.assertEqual(len(registry.plan_for(Category).records), 1)
+        self.assertEqual(len(registry.plan_for(Ticket).records), 0)
+
+
+class FrozenPlanProjectionsTest(SimpleTestCase):
+    def test_frozen_plan_still_projects(self):
+        registry = TrustsRegistry()
+        _contribute_category(registry)
+        before = registry.plan_for(Category)
+        registry.freeze()
+        plan = registry.plan_for(Category)
+        self.assertEqual(plan.records, before.records)
+        user = User(pk=1)
+        permission = Permission(pk=1)
+        exists = plan.content_exists(user, permission)
+        self.assertIsNotNone(exists)
+        self.assertFalse(
+            registry.plan_for(Ticket).records,
+        )
+        qs = Category.objects.all()
+        filtered = registry.filter_authorized(qs, user, permission)
+        self.assertIs(filtered.model, Category)
+
+
+class LiveFreezeLifecycleTest(_RegistryRestoreMixin, SimpleTestCase):
+    def test_writable_during_contributor_ready_then_freeze_on_first_read(self):
+        isolated = TrustsRegistry()
+        self.live.registries[CONCRETE] = isolated
+        self.assertFalse(isolated.frozen)
+        with override_apps_ready(False):
+            handle = self.live.configured_backend()
+            self.assertIs(handle.registry, isolated)
+            self.assertFalse(isolated.frozen)
+            _contribute_category(isolated)
+            alias = self.live.registry
+            self.assertIs(alias, isolated)
+            self.assertFalse(isolated.frozen)
+            handles = self.live.configured_handles()
+            self.assertIs(handles[0].registry, isolated)
+            self.assertFalse(isolated.frozen)
+        handle = self.live.configured_backend()
+        self.assertIs(handle.registry, isolated)
+        self.assertTrue(isolated.frozen)
+        self.assertIs(self.live.registry, isolated)
+        self.assertIs(self.live.configured_handles()[0].registry, isolated)
+        with self.assertRaises(TrustsConfigurationError):
+            _contribute_ticket(isolated)
+        self.assertEqual(len(isolated.plan_for(Category).records), 1)
+        self.assertEqual(len(isolated.plan_for(Ticket).records), 0)
+
+    def test_multi_path_reversed_duplicate_and_late_observed_path(self):
+        with override_settings(AUTHENTICATION_BACKENDS=(MIXIN, CONCRETE)):
+            handles = self.live.configured_handles()
+            self.assertEqual([handle.path for handle in handles], [MIXIN, CONCRETE])
+            self.assertIs(handles[0].registry, self.live.registries[MIXIN])
+            self.assertIs(handles[1].registry, self.live.registries[CONCRETE])
+            self.assertTrue(handles[0].registry.frozen)
+            self.assertTrue(handles[1].registry.frozen)
+            self.assertIs(
+                self.live.configured_backend(MIXIN).registry,
+                self.live.registries[MIXIN],
+            )
+            self.assertIs(
+                self.live.configured_backend(CONCRETE).registry,
+                self.live.registries[CONCRETE],
+            )
+        with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, CONCRETE)):
+            handle = self.live.configured_backend()
+            self.assertEqual(handle.path, CONCRETE)
+            self.assertIs(handle.registry, self.live.registries[CONCRETE])
+            self.assertTrue(handle.registry.frozen)
+            self.assertIs(self.live.registry, handle.registry)
+        self.assertNotIn(HOST, self.live.registries)
+        with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, HOST)):
+            late = self.live.configured_backend(HOST)
+            self.assertIs(late.registry, self.live.registries[HOST])
+            self.assertTrue(late.registry.frozen)
+            with self.assertRaises(TrustsConfigurationError):
+                _contribute_category(late.registry)
+            again = self.live.configured_backend(HOST)
+            self.assertIs(again.registry, late.registry)
+
+    def test_ready_does_not_replace_stored_objects_when_freezing(self):
+        store = self.live.registries
+        first = self.live.registries[CONCRETE]
+        self.live.ready()
+        self.assertIs(self.live.registries, store)
+        self.assertIs(self.live.registries[CONCRETE], first)
+        self.assertIs(self.live.configured_backend().registry, first)
+        self.assertTrue(first.frozen)
+
+    def test_standalone_appconfig_does_not_auto_freeze(self):
+        import trusts
+
+        isolated = TrustsAppConfig('trusts', trusts)
+        self.assertFalse(isolated._apps_instance_ready())
+        first = isolated.registry
+        self.assertFalse(first.frozen)
+        isolated.ready()
+        self.assertIs(isolated.registry, first)
+        self.assertFalse(first.frozen)
+        self.assertTrue(first.plan_for(Trust).records)
+
+
+class SentinelAfterFreezeTest(_RegistryRestoreMixin, SimpleTestCase):
+    def test_same_instance_reentry_is_noop_after_freeze(self):
+        handle = self.live.configured_backend()
+        self.assertTrue(handle.registry.frozen)
+        before = handle.registry.records
+        with patch.object(
+            handle.registry, 'register', wraps=handle.registry.register,
+        ) as register:
+            self.live.ready()
+            self.live_contributor.ready()
+        register.assert_not_called()
+        self.assertEqual(handle.registry.records, before)
+        self.assertIs(
+            self.live_contributor._trusts_tup_category_registry_id,
+            handle.registry,
+        )
+
+    def test_new_contributor_cannot_mutate_frozen_live_store(self):
+        handle = self.live.configured_backend()
+        before = handle.registry.records
+        contributor = _new_contributor(apps)
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            contributor.ready()
+        self.assertIn('frozen', str(ctx.exception).lower())
+        self.assertEqual(handle.registry.records, before)
+        self.assertIsNone(
+            getattr(contributor, '_trusts_tup_category_registry_id', None)
+        )
+        self.assertIsNone(
+            getattr(contributor, '_trusts_tup_ticket_registry_id', None)
+        )
+        self.assertIsNone(
+            getattr(contributor, '_trusts_tup_group_registry_id', None)
+        )
+
+    def test_partial_late_contribution_raises_without_setting_sentinel(self):
+        isolated = install_writable_registry(self.live, CONCRETE)
+        self.live.configured_backend()
+        self.assertTrue(isolated.frozen)
+        contributor = _new_contributor(apps)
+        contributor._trusts_tup_category_registry_id = isolated
+        with self.assertRaises(TrustsConfigurationError):
+            contributor.ready()
+        self.assertIs(contributor._trusts_tup_category_registry_id, isolated)
+        self.assertIsNone(
+            getattr(contributor, '_trusts_tup_ticket_registry_id', None)
+        )
+        self.assertEqual(isolated.records, ())
+
+    def test_package_ready_after_supported_read_cannot_mutate_new_registry(self):
+        isolated = install_writable_registry(self.live, CONCRETE)
+        self.live.configured_backend()
+        self.assertTrue(isolated.frozen)
+        with self.assertRaises(TrustsConfigurationError):
+            self.live.ready()
+        self.assertIsNot(
+            getattr(self.live, '_trusts_tup_trust_registry_id', None),
+            isolated,
+        )
+        self.assertFalse(isolated.plan_for(Trust).records)
+
+
+class MissingDeclarationCheckTest(_RegistryRestoreMixin, SimpleTestCase):
+    def test_declared_terminals_have_no_e003(self):
+        messages = _e003()
+        self.assertEqual(messages, [])
+        self.assertFalse(
+            _objs(messages) & {Category, Ticket, Trust, TestGroupJunction, Group}
+        )
+
+    def test_undeclared_content_and_junction_are_reported(self):
+        class OrphanSheet(Content):
+            title = models.CharField(max_length=12)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        class OrphanTarget(models.Model):
+            title = models.CharField(max_length=12)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        class OrphanJunction(Junction):
+            content = models.ForeignKey(
+                OrphanTarget, unique=True, on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        with _dynamic_models(OrphanSheet, OrphanTarget, OrphanJunction):
+            messages = _e003()
+            objs = _objs(messages)
+            self.assertIn(OrphanSheet, objs)
+            self.assertIn(OrphanJunction, objs)
+            self.assertNotIn(OrphanTarget, objs)
+            self.assertNotIn(Category, objs)
+            self.assertTrue(all(isinstance(message, Error) for message in messages))
+            self.assertTrue(all(message.hint for message in messages))
+            sheet = [message for message in messages if message.obj is OrphanSheet]
+            junction = [
+                message for message in messages if message.obj is OrphanJunction
+            ]
+            self.assertEqual(len(sheet), 1)
+            self.assertEqual(len(junction), 1)
+            self.assertIn('OrphanSheet', sheet[0].msg)
+            self.assertIn('OrphanJunction', junction[0].msg)
+            self.assertIn('exact backend path', sheet[0].hint)
+
+    def test_coverage_on_second_handle_only_clears_e003(self):
+        class SecondSheet(Content):
+            title = models.CharField(max_length=12)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        with _dynamic_models(SecondSheet):
+            self.assertIn(SecondSheet, _objs(_e003()))
+            with override_settings(AUTHENTICATION_BACKENDS=(CONCRETE, MIXIN)):
+                mixin = install_writable_registry(self.live, MIXIN)
+                j = Ref(TrustUserPermission)
+                rev = SecondSheet._meta.get_field(
+                    'trust',
+                ).remote_field.get_accessor_name()
+                mixin.register(
+                    content=getattr(j.trust, rev),
+                    user=j.entity,
+                    permission=j.permission,
+                )
+                self.assertNotIn(SecondSheet, _objs(_e003()))
+                self.assertFalse(
+                    self.live.configured_backend(CONCRETE).registry.plan_for(
+                        SecondSheet,
+                    ).records
+                )
+                self.assertTrue(
+                    self.live.configured_backend(MIXIN).registry.plan_for(
+                        SecondSheet,
+                    ).records
+                )
+
+    def test_abstract_proxy_and_manual_dependents_are_not_reported(self):
+        class AbstractHolder(Content):
+            class Meta:
+                abstract = True
+                app_label = 'trusts_tests'
+
+        class ManualImage(models.Model):
+            title = models.CharField(max_length=12)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        with _dynamic_models(ManualImage):
+            messages = _e003()
+            objs = _objs(messages)
+            self.assertNotIn(AbstractHolder, objs)
+            self.assertNotIn(AutoAdminCategory, objs)
+            self.assertNotIn(ManualAdminCategory, objs)
+            self.assertNotIn(AutoAdminJunction, objs)
+            self.assertNotIn(ManualImage, objs)
+
+    def test_malformed_junction_is_diagnostic_not_a_crash(self):
+        class BrokenJunction(Junction):
+            extra = models.ForeignKey(
+                User, null=True, on_delete=models.SET_NULL,
+            )
+            other = models.ForeignKey(
+                Group, null=True, on_delete=models.SET_NULL,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        with _dynamic_models(BrokenJunction):
+            messages = _e003()
+            broken = [message for message in messages if message.obj is BrokenJunction]
+            self.assertEqual(len(broken), 1)
+            self.assertIsInstance(broken[0], Error)
+            self.assertIn('malformed', broken[0].msg.lower())
+            self.assertEqual(broken[0].id, CHECK_ID_MISSING_DECLARATION)
+
+    def test_check_is_zero_sql_and_does_not_register(self):
+        live = self.live.configured_backend().registry
+        before = live.records
+        sentinels = (
+            getattr(self.live, '_trusts_tup_trust_registry_id', None),
+            getattr(self.live_contributor, '_trusts_tup_category_registry_id', None),
+        )
+        with self.assertNumQueries(0):
+            messages = check_missing_declarations(None)
+        self.assertEqual(_e003(messages), [])
+        self.assertEqual(live.records, before)
+        self.assertEqual(
+            (
+                getattr(self.live, '_trusts_tup_trust_registry_id', None),
+                getattr(self.live_contributor, '_trusts_tup_category_registry_id', None),
+            ),
+            sentinels,
+        )
+        with patch.object(live, 'register') as register:
+            check_missing_declarations(None)
+        register.assert_not_called()
+
+    def test_manage_py_check_subset_and_direct_invocation(self):
+        with self.assertNumQueries(0):
+            out = StringIO()
+            err = StringIO()
+            call_command('check', stdout=out, stderr=err)
+            combined = out.getvalue() + err.getvalue()
+        self.assertNotIn(CHECK_ID_MISSING_DECLARATION, combined)
+        with self.assertNumQueries(0):
+            out = StringIO()
+            err = StringIO()
+            call_command('check', 'trusts', stdout=out, stderr=err)
+            subset = out.getvalue() + err.getvalue()
+        self.assertNotIn(CHECK_ID_MISSING_DECLARATION, subset)
+        trusts_only = [apps.get_app_config('trusts')]
+        with self.assertNumQueries(0):
+            subset_messages = check_missing_declarations(app_configs=trusts_only)
+        self.assertEqual(_e003(subset_messages), [])
+
+    def test_e003_coexists_and_silencing_does_not_authorize(self):
+        class QuietSheet(Content):
+            title = models.CharField(max_length=12)
+
+            class Meta:
+                app_label = 'trusts_tests'
+                managed = False
+
+        with _dynamic_models(QuietSheet):
+            all_ids = {message.id for message in run_checks()}
+            self.assertIn(CHECK_ID_MISSING_DECLARATION, all_ids)
+            condition_ids = {message.id for message in check_permission_conditions(None)}
+            compiler_ids = {message.id for message in check_query_compilers(None)}
+            self.assertNotIn(CHECK_ID_MISSING_DECLARATION, condition_ids)
+            self.assertNotIn(CHECK_ID_MISSING_DECLARATION, compiler_ids)
+            self.assertNotIn(CHECK_ID_LEGACY_CALLBACK_WARNING, _e003())
+            with override_settings(
+                SILENCED_SYSTEM_CHECKS=['trusts.E003', 'fields.W342'],
+            ):
+                silenced = check_missing_declarations(None)
+                self.assertTrue(silenced)
+                self.assertTrue(all(message.is_silenced() for message in silenced))
+                call_command('check', stdout=StringIO(), stderr=StringIO())
+            self.assertFalse(
+                self.live.configured_backend().registry.plan_for(QuietSheet).records
+            )
+
+
+class LiveHandleIdentityTest(_RegistryRestoreMixin, SimpleTestCase):
+    def test_supported_surfaces_return_the_same_stored_object(self):
+        stored = self.live.registries[CONCRETE]
+        handle = self.live.configured_backend()
+        alias = self.live.registry
+        handles = self.live.configured_handles()
+        self.assertIs(handle.registry, stored)
+        self.assertIs(alias, stored)
+        self.assertIs(handles[0].registry, stored)
+        self.assertTrue(stored.frozen)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #89.

Parent design: #69 r2 (accepted). Predecessor #87 / PR #88 merged to `dev` as `df9b51858047566574f378c3df2b648fb386fd4e`.

## Goal

S8 only — the final #69 slice:

1. Freeze each live AppConfig-owned, path-scoped registry after Django application population so authorization plans cannot mutate late.
2. Add zero-SQL `trusts.E003` diagnostics for structurally detectable missing Content/Junction declarations.

Standalone `TrustsRegistry()` instances remain independent and writable unless explicitly frozen.

## Freeze contract

- Instance-owned `TrustsRegistry.freeze()` / `.frozen`.
- `register()` on that exact frozen instance raises `TrustsConfigurationError` before validation or mutation. Records stay unchanged.
- Standalone/isolated registries never inspect Django's global readiness and never auto-freeze.
- Freeze is owned by `trusts.apps.AppConfig` for the existing objects in its path-scoped `registries` store. `ready()` does not replace those objects.
- `configured_backend(path)`, `configured_handles()`, and the one-path `registry` alias return the same stored object and freeze it on first read when **that AppConfig's `self.apps.ready`** is true.
- After readiness, the `registry` setter freezes the replacement before storing it, so a caller-held reference cannot mutate the live store. Assignment before ready stays writable and freezes on the first supported post-populate read.
- During `Apps.populate`, contributor `ready()` methods remain writable. After population, a newly observed live path is frozen before exposure.
- Same-contributor re-entry after freeze is a sentinel no-op. A new/failed/partial late contribution raises.

## E003

Django model check `trusts.E003` walks `apps.get_models()` and reports, without registering anything:

- each concrete, non-proxy, non-abstract `Content` subclass with no covering record on any valid configured Trusts handle
- each concrete, non-proxy, non-abstract `Junction` subclass whose `get_content_model()` has no covering record on any valid handle

Coverage on one exact handle is enough. Manual dependents stay outside E003 and fail closed at runtime. Malformed Junction contracts become diagnostics. 0 SQL. Coexists with E001/E002/W001/E004.

## Docs

`migrates.md` records the old mutable-live-registry vs new lifecycle, exception/no-partial-write behavior, host AppConfig timing, E003 domain, authorization implications, rollback, and a migration-bot checklist. Registry docs distinguish the supported AppConfig handle API from isolated standalone registries.

## Local verification

- `python3 -m tests.runtests`: 453 tests, 1 expected failure
- `python3 -m django check --settings=tests.settings`: no issues (1 silenced)
- fresh `migrate --noinput`
- `scripts/verify-legacy-upgrade.py`: ok

## Boundaries

No condition-registry migration, callback relocation, historical group-trustee replacement, backend/module extraction, graph/CTE/inheritance, #54/Zero, GH, example #7, Windows #17, schema, migration, permission identity, or package-version work.

Rollback is removal of AppConfig-owned freezing and E003 only; S1–S7 remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d346170e-7def-4cee-9666-161bd657bf02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d346170e-7def-4cee-9666-161bd657bf02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

