### PR TITLE
#115: write the core README for implementation authors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
         python -m pip install "Django>=6.1,<6.2"
         python -m build
         twine check dist/*
+    - name: Package metadata (README, LICENSE, BSD-2-Clause)
+      run: python scripts/verify-package-metadata.py
     - name: Install kernel wheel and import from outside the checkout
       env:
         PYTHONPATH: ""

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,99 @@
+# DEV.md — contributor / development history
+
+This file is an internal development record. It may describe
+unsupported or superseded states. The user-facing package introduction
+is [README.md](README.md). `pyproject.toml` long-description metadata
+points at `README.md`, not this file.
+
+## Current pairing
+
+This tree is `django-trusts==1.0.0.dev3`, the final core-library cut
+([#112](https://github.com/django-trusts/django-trusts/pull/112)
+merge `11058641b533e0f8489598e0b1f5cbe5d42a81db`). That mark is a
+development-line identifier, not a production 1.0 release. See
+[docs/development-version.md](docs/development-version.md).
+
+The completed Zero user path is django-trusts-zero
+[#14](https://github.com/django-trusts/django-trusts-zero/pull/14)
+merge `f0b25c5562c4f9803d861503dd2acac21613119d`
+(`django-trusts-zero==1.0.0.dev0`).
+
+Core is a Python dependency only: do **not** list `'trusts'` in
+`INSTALLED_APPS`. Final core ships no Django `AppConfig`, no
+`kernel_config()`, and no `trusts.backends.TrustModelBackend`. The
+mixin stays at `trusts.backends.TrustModelBackendMixin`. Historical
+Trust / Content / settlor / trustee models and the concrete backend
+live only in `django-trusts-zero`.
+
+Pair CI still pins the supported Zero companion
+`94e0fa109a8a7a5f53a028438ada899cbc1be1ad` for existing Matrix B and
+wheel-overlay proofs. That pin is independent of Zero's later
+user-README rewrite.
+
+## What this package is not
+
+Earlier top-level README copy described django-trusts itself as a
+multiple-organization Trust/settlor/trustee add-on with concrete
+`Content` / `Group` models. That product description is false for this
+library after the final core cut. Readers who want that 0.x behavior
+should use [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero).
+
+## Supported versions
+
+The `1.0.0.dev3` development line requires **Python 3.12–3.14** and
+**Django 6.1**. Sources checked on 2026-09-07 and the rationale are in
+[docs/support-matrix.md](docs/support-matrix.md).
+
+This is not a published PyPI release. Install from a local checkout or
+sdist/wheel built from this tree.
+
+```
+python -m pip install "Django>=6.1,<6.2"
+python -m pip install .
+```
+
+A host implementation owns `INSTALLED_APPS` and
+`AUTHENTICATION_BACKENDS`. One supported pairing is:
+
+```
+INSTALLED_APPS = (
+    'trusts.zero.apps.ZeroConfig',
+)
+AUTHENTICATION_BACKENDS = (
+    'trusts.zero.backends.TrustModelBackend',
+)
+```
+
+API and compatibility notes for this modernization are in
+[migrates.md](migrates.md).
+
+## Test
+
+```
+python -m pip install "Django>=6.1,<6.2" coverage
+python -m pip install -e .
+python -m tests.runtests
+python -m django check --settings=tests.settings
+python scripts/verify-legacy-upgrade.py
+```
+
+CI is GitHub Actions (`.github/workflows/ci.yml`): kernel-only
+authorization tests, a fresh migrate, `manage.py check`, an OrderedFold
+PostgreSQL job, pair proofs against the supported Zero companion, and a
+`package` job that builds an sdist/wheel, checks that the long description
+comes from the user `README.md` (not this file), verifies BeeDesk
+2015-2026 / BSD-2-Clause `LICENSE` metadata, and imports the wheel from a
+temporary directory so the source tree cannot satisfy the import. Do not
+treat a removed Travis check as a stand-in green status.
+
+## Legacy baseline
+
+The exact pre-modernization default-branch commit, existing release tags,
+source archive checksum, and historical Python/Django requirements are
+recorded in [docs/legacy-baseline.md](docs/legacy-baseline.md). That
+snapshot is historical documentation only.
+
+## License
+
+BSD-2-Clause. Copyright holder is exactly BeeDesk, Inc. Notice years
+are 2015-2026.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, BeeDesk, Inc.
+Copyright (c) 2015-2026, BeeDesk, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include DEV.md
 include requirements.txt
 include migrates.md
 include pyproject.toml

--- a/README.md
+++ b/README.md
@@ -43,47 +43,61 @@ rows that an implementation defines.
 
 ## Install
 
-```bash
-pip install django-trusts
-```
-
 This is a development release of the 1.x line, not a declared stable
 1.0, and not a published PyPI release. Install from a local checkout
-or a built sdist/wheel until a stable tag exists.
+or a built sdist/wheel:
+
+```
+python -m pip install "Django>=6.1,<6.2"
+python -m pip install .
+```
 
 Requires **Python 3.12–3.14** and **Django 6.1**. See
 [docs/support-matrix.md](docs/support-matrix.md).
 
 ## Configure
 
-These imports and settings match the project's verified test
-configuration. A real implementation substitutes its own app module,
-`TrustsImplementationConfig` subclass, and mixin backend path.
+The worked example is the `tests.myapp` consumer in this tree. Every
+import and settings path below is that module.
 
 ```python
 from django.contrib.auth.backends import ModelBackend
 
 from trusts.apps import TrustsImplementationConfig
 from trusts.backends import TrustModelBackendMixin
+from trusts.core import Ref
 
-HOST_BACKEND = 'tests.backends.HostTrustModelBackend'
+DOCUMENT_BACKEND = 'tests.myapp.backends.DocumentBackend'
 
-class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):
+class DocumentBackend(TrustModelBackendMixin, ModelBackend):
     pass
 
-class KernelHostConfig(TrustsImplementationConfig):
-    name = 'tests.kernel_host'
-    label = 'trusts_kernel_host'
-    trusts_backend_paths = (HOST_BACKEND,)
+class DocumentConfig(TrustsImplementationConfig):
+    name = 'tests.myapp'
+    label = 'myapp'
+    trusts_backend_paths = (DOCUMENT_BACKEND,)
+
+    def ready(self):
+        super().ready()
+        from tests.myapp.models import DocumentGrant
+
+        handle = self.configured_backend()
+        registry = handle.registry
+        j = Ref(DocumentGrant)
+        registry.register(
+            content=j.document,
+            user=j.user,
+            permission=j.permission,
+        )
 
 INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.auth',
-    'tests.kernel_host.apps.KernelHostConfig',
+    'tests.myapp.apps.DocumentConfig',
 )
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
-    'tests.backends.HostTrustModelBackend',
+    'tests.myapp.backends.DocumentBackend',
 )
 ```
 
@@ -91,15 +105,14 @@ Do not add `'trusts'` to `INSTALLED_APPS`.
 
 ## Declare and authorize
 
-Ordinary application-owned models plus one `Ref` registration. Grant
-mutation happens through those models; core has no generic grant/revoke
-workflow.
+Ordinary application-owned models plus the `Ref` registration above.
+Grant mutation happens through those models; core has no generic
+grant/revoke workflow.
 
 ```python
 from django.contrib.auth.models import Permission
 from django.db import models
 
-from trusts.core import Ref
 from trusts.query import AuthorizedManager
 
 class Document(models.Model):
@@ -107,7 +120,7 @@ class Document(models.Model):
     objects = AuthorizedManager()
 
     class Meta:
-        app_label = 'trusts_tests'
+        app_label = 'myapp'
 
 class DocumentGrant(models.Model):
     document = models.ForeignKey(Document, on_delete=models.CASCADE)
@@ -115,29 +128,23 @@ class DocumentGrant(models.Model):
     permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
 
     class Meta:
-        app_label = 'trusts_tests'
+        app_label = 'myapp'
 
-j = Ref(DocumentGrant)
-registry.register(
-    content=j.document,
-    user=j.user,
-    permission=j.permission,
-)
 DocumentGrant.objects.create(
     document=document, user=user, permission=change_permission,
 )
-user.has_perm('trusts_tests.change_document', document)
+user.has_perm('myapp.change_document', document)
 Document.objects.authorized(user, change_permission)
 ```
 
-View guard, copied from the passing decorator test:
+View guard for the same permission:
 
 ```python
 from trusts.decorators import permission_required
 
-@permission_required('auth.read_group', fieldlookups_kwargs={'pk': 'pk'})
-def view_group(request, pk):
-    ...
+@permission_required('myapp.change_document', fieldlookups_kwargs={'pk': 'pk'})
+def edit_document(request, pk):
+    return 'ok'
 ```
 
 ## Documentation
@@ -151,4 +158,4 @@ def view_group(request, pk):
 
 Contributor and build history lives in [DEV.md](DEV.md).
 
-Licensed under the BSD 2-Clause License. Copyright BeeDesk, Inc.
+Copyright BeeDesk, Inc., 2015–2026 (BSD-2-Clause).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ from django.contrib.auth.models import Permission
 from django.db import models
 
 from trusts.core import Ref
-from trusts.decorators import permission_required
 from trusts.query import AuthorizedManager
 
 class Document(models.Model):
@@ -131,14 +130,13 @@ user.has_perm('trusts_tests.change_document', document)
 Document.objects.authorized(user, change_permission)
 ```
 
-View guard from the same passing test:
+View guard, copied from the passing decorator test:
 
 ```python
-@permission_required(
-    'trusts_tests.change_document',
-    fieldlookups_kwargs={'pk': 'pk'},
-)
-def edit_document(request, pk):
+from trusts.decorators import permission_required
+
+@permission_required('auth.read_group', fieldlookups_kwargs={'pk': 'pk'})
+def view_group(request, pk):
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,156 @@
-Django Trusts
--------------
+# django-trusts
 
-[![Docs](https://readthedocs.org/projects/django-trusts/badge/)](http://django-trusts.readthedocs.org) [![CI](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml)
+`django-trusts` is a **non-standalone Python dependency** for applications
+and packages that define their own declarative Django authorization
+implementation.
 
-Django authorization add-on for multiple organizations and object-level permission settings
+Core supplies no concrete permission schema, no Trust / Content / Group /
+ACL / organization / role models, no generic grant editor, and no Django
+`AppConfig`. Do **not** list `'trusts'` in `INSTALLED_APPS`. The consumer
+implementation owns its `TrustsImplementationConfig`, backend path,
+models, and persisted policy facts.
 
-Introduction
-------------
+## Which package?
 
-``django-trusts`` is a add-on to Django's builtin authorization. It strives to be a **minimal** implementation, adding only a single concept, ``trust``, to enable maintainable per-object permission settings for a django project that hosts users of multiple organizations  with a single user namespace.
+- Seeking or upgrading from django-trusts 0.x concrete Trust/Content
+  behavior → [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero)
+- Studying persisted organization / team / repository relationships →
+  [django-trusts-gh-permissions](https://github.com/django-trusts/django-trusts-gh-permissions)
+- Building a new permission implementation → continue here
 
-A ``trust`` is a relationship whereby content access is permitted by the creator [``settlor``] to specific user(s) [``trustee`` (s)] or ``group`` (s). Content can be an instance of a `Content` subclass, or of an existing model via a junction table. Access to multiple content can be permitted by a single ``trust`` for maintainable permssion settings. Django's builtin model, `group`, is supported and can be used to define reusuable permissions for a ``group`` of ``user``'s.
+A forthcoming Windows ordered-policy example will show explicit
+allow/deny rows. That reference implementation is not complete on the
+final core API yet.
 
-``django-trusts`` also strives to be a **scalable** solution. Permissions checking is offloaded to the database by design, and the implementation minimizes database hits. Permissions are cached per ``trust`` for the lifecycle of ``request user``. If a project's request lifecycle resolves most checked content to one or few ``trusts``, which should be very typically the case, this design should be a winner in term of performance. Permissions checking is done against an individual content or a ``QuerySet``.
+## Principles
 
-``django-trusts`` supports Django's builtins User models ``has_perm()`` / ``has_perms()`` and does not provides any in-addition.
+- **Minimal** — ordinary Django models plus compact declarations
+- **Declarative** — relationship paths name where user, permission, and
+  protected content meet
+- **Persisted truth** — authorization derives from stored relational
+  state, not transient application guesses
+- **Database-first** — object decisions and authorized querysets share
+  compiled policy; supported work is pushed into one SQL query before
+  pagination
+- **Fail closed** — malformed, unsupported, or missing policy cannot
+  become a grant
+- **Implementation-neutral** — core does not impose one permission schema
 
-Read more: http://django-trusts.readthedocs.org/en/latest/
+This is not an object-permission store. A grant may be implied by
+persisted organization relationships rather than requiring one
+permission row per user/object, or it may come from explicit policy
+rows that an implementation defines.
 
-Supported versions
-------------------
+## Install
 
-The `1.0.0.dev3` development line requires **Python 3.12–3.14** and **Django 6.1**.
-Sources checked on 2026-09-07 and the rationale are in
+```bash
+pip install django-trusts
+```
+
+This is a development release of the 1.x line, not a declared stable
+1.0, and not a published PyPI release. Install from a local checkout
+or a built sdist/wheel until a stable tag exists.
+
+Requires **Python 3.12–3.14** and **Django 6.1**. See
 [docs/support-matrix.md](docs/support-matrix.md).
 
-This is not a published PyPI release. Install from a local checkout or sdist/wheel
-built from this tree.
+## Configure
 
-```
-python -m pip install "Django>=6.1,<6.2"
-python -m pip install .
-```
+These imports and settings match the project's verified test
+configuration. A real implementation substitutes its own app module,
+`TrustsImplementationConfig` subclass, and mixin backend path.
 
-`django-trusts` is a Python library, not an installed Django app. Do not
-list `'trusts'` in `INSTALLED_APPS`. Install a host
-`TrustsImplementationConfig` such as `trusts.zero.apps.ZeroConfig` and
-set that host's canonical backend path:
+```python
+from django.contrib.auth.backends import ModelBackend
 
-```
+from trusts.apps import TrustsImplementationConfig
+from trusts.backends import TrustModelBackendMixin
+
+HOST_BACKEND = 'tests.backends.HostTrustModelBackend'
+
+class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):
+    pass
+
+class KernelHostConfig(TrustsImplementationConfig):
+    name = 'tests.kernel_host'
+    label = 'trusts_kernel_host'
+    trusts_backend_paths = (HOST_BACKEND,)
+
 INSTALLED_APPS = (
-    'trusts.zero.apps.ZeroConfig',
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'tests.kernel_host.apps.KernelHostConfig',
 )
 AUTHENTICATION_BACKENDS = (
-    'trusts.zero.backends.TrustModelBackend',
+    'django.contrib.auth.backends.ModelBackend',
+    'tests.backends.HostTrustModelBackend',
 )
 ```
 
-API and compatibility notes for this modernization are in [migrates.md](migrates.md).
+Do not add `'trusts'` to `INSTALLED_APPS`.
 
-Test
-----
+## Declare and authorize
 
+Ordinary application-owned models plus one `Ref` registration. Grant
+mutation happens through those models; core has no generic grant/revoke
+workflow.
+
+```python
+from django.contrib.auth.models import Permission
+from django.db import models
+
+from trusts.core import Ref
+from trusts.decorators import permission_required
+from trusts.query import AuthorizedManager
+
+class Document(models.Model):
+    title = models.CharField(max_length=200)
+    objects = AuthorizedManager()
+
+    class Meta:
+        app_label = 'trusts_tests'
+
+class DocumentGrant(models.Model):
+    document = models.ForeignKey(Document, on_delete=models.CASCADE)
+    user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+    class Meta:
+        app_label = 'trusts_tests'
+
+j = Ref(DocumentGrant)
+registry.register(
+    content=j.document,
+    user=j.user,
+    permission=j.permission,
+)
+DocumentGrant.objects.create(
+    document=document, user=user, permission=change_permission,
+)
+user.has_perm('trusts_tests.change_document', document)
+Document.objects.authorized(user, change_permission)
 ```
-python -m pip install "Django>=6.1,<6.2" coverage
-python -m pip install -e .
-python -m tests.runtests
-python -m django check --settings=tests.settings
-python scripts/verify-legacy-upgrade.py
+
+View guard from the same passing test:
+
+```python
+@permission_required(
+    'trusts_tests.change_document',
+    fieldlookups_kwargs={'pk': 'pk'},
+)
+def edit_document(request, pk):
+    ...
 ```
 
-CI is GitHub Actions (`.github/workflows/ci.yml`): kernel-only
-authorization tests, a fresh migrate, ``manage.py check``, an OrderedFold
-PostgreSQL job, pair proofs against the supported Zero companion, and a
-`package` job that builds an sdist/wheel and imports it from a temporary
-directory so the source tree cannot satisfy the import. Do not treat a
-removed Travis check as a stand-in green status.
+## Documentation
 
-Development version
--------------------
+- [migrates.md](migrates.md) — core API migration guide
+- [docs/source/index.rst](docs/source/index.rst) — full docs
+- [docs/support-matrix.md](docs/support-matrix.md) — Python / Django matrix
+- [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero) — 0.x continuation
+- [django-trusts-gh-permissions](https://github.com/django-trusts/django-trusts-gh-permissions) — organization/team/repository example
+- [Issues](https://github.com/django-trusts/django-trusts/issues)
 
-The active package version is **1.0.0.dev3**. That is a development-line mark,
-not a production 1.0 release. See [docs/development-version.md](docs/development-version.md).
+Contributor and build history lives in [DEV.md](DEV.md).
 
-Legacy baseline
----------------
-
-The exact pre-modernization default-branch commit, existing release tags, source
-archive checksum, and historical Python/Django requirements are recorded in
-[docs/legacy-baseline.md](docs/legacy-baseline.md). That snapshot is historical
-documentation only.
+Licensed under the BSD 2-Clause License. Copyright BeeDesk, Inc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-trusts"
 version = "1.0.0.dev3"
-description = "Django authorization add-on for multiple organizations and object-level permission settings"
+description = "Implementation-neutral Django authorization library for applications that declare their own permission layer"
 readme = "README.md"
 license = "BSD-2-Clause"
 authors = [
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
 ]
-keywords = ["django", "authorization", "permissions", "organizations"]
+keywords = ["django", "authorization", "permissions", "declarative"]
 
 [project.urls]
 Homepage = "https://github.com/django-trusts/django-trusts"

--- a/scripts/verify-package-metadata.py
+++ b/scripts/verify-package-metadata.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Prove wheel/sdist identity: core 1.0.0.dev3, BSD-2-Clause, user README."""
+
+from __future__ import annotations
+
+import os
+import tarfile
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSION = '1.0.0.dev3'
+EXPECTED_NAME = 'django-trusts'
+FORBIDDEN_LONG_DESC = (
+    'Step I',
+    'Step II',
+    'Step III',
+    'kernel_config',
+    'trusts.core_backends',
+    'pair pin',
+    'multiple organizations and object-level permission settings',
+)
+
+
+def _dist() -> Path:
+    return ROOT / 'dist'
+
+
+def _require_dist(files: list[Path], kind: str) -> Path:
+    if not files:
+        raise SystemExit('no %s in dist/' % kind)
+    return files[-1]
+
+
+def _check_metadata(meta_text: str, origin: str) -> None:
+    meta = Parser().parsestr(meta_text)
+    if meta.get('Name') != EXPECTED_NAME:
+        raise SystemExit('%s Name is %r, expected %s' % (origin, meta.get('Name'), EXPECTED_NAME))
+    if meta.get('Version') != EXPECTED_VERSION:
+        raise SystemExit(
+            '%s Version is %r, expected %s' % (origin, meta.get('Version'), EXPECTED_VERSION)
+        )
+    license_expr = meta.get('License-Expression') or meta.get('License') or ''
+    if 'BSD-2-Clause' not in license_expr:
+        raise SystemExit('%s license is %r, expected BSD-2-Clause' % (origin, license_expr))
+    description = meta.get('Description') or meta_text
+    if 'non-standalone Python dependency' not in description:
+        raise SystemExit('%s long description is not the user README' % origin)
+    if "Do **not** list `'trusts'` in `INSTALLED_APPS`" not in description:
+        raise SystemExit('%s long description missing INSTALLED_APPS warning' % origin)
+    for needle in FORBIDDEN_LONG_DESC:
+        if needle in description:
+            raise SystemExit(
+                '%s long description still contains internal-status language: %s'
+                % (origin, needle)
+            )
+    summary = meta.get('Summary') or ''
+    if 'multiple organizations' in summary:
+        raise SystemExit('%s summary still describes the removed concrete product' % origin)
+
+
+def _check_wheel(wheel: Path) -> None:
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+        meta_name = next(
+            (name for name in names if name.endswith('.dist-info/METADATA')),
+            None,
+        )
+        if meta_name is None:
+            raise SystemExit('wheel missing METADATA: %s' % wheel.name)
+        _check_metadata(zf.read(meta_name).decode(), wheel.name)
+        license_hits = [
+            name for name in names
+            if name.endswith('/LICENSE') or name.endswith('.dist-info/LICENSE')
+        ]
+        if not license_hits:
+            raise SystemExit('wheel missing LICENSE: %s' % names[-20:])
+        notice = zf.read(license_hits[0]).decode()
+        if 'Copyright (c) 2015-2026, BeeDesk, Inc.' not in notice:
+            raise SystemExit('wheel LICENSE notice is not BeeDesk 2015-2026')
+        if 'and contributors' in notice.split('THIS SOFTWARE')[0]:
+            raise SystemExit('wheel LICENSE copyright adds "and contributors"')
+        if 'django_trusts-1.0.0.dev3' not in wheel.name:
+            raise SystemExit('wheel filename is not 1.0.0.dev3: %s' % wheel.name)
+    print('wheel metadata ok', wheel.name)
+
+
+def _check_sdist(sdist: Path) -> None:
+    with tarfile.open(sdist, 'r:gz') as tf:
+        names = tf.getnames()
+        prefix = 'django_trusts-1.0.0.dev3'
+        if not any(name == prefix or name.startswith(prefix + '/') for name in names):
+            raise SystemExit('sdist is not 1.0.0.dev3: %s' % sdist.name)
+        license_name = next((name for name in names if name.endswith('/LICENSE')), None)
+        if license_name is None:
+            raise SystemExit('sdist missing LICENSE')
+        notice = tf.extractfile(license_name).read().decode()
+        if 'Copyright (c) 2015-2026, BeeDesk, Inc.' not in notice:
+            raise SystemExit('sdist LICENSE notice is not BeeDesk 2015-2026')
+        pkg_info = next((name for name in names if name.endswith('/PKG-INFO')), None)
+        if pkg_info is None:
+            raise SystemExit('sdist missing PKG-INFO')
+        _check_metadata(tf.extractfile(pkg_info).read().decode(), sdist.name)
+        readme_name = next((name for name in names if name.endswith('/README.md')), None)
+        if readme_name is None:
+            raise SystemExit('sdist missing README.md')
+        readme = tf.extractfile(readme_name).read().decode()
+        if 'non-standalone Python dependency' not in readme:
+            raise SystemExit('sdist README.md is not the user README')
+        if any(name.endswith('/DEV.md') for name in names):
+            pass
+        else:
+            raise SystemExit('sdist missing DEV.md')
+    print('sdist metadata ok', sdist.name)
+
+
+def main() -> int:
+    dist = _dist()
+    wheels = sorted(dist.glob('django_trusts-*.whl'))
+    sdists = sorted(dist.glob('django_trusts-*.tar.gz'))
+    wheel = _require_dist(wheels, 'wheel')
+    sdist = _require_dist(sdists, 'sdist')
+    _check_wheel(wheel)
+    _check_sdist(sdist)
+    print('package metadata ok')
+    print('core', EXPECTED_NAME + '==' + EXPECTED_VERSION)
+    print('license BSD-2-Clause')
+    return 0
+
+
+if __name__ == '__main__':
+    os.chdir(ROOT)
+    raise SystemExit(main())

--- a/scripts/verify-package-metadata.py
+++ b/scripts/verify-package-metadata.py
@@ -49,6 +49,10 @@ def _check_metadata(meta_text: str, origin: str) -> None:
         raise SystemExit('%s long description is not the user README' % origin)
     if "Do **not** list `'trusts'` in `INSTALLED_APPS`" not in description:
         raise SystemExit('%s long description missing INSTALLED_APPS warning' % origin)
+    if 'pip install django-trusts' in description:
+        raise SystemExit('%s long description still has a bare PyPI install' % origin)
+    if 'BeeDesk, Inc., 2015–2026 (BSD-2-Clause)' not in description:
+        raise SystemExit('%s long description missing BeeDesk 2015–2026 notice' % origin)
     for needle in FORBIDDEN_LONG_DESC:
         if needle in description:
             raise SystemExit(

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -33,17 +33,22 @@ def isolated_owner():
 
 
 def live_config(apps_registry=None):
-    """The unique installed ``TrustsImplementationConfig``.
+    """The kernel-host or unique installed ``TrustsImplementationConfig``.
 
-    Kernel-only tests get ``KernelHostConfig``. The supported Zero
-    pair gets ``ZeroConfig``.
+    Kernel-only tests prefer ``KernelHostConfig`` when the README
+    consumer is also installed. The supported Zero pair still has
+    exactly one owner (``ZeroConfig``).
     """
+    from tests.kernel_host.apps import KernelHostConfig
     from trusts.apps import implementation_configs
     from trusts.core import TrustsConfigurationError
 
     configs = implementation_configs(apps_registry)
     if len(configs) == 1:
         return configs[0]
+    hosts = [config for config in configs if type(config) is KernelHostConfig]
+    if len(hosts) == 1:
+        return hosts[0]
     raise TrustsConfigurationError(
         'live_config() needs exactly one implementation owner; got %r'
         % (configs,)

--- a/tests/fold_settings.py
+++ b/tests/fold_settings.py
@@ -13,3 +13,6 @@ INSTALLED_APPS = (
     'tests.kernel_host.apps.KernelHostConfig',
     'tests.fold_apps.FoldTestsConfig',
 )
+AUTHENTICATION_BACKENDS = (
+    'tests.backends.HostTrustModelBackend',
+)

--- a/tests/myapp/__init__.py
+++ b/tests/myapp/__init__.py
@@ -1,0 +1,1 @@
+# README consumer example. Import paths are the documented spellings.

--- a/tests/myapp/apps.py
+++ b/tests/myapp/apps.py
@@ -1,0 +1,28 @@
+from trusts.apps import TrustsImplementationConfig
+from trusts.core import Ref
+
+DOCUMENT_BACKEND = 'tests.myapp.backends.DocumentBackend'
+
+
+class DocumentConfig(TrustsImplementationConfig):
+    name = 'tests.myapp'
+    label = 'myapp'
+    default = False
+    default_auto_field = 'django.db.models.AutoField'
+    trusts_backend_paths = (DOCUMENT_BACKEND,)
+
+    def ready(self):
+        super().ready()
+        from tests.myapp.models import DocumentGrant
+
+        handle = self.configured_backend()
+        registry = handle.registry
+        if getattr(self, '_document_grant_registry_id', None) is registry:
+            return
+        j = Ref(DocumentGrant)
+        registry.register(
+            content=j.document,
+            user=j.user,
+            permission=j.permission,
+        )
+        self._document_grant_registry_id = registry

--- a/tests/myapp/backends.py
+++ b/tests/myapp/backends.py
@@ -1,0 +1,7 @@
+from django.contrib.auth.backends import ModelBackend
+
+from trusts.backends import TrustModelBackendMixin
+
+
+class DocumentBackend(TrustModelBackendMixin, ModelBackend):
+    pass

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import Permission
+from django.db import models
+
+from trusts.query import AuthorizedManager
+
+
+class Document(models.Model):
+    title = models.CharField(max_length=200)
+    objects = AuthorizedManager()
+
+    class Meta:
+        app_label = 'myapp'
+
+
+class DocumentGrant(models.Model):
+    document = models.ForeignKey(Document, on_delete=models.CASCADE)
+    user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+    class Meta:
+        app_label = 'myapp'

--- a/tests/myapp/settings.py
+++ b/tests/myapp/settings.py
@@ -1,0 +1,9 @@
+INSTALLED_APPS = (
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'tests.myapp.apps.DocumentConfig',
+)
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'tests.myapp.backends.DocumentBackend',
+)

--- a/tests/myapp/views.py
+++ b/tests/myapp/views.py
@@ -1,0 +1,6 @@
+from trusts.decorators import permission_required
+
+
+@permission_required('myapp.change_document', fieldlookups_kwargs={'pk': 'pk'})
+def edit_document(request, pk):
+    return 'ok'

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -24,6 +24,7 @@ KERNEL_SUITE = [
     'trusts.test_issue103',
     'trusts.test_issue108',
     'trusts.test_issue111',
+    'trusts.test_issue115',
 ]
 
 # C1 ran ``run_tests(['trusts'])``. Pair re-runs that full package except

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,6 +19,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'tests.kernel_host.apps.KernelHostConfig',
+    'tests.myapp.apps.DocumentConfig',
     'tests.gh_permissions.apps.GhPermissionsConfig',
     'tests.apps.TestsConfig',
 )
@@ -26,10 +27,12 @@ INSTALLED_APPS = (
 # Test-app migrations depend on trusts.0001_initial (Zero-owned after C2).
 MIGRATION_MODULES = {
     'trusts_tests': None,
+    'myapp': None,
 }
 
 AUTHENTICATION_BACKENDS = (
     'tests.backends.HostTrustModelBackend',
+    'tests.myapp.backends.DocumentBackend',
 )
 
 MIDDLEWARE = (

--- a/trusts/test_issue115.py
+++ b/trusts/test_issue115.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection, models
 from django.http import HttpRequest
@@ -147,6 +147,7 @@ class ReadmeExampleAuthorizationTest(TransactionTestCase):
         )
 
     def test_permission_required_guard_uses_has_perms(self):
+        group = Group.objects.create(name='readme-115')
         request = HttpRequest()
         request.user = self.alice
         request.META['SERVER_NAME'] = 'testserver'
@@ -155,16 +156,15 @@ class ReadmeExampleAuthorizationTest(TransactionTestCase):
         has_perms = Mock(return_value=True)
         self.alice.has_perms = has_perms
         decorated = permission_required(
-            'trusts_tests.change_document',
+            'auth.read_group',
             fieldlookups_kwargs={'pk': 'pk'},
         )(mock)
-        response = decorated(request, pk=self.document.pk)
+        response = decorated(request, pk=group.pk)
         self.assertEqual(response, 'ok')
         self.assertTrue(has_perms.called)
-        self.assertEqual(
-            has_perms.call_args[0][0],
-            ('trusts_tests.change_document',),
-        )
+        self.assertEqual(has_perms.call_args[0][0], ('auth.read_group',))
+        items = has_perms.call_args[0][1]
+        self.assertEqual(items.get().pk, group.pk)
 
 
 class ReadmeHostSurfaceTest(SimpleTestCase):
@@ -283,5 +283,9 @@ class UserFacingReadmeAndPackageTest(SimpleTestCase):
         )
         self.assertIn(
             "fieldlookups_kwargs={'pk': 'pk'}",
+            readme,
+        )
+        self.assertIn(
+            "@permission_required('auth.read_group', fieldlookups_kwargs={'pk': 'pk'})",
             readme,
         )

--- a/trusts/test_issue115.py
+++ b/trusts/test_issue115.py
@@ -1,187 +1,141 @@
 """#115: user-facing README and package metadata for the final core library.
 
-Behavioral fragments are the same spellings as README.md. Structural
-checks reject internal-status language and removed surfaces.
+The README consumer is ``tests.myapp``. Behavioral tests load that
+exact documented configuration and use the owner ``ready()`` registry.
 """
 
-from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import Mock
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db import connection, models
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
-from django.test import SimpleTestCase, TransactionTestCase
-from django.test.utils import isolate_apps
+from django.test import SimpleTestCase, TestCase
+from django.test.utils import override_settings
 
-from tests.apps import isolate_live_registry, live_config
-from tests.backends import HostTrustModelBackend
-from tests.kernel_host.apps import HOST_BACKEND, KernelHostConfig
-from trusts.apps import TrustsImplementationConfig
+from tests.apps import live_config
+from tests.kernel_host.apps import KernelHostConfig
+from tests.myapp.apps import DOCUMENT_BACKEND, DocumentConfig
+from tests.myapp.backends import DocumentBackend
+from tests.myapp.models import Document, DocumentGrant
+from tests.myapp.settings import AUTHENTICATION_BACKENDS, INSTALLED_APPS
+from tests.myapp.views import edit_document
+from trusts.apps import TrustsImplementationConfig, implementation_for_path
 from trusts.backends import TrustModelBackendMixin
-from trusts.core import Ref
-from trusts.decorators import permission_required
-from trusts.query import AuthorizedManager, AuthorizedQuerySet
+from trusts.query import AuthorizedQuerySet
 
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def _readme_models():
-    """Ordinary models copied into README.md."""
-    User = get_user_model()
-
-    class Document(models.Model):
-        title = models.CharField(max_length=200)
-        objects = AuthorizedManager()
-
-        class Meta:
-            app_label = 'trusts_tests'
-
-    class DocumentGrant(models.Model):
-        document = models.ForeignKey(Document, on_delete=models.CASCADE)
-        user = models.ForeignKey(User, on_delete=models.CASCADE)
-        permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
-
-        class Meta:
-            app_label = 'trusts_tests'
-
-    return Document, DocumentGrant
-
-
-@contextmanager
-def _tables(*model_classes):
-    with connection.schema_editor() as editor:
-        for model in model_classes:
-            editor.create_model(model)
-    try:
-        yield
-    finally:
-        with connection.schema_editor() as editor:
-            for model in reversed(model_classes):
-                editor.delete_model(model)
-
-
-def _perm(codename):
-    ct, _created = ContentType.objects.get_or_create(
-        app_label='trusts_tests', model='document',
-    )
+def _change_permission():
+    ct = ContentType.objects.get_for_model(Document)
     permission, _created = Permission.objects.get_or_create(
         content_type=ct,
-        codename=codename,
-        defaults={'name': codename},
+        codename='change_document',
+        defaults={'name': 'Can change document'},
     )
     return permission
 
 
-@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
-class ReadmeExampleAuthorizationTest(TransactionTestCase):
+def _request(user):
+    request = HttpRequest()
+    request.user = user
+    request.META['SERVER_NAME'] = 'testserver'
+    request.META['SERVER_PORT'] = '80'
+    return request
+
+
+class ReadmeExampleAuthorizationTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._auth_override = override_settings(
+            AUTHENTICATION_BACKENDS=AUTHENTICATION_BACKENDS,
+        )
+        cls._auth_override.enable()
+        cls._apps_override = override_settings(INSTALLED_APPS=INSTALLED_APPS)
+        cls._apps_override.enable()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls._apps_override.disable()
+        cls._auth_override.disable()
+
     def setUp(self):
-        self.Document, self.DocumentGrant = _readme_models()
-        self._table_cm = _tables(self.Document, self.DocumentGrant)
-        self._table_cm.__enter__()
         User = get_user_model()
         self.alice = User.objects.create_user(username='alice-115', password='x')
         self.bob = User.objects.create_user(username='bob-115', password='x')
-        self.change_permission = _perm('change_document')
-        self.document = self.Document.objects.create(title='readme')
-        self.other = self.Document.objects.create(title='other')
-        self.registry = self._register()
-        self.live = live_config()
-        self._saved = dict(self.live.registries)
-        isolate_live_registry(self.live, self.registry)
-        self.DocumentGrant.objects.create(
+        self.change_permission = _change_permission()
+        self.document = Document.objects.create(title='readme')
+        self.other = Document.objects.create(title='other')
+        DocumentGrant.objects.create(
             document=self.document,
             user=self.alice,
             permission=self.change_permission,
         )
 
-    def tearDown(self):
-        self.live.registries.clear()
-        self.live.registries.update(self._saved)
-        self._table_cm.__exit__(None, None, None)
-
-    def _register(self):
-        from trusts.core import TrustsRegistry
-
-        registry = TrustsRegistry()
-        j = Ref(self.DocumentGrant)
-        registry.register(
-            content=j.document,
-            user=j.user,
-            permission=j.permission,
+    def test_ready_contributed_the_documented_ref_to_the_owner_registry(self):
+        owner = implementation_for_path(DOCUMENT_BACKEND)
+        self.assertIs(type(owner), DocumentConfig)
+        self.assertIsInstance(owner, TrustsImplementationConfig)
+        handle = owner.configured_backend()
+        self.assertEqual(handle.path, DOCUMENT_BACKEND)
+        self.assertIs(handle.registry, owner.registries[DOCUMENT_BACKEND])
+        self.assertTrue(handle.registry.records)
+        self.assertIs(
+            handle.registry.records[0].content_model,
+            Document,
         )
-        return registry
 
     def test_object_has_perm_and_authorized_queryset(self):
         self.assertTrue(
-            self.alice.has_perm('trusts_tests.change_document', self.document),
+            self.alice.has_perm('myapp.change_document', self.document),
         )
         self.assertFalse(
-            self.bob.has_perm('trusts_tests.change_document', self.document),
+            self.bob.has_perm('myapp.change_document', self.document),
         )
         self.assertFalse(
-            self.alice.has_perm('trusts_tests.change_document', self.other),
+            self.alice.has_perm('myapp.change_document', self.other),
         )
-        self.assertFalse(
-            self.alice.has_perm('trusts_tests.change_document'),
-        )
-        backend = HostTrustModelBackend()
+        self.assertFalse(self.alice.has_perm('myapp.change_document'))
+        backend = DocumentBackend()
         self.assertTrue(
             backend.has_perm(
-                self.alice, 'trusts_tests.change_document', self.document,
+                self.alice, 'myapp.change_document', self.document,
             ),
         )
-        qs = self.Document.objects.authorized(self.alice, self.change_permission)
+        qs = Document.objects.authorized(self.alice, self.change_permission)
         self.assertIsInstance(qs, AuthorizedQuerySet)
-        self.assertEqual(
-            set(qs.values_list('pk', flat=True)),
-            {self.document.pk},
-        )
+        self.assertEqual(set(qs.values_list('pk', flat=True)), {self.document.pk})
         self.assertFalse(
-            self.Document.objects.authorized(
-                self.bob, self.change_permission,
-            ).exists()
+            Document.objects.authorized(self.bob, self.change_permission).exists()
         )
 
-    def test_permission_required_guard_uses_has_perms(self):
-        group = Group.objects.create(name='readme-115')
-        request = HttpRequest()
-        request.user = self.alice
-        request.META['SERVER_NAME'] = 'testserver'
-        request.META['SERVER_PORT'] = '80'
-        mock = Mock(return_value='ok')
-        has_perms = Mock(return_value=True)
-        self.alice.has_perms = has_perms
-        decorated = permission_required(
-            'auth.read_group',
-            fieldlookups_kwargs={'pk': 'pk'},
-        )(mock)
-        response = decorated(request, pk=group.pk)
-        self.assertEqual(response, 'ok')
-        self.assertTrue(has_perms.called)
-        self.assertEqual(has_perms.call_args[0][0], ('auth.read_group',))
-        items = has_perms.call_args[0][1]
-        self.assertEqual(items.get().pk, group.pk)
+    def test_permission_required_uses_the_same_permission(self):
+        allowed = edit_document(_request(self.alice), pk=self.document.pk)
+        self.assertEqual(allowed, 'ok')
+        with self.assertRaises(PermissionDenied):
+            edit_document(_request(self.bob), pk=self.document.pk)
+        with self.assertRaises(PermissionDenied):
+            edit_document(_request(self.alice), pk=self.other.pk)
 
 
 class ReadmeHostSurfaceTest(SimpleTestCase):
-    def test_verified_host_spellings(self):
-        self.assertTrue(issubclass(HostTrustModelBackend, TrustModelBackendMixin))
-        self.assertEqual(HOST_BACKEND, 'tests.backends.HostTrustModelBackend')
-        self.assertTrue(issubclass(KernelHostConfig, TrustsImplementationConfig))
-        self.assertEqual(KernelHostConfig.trusts_backend_paths, (HOST_BACKEND,))
-        self.assertEqual(
-            TrustModelBackendMixin.__module__, 'trusts.backends',
-        )
+    def test_default_suite_still_has_no_trusts_app(self):
         owner = live_config()
         self.assertIs(type(owner), KernelHostConfig)
         labels = {config.label for config in owner.apps.get_app_configs()}
         names = {config.name for config in owner.apps.get_app_configs()}
         self.assertNotIn('trusts', labels)
         self.assertNotIn('trusts', names)
+        self.assertEqual(
+            TrustModelBackendMixin.__module__, 'trusts.backends',
+        )
+        self.assertTrue(issubclass(DocumentBackend, TrustModelBackendMixin))
+        self.assertEqual(DOCUMENT_BACKEND, 'tests.myapp.backends.DocumentBackend')
 
 
 class UserFacingReadmeAndPackageTest(SimpleTestCase):
@@ -223,69 +177,67 @@ class UserFacingReadmeAndPackageTest(SimpleTestCase):
             '11058641',
             'f0b25c55',
             '94e0fa1',
+            'pip install django-trusts',
+            'auth.read_group',
+            'tests.kernel_host',
+            'HostTrustModelBackend',
+            'isolate_live_registry',
         )
         offenders = [needle for needle in forbidden if needle in readme]
         self.assertEqual(offenders, [])
         self.assertNotIn("'trusts',", readme)
         self.assertIn("Do **not** list `'trusts'` in `INSTALLED_APPS`", readme)
         self.assertIn('non-standalone Python dependency', readme)
+        self.assertIn('python -m pip install .', readme)
         self.assertIn('TrustsImplementationConfig', readme)
         self.assertIn('from trusts.backends import TrustModelBackendMixin', readme)
         self.assertIn('from trusts.core import Ref', readme)
-        self.assertIn("'tests.kernel_host.apps.KernelHostConfig'", readme)
-        self.assertIn("'tests.backends.HostTrustModelBackend'", readme)
-        self.assertIn('user.has_perm', readme)
-        self.assertIn('Document.objects.authorized', readme)
-        self.assertIn('permission_required', readme)
-        self.assertIn('fieldlookups_kwargs', readme)
+        self.assertIn('super().ready()', readme)
+        self.assertIn("'tests.myapp.apps.DocumentConfig'", readme)
+        self.assertIn("'tests.myapp.backends.DocumentBackend'", readme)
+        self.assertIn("user.has_perm('myapp.change_document', document)", readme)
+        self.assertIn('Document.objects.authorized(user, change_permission)', readme)
+        self.assertIn("app_label = 'myapp'", readme)
+        self.assertIn(
+            "@permission_required('myapp.change_document', fieldlookups_kwargs={'pk': 'pk'})",
+            readme,
+        )
         self.assertIn('django-trusts-zero', readme)
         self.assertIn('django-trusts-gh-permissions', readme)
         self.assertIn('migrates.md', readme)
         self.assertIn('forthcoming', readme.lower())
         self.assertIn('not complete', readme.lower())
-        self.assertIn('BeeDesk, Inc.', readme)
+        self.assertIn('BeeDesk, Inc., 2015–2026 (BSD-2-Clause)', readme)
         self.assertIn('DEV.md', readme)
         dev = (ROOT / 'DEV.md').read_text()
         self.assertIn('internal', dev[:800].lower())
         self.assertIn('development', dev[:800].lower())
         self.assertIn('README.md', dev[:800])
 
-    def test_readme_examples_match_verified_settings(self):
-        settings_text = (ROOT / 'tests' / 'settings.py').read_text()
-        self.assertIn("'tests.kernel_host.apps.KernelHostConfig'", settings_text)
-        self.assertIn("'tests.backends.HostTrustModelBackend'", settings_text)
+    def test_readme_examples_match_consumer_modules(self):
+        readme = (ROOT / 'README.md').read_text()
+        settings_text = (ROOT / 'tests' / 'myapp' / 'settings.py').read_text()
+        self.assertIn("'tests.myapp.apps.DocumentConfig'", settings_text)
+        self.assertIn("'tests.myapp.backends.DocumentBackend'", settings_text)
         self.assertNotIn("'trusts',", settings_text)
-        backends = (ROOT / 'tests' / 'backends.py').read_text()
+        self.assertIn(settings_text.strip(), readme)
+        backends = (ROOT / 'tests' / 'myapp' / 'backends.py').read_text()
         self.assertIn(
-            'class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):',
+            'class DocumentBackend(TrustModelBackendMixin, ModelBackend):',
             backends,
         )
-        host = (ROOT / 'tests' / 'kernel_host' / 'apps.py').read_text()
-        self.assertIn('class KernelHostConfig(TrustsImplementationConfig):', host)
-        self.assertIn("HOST_BACKEND = 'tests.backends.HostTrustModelBackend'", host)
-        readme = (ROOT / 'README.md').read_text()
+        self.assertIn(DOCUMENT_BACKEND, readme)
+        apps = (ROOT / 'tests' / 'myapp' / 'apps.py').read_text()
+        self.assertIn('class DocumentConfig(TrustsImplementationConfig):', apps)
+        self.assertIn('super().ready()', apps)
+        self.assertIn('content=j.document', apps)
+        self.assertIn('content=j.document', readme)
+        views = (ROOT / 'tests' / 'myapp' / 'views.py').read_text()
         self.assertIn(
-            'class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):',
-            readme,
+            "@permission_required('myapp.change_document', fieldlookups_kwargs={'pk': 'pk'})",
+            views,
         )
-        self.assertIn('class KernelHostConfig(TrustsImplementationConfig):', readme)
-        self.assertIn(
-            "HOST_BACKEND = 'tests.backends.HostTrustModelBackend'",
-            readme,
-        )
-        self.assertIn(
-            'user.has_perm(\'trusts_tests.change_document\', document)',
-            readme,
-        )
-        self.assertIn(
-            'Document.objects.authorized(user, change_permission)',
-            readme,
-        )
-        self.assertIn(
-            "fieldlookups_kwargs={'pk': 'pk'}",
-            readme,
-        )
-        self.assertIn(
-            "@permission_required('auth.read_group', fieldlookups_kwargs={'pk': 'pk'})",
-            readme,
-        )
+        default_settings = (ROOT / 'tests' / 'settings.py').read_text()
+        self.assertIn("'tests.myapp.apps.DocumentConfig'", default_settings)
+        self.assertIn("'tests.myapp.backends.DocumentBackend'", default_settings)
+        self.assertNotIn("'trusts',", default_settings)

--- a/trusts/test_issue115.py
+++ b/trusts/test_issue115.py
@@ -1,0 +1,287 @@
+"""#115: user-facing README and package metadata for the final core library.
+
+Behavioral fragments are the same spellings as README.md. Structural
+checks reject internal-status language and removed surfaces.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import Mock
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection, models
+from django.http import HttpRequest
+from django.test import SimpleTestCase, TransactionTestCase
+from django.test.utils import isolate_apps
+
+from tests.apps import isolate_live_registry, live_config
+from tests.backends import HostTrustModelBackend
+from tests.kernel_host.apps import HOST_BACKEND, KernelHostConfig
+from trusts.apps import TrustsImplementationConfig
+from trusts.backends import TrustModelBackendMixin
+from trusts.core import Ref
+from trusts.decorators import permission_required
+from trusts.query import AuthorizedManager, AuthorizedQuerySet
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _readme_models():
+    """Ordinary models copied into README.md."""
+    User = get_user_model()
+
+    class Document(models.Model):
+        title = models.CharField(max_length=200)
+        objects = AuthorizedManager()
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    class DocumentGrant(models.Model):
+        document = models.ForeignKey(Document, on_delete=models.CASCADE)
+        user = models.ForeignKey(User, on_delete=models.CASCADE)
+        permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    return Document, DocumentGrant
+
+
+@contextmanager
+def _tables(*model_classes):
+    with connection.schema_editor() as editor:
+        for model in model_classes:
+            editor.create_model(model)
+    try:
+        yield
+    finally:
+        with connection.schema_editor() as editor:
+            for model in reversed(model_classes):
+                editor.delete_model(model)
+
+
+def _perm(codename):
+    ct, _created = ContentType.objects.get_or_create(
+        app_label='trusts_tests', model='document',
+    )
+    permission, _created = Permission.objects.get_or_create(
+        content_type=ct,
+        codename=codename,
+        defaults={'name': codename},
+    )
+    return permission
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class ReadmeExampleAuthorizationTest(TransactionTestCase):
+    def setUp(self):
+        self.Document, self.DocumentGrant = _readme_models()
+        self._table_cm = _tables(self.Document, self.DocumentGrant)
+        self._table_cm.__enter__()
+        User = get_user_model()
+        self.alice = User.objects.create_user(username='alice-115', password='x')
+        self.bob = User.objects.create_user(username='bob-115', password='x')
+        self.change_permission = _perm('change_document')
+        self.document = self.Document.objects.create(title='readme')
+        self.other = self.Document.objects.create(title='other')
+        self.registry = self._register()
+        self.live = live_config()
+        self._saved = dict(self.live.registries)
+        isolate_live_registry(self.live, self.registry)
+        self.DocumentGrant.objects.create(
+            document=self.document,
+            user=self.alice,
+            permission=self.change_permission,
+        )
+
+    def tearDown(self):
+        self.live.registries.clear()
+        self.live.registries.update(self._saved)
+        self._table_cm.__exit__(None, None, None)
+
+    def _register(self):
+        from trusts.core import TrustsRegistry
+
+        registry = TrustsRegistry()
+        j = Ref(self.DocumentGrant)
+        registry.register(
+            content=j.document,
+            user=j.user,
+            permission=j.permission,
+        )
+        return registry
+
+    def test_object_has_perm_and_authorized_queryset(self):
+        self.assertTrue(
+            self.alice.has_perm('trusts_tests.change_document', self.document),
+        )
+        self.assertFalse(
+            self.bob.has_perm('trusts_tests.change_document', self.document),
+        )
+        self.assertFalse(
+            self.alice.has_perm('trusts_tests.change_document', self.other),
+        )
+        self.assertFalse(
+            self.alice.has_perm('trusts_tests.change_document'),
+        )
+        backend = HostTrustModelBackend()
+        self.assertTrue(
+            backend.has_perm(
+                self.alice, 'trusts_tests.change_document', self.document,
+            ),
+        )
+        qs = self.Document.objects.authorized(self.alice, self.change_permission)
+        self.assertIsInstance(qs, AuthorizedQuerySet)
+        self.assertEqual(
+            set(qs.values_list('pk', flat=True)),
+            {self.document.pk},
+        )
+        self.assertFalse(
+            self.Document.objects.authorized(
+                self.bob, self.change_permission,
+            ).exists()
+        )
+
+    def test_permission_required_guard_uses_has_perms(self):
+        request = HttpRequest()
+        request.user = self.alice
+        request.META['SERVER_NAME'] = 'testserver'
+        request.META['SERVER_PORT'] = '80'
+        mock = Mock(return_value='ok')
+        has_perms = Mock(return_value=True)
+        self.alice.has_perms = has_perms
+        decorated = permission_required(
+            'trusts_tests.change_document',
+            fieldlookups_kwargs={'pk': 'pk'},
+        )(mock)
+        response = decorated(request, pk=self.document.pk)
+        self.assertEqual(response, 'ok')
+        self.assertTrue(has_perms.called)
+        self.assertEqual(
+            has_perms.call_args[0][0],
+            ('trusts_tests.change_document',),
+        )
+
+
+class ReadmeHostSurfaceTest(SimpleTestCase):
+    def test_verified_host_spellings(self):
+        self.assertTrue(issubclass(HostTrustModelBackend, TrustModelBackendMixin))
+        self.assertEqual(HOST_BACKEND, 'tests.backends.HostTrustModelBackend')
+        self.assertTrue(issubclass(KernelHostConfig, TrustsImplementationConfig))
+        self.assertEqual(KernelHostConfig.trusts_backend_paths, (HOST_BACKEND,))
+        self.assertEqual(
+            TrustModelBackendMixin.__module__, 'trusts.backends',
+        )
+        owner = live_config()
+        self.assertIs(type(owner), KernelHostConfig)
+        labels = {config.label for config in owner.apps.get_app_configs()}
+        names = {config.name for config in owner.apps.get_app_configs()}
+        self.assertNotIn('trusts', labels)
+        self.assertNotIn('trusts', names)
+
+
+class UserFacingReadmeAndPackageTest(SimpleTestCase):
+    def test_license_notice_is_beedesk_2015_2026(self):
+        text = (ROOT / 'LICENSE').read_text()
+        self.assertIn('Copyright (c) 2015-2026, BeeDesk, Inc.', text)
+        self.assertNotIn('and contributors', text.split('THIS SOFTWARE')[0])
+        pyproject = (ROOT / 'pyproject.toml').read_text()
+        self.assertIn('license = "BSD-2-Clause"', pyproject)
+        self.assertIn('readme = "README.md"', pyproject)
+        self.assertNotIn('readme = "DEV.md"', pyproject)
+        self.assertIn('version = "1.0.0.dev3"', pyproject)
+        self.assertNotIn(
+            'multiple organizations and object-level permission settings',
+            pyproject,
+        )
+        self.assertNotIn('"organizations"', pyproject)
+
+    def test_user_readme_is_not_internal_status(self):
+        readme = (ROOT / 'README.md').read_text()
+        forbidden = (
+            'Step I',
+            'Step II',
+            'Step III',
+            'C1',
+            'C2',
+            'Z1',
+            'pair pin',
+            'baton',
+            'code budget',
+            'kernel_config',
+            'trusts.core_backends',
+            'from trusts.backends import TrustModelBackend\n',
+            'from trusts.models import Trust',
+            'trusts.models.Trust',
+            '1.0.0.dev1',
+            '1.0.0.dev2',
+            '1.0.0.dev3',
+            '11058641',
+            'f0b25c55',
+            '94e0fa1',
+        )
+        offenders = [needle for needle in forbidden if needle in readme]
+        self.assertEqual(offenders, [])
+        self.assertNotIn("'trusts',", readme)
+        self.assertIn("Do **not** list `'trusts'` in `INSTALLED_APPS`", readme)
+        self.assertIn('non-standalone Python dependency', readme)
+        self.assertIn('TrustsImplementationConfig', readme)
+        self.assertIn('from trusts.backends import TrustModelBackendMixin', readme)
+        self.assertIn('from trusts.core import Ref', readme)
+        self.assertIn("'tests.kernel_host.apps.KernelHostConfig'", readme)
+        self.assertIn("'tests.backends.HostTrustModelBackend'", readme)
+        self.assertIn('user.has_perm', readme)
+        self.assertIn('Document.objects.authorized', readme)
+        self.assertIn('permission_required', readme)
+        self.assertIn('fieldlookups_kwargs', readme)
+        self.assertIn('django-trusts-zero', readme)
+        self.assertIn('django-trusts-gh-permissions', readme)
+        self.assertIn('migrates.md', readme)
+        self.assertIn('forthcoming', readme.lower())
+        self.assertIn('not complete', readme.lower())
+        self.assertIn('BeeDesk, Inc.', readme)
+        self.assertIn('DEV.md', readme)
+        dev = (ROOT / 'DEV.md').read_text()
+        self.assertIn('internal', dev[:800].lower())
+        self.assertIn('development', dev[:800].lower())
+        self.assertIn('README.md', dev[:800])
+
+    def test_readme_examples_match_verified_settings(self):
+        settings_text = (ROOT / 'tests' / 'settings.py').read_text()
+        self.assertIn("'tests.kernel_host.apps.KernelHostConfig'", settings_text)
+        self.assertIn("'tests.backends.HostTrustModelBackend'", settings_text)
+        self.assertNotIn("'trusts',", settings_text)
+        backends = (ROOT / 'tests' / 'backends.py').read_text()
+        self.assertIn(
+            'class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):',
+            backends,
+        )
+        host = (ROOT / 'tests' / 'kernel_host' / 'apps.py').read_text()
+        self.assertIn('class KernelHostConfig(TrustsImplementationConfig):', host)
+        self.assertIn("HOST_BACKEND = 'tests.backends.HostTrustModelBackend'", host)
+        readme = (ROOT / 'README.md').read_text()
+        self.assertIn(
+            'class HostTrustModelBackend(TrustModelBackendMixin, ModelBackend):',
+            readme,
+        )
+        self.assertIn('class KernelHostConfig(TrustsImplementationConfig):', readme)
+        self.assertIn(
+            "HOST_BACKEND = 'tests.backends.HostTrustModelBackend'",
+            readme,
+        )
+        self.assertIn(
+            'user.has_perm(\'trusts_tests.change_document\', document)',
+            readme,
+        )
+        self.assertIn(
+            'Document.objects.authorized(user, change_permission)',
+            readme,
+        )
+        self.assertIn(
+            "fieldlookups_kwargs={'pk': 'pk'}",
+            readme,
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [django-trusts#115](https://github.com/django-trusts/django-trusts/issues/115), the next repository-specific slice of [django-trusts#113](https://github.com/django-trusts/django-trusts/issues/113).

**HEAD:** `41d8f7f6f0b11aa12b9c032720be9d32dff73e74` (R1)  
**Reviewed-and-returned head:** `78ef3060b5cfde6987d1b5b2699a2bb96c1dfb10`  
**Baseline:** `11058641b533e0f8489598e0b1f5cbe5d42a81db` (`dev`, #112 merge, `1.0.0.dev3`)  
**Zero user path:** django-trusts-zero #14 merge `f0b25c5562c4f9803d861503dd2acac21613119d`

Ready for `r? @chatforthomas` on django-trusts PR #93.

Closes #115.

## What this PR does

- Renames the historical Trust/settlor/trustee README to `DEV.md` and marks it contributor/development history.
- Writes a concise user-facing `README.md` for implementation authors: non-standalone dependency; no concrete Trust/Content/Group/ACL models or AppConfig; must not list `'trusts'` in `INSTALLED_APPS`; final principles; contrast with object-permission stores; routes to Zero / GH / core. Windows is named only as a forthcoming ordered-policy example.
- Install path is checkout / built wheel only (`python -m pip install .`). No bare `pip install django-trusts`.
- Consumer example is `tests.myapp`: `DocumentConfig.ready()` contributes the `Ref` after `super().ready()`, settings list `tests.myapp.apps.DocumentConfig` and `tests.myapp.backends.DocumentBackend`, and the guard is `@permission_required('myapp.change_document', fieldlookups_kwargs={'pk': 'pk'})`. `trusts.test_issue115` exercises that exact path (`has_perm`, authorized queryset, unmocked decorator).
- Keeps `pyproject.toml` long-description on `README.md`. Replaces the removed concrete-product description/keywords.
- Keeps BSD-2-Clause with copyright holder exactly BeeDesk, Inc. README license line states BeeDesk, Inc., 2015–2026 (BSD-2-Clause). No “and contributors” on the copyright line.
- Adds `scripts/verify-package-metadata.py` and README/package tests that reject internal-status language, the unpublished PyPI install line, and stale fixture snippets.

## What was not changed

- No authorization semantics, registry/compiler behavior, public callables, schema, migrations, stored identity, or package version (`1.0.0.dev3`).
- No new `migrates.md` API entry.
- No GH / Windows / example documentation, stable release-number decision, or later #113 work.
- Pair CI still pins supported Zero companion `94e0fa109a8a7a5f53a028438ada899cbc1be1ad`.

## Proofs

**GitHub CI: all 6 checks green** on this HEAD — [run 34647010277](https://github.com/django-trusts/django-trusts/actions/runs/34647010277)

- tests kernel-only on Python 3.12 / 3.13 / 3.14
- OrderedFold PostgreSQL
- pair with Zero IIa `94e0fa109a8a7a5f53a028438ada899cbc1be1ad`
- package (sdist/wheel, twine, user-README long description, BeeDesk 2015-2026 LICENSE, wheel isolation)

Local (Python 3.12 / Django 6.1, `python -m tests.runtests`):

- kernel suite: 210 tests OK (13 skipped); `django check` quiet
- `trusts.test_issue115` included in that suite

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fbbefb9-30bc-4188-8e0f-06726b296adc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fbbefb9-30bc-4188-8e0f-06726b296adc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

