### PR TITLE
#115: rewrite the core README for implementation authors

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,109 @@
+# DEV.md — contributor / development record
+
+This file is an internal development record. It may describe
+unsupported or superseded states. The user-facing package introduction
+is [README.md](README.md). `pyproject.toml` long-description metadata
+points at `README.md`, not this file.
+
+## Final library cut (correcting earlier README copy)
+
+`django-trusts==1.0.0.dev3` is a **Python library**, not an installed
+Django app and not a concrete Trust/settlor/trustee product.
+
+- Do **not** list `'trusts'` in `INSTALLED_APPS`.
+- Core ships no Django `AppConfig`, no Django app label, and no
+  `kernel_config()`.
+- `trusts.core_backends` is gone. The generic mixin lives only at
+  `from trusts.backends import TrustModelBackendMixin`.
+- Historical concrete models and `TrustModelBackend` live under
+  `trusts.zero.*` when `django-trusts-zero` is installed.
+- The Trust/settlor/trustee introduction that used to lead this
+  repository described the 0.x product. That product continues as
+  [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero).
+
+A host `TrustsImplementationConfig` owns the backend path and registry.
+Kernel-only tests use `tests.kernel_host.apps.KernelHostConfig`. The
+supported Zero pair uses `trusts.zero.apps.ZeroConfig`:
+
+```
+INSTALLED_APPS = (
+    'trusts.zero.apps.ZeroConfig',
+)
+AUTHENTICATION_BACKENDS = (
+    'trusts.zero.backends.TrustModelBackend',
+)
+```
+
+## Supported versions
+
+The `1.0.0.dev3` development line requires **Python 3.12–3.14** and
+**Django 6.1**. Sources checked on 2026-09-07 and the rationale are in
+[docs/support-matrix.md](docs/support-matrix.md).
+
+This is not a published PyPI release. Install from a local checkout or
+sdist/wheel built from this tree.
+
+```
+python -m pip install "Django>=6.1,<6.2"
+python -m pip install .
+```
+
+API and compatibility notes for this modernization are in
+[migrates.md](migrates.md).
+
+## Test
+
+```
+python -m pip install "Django>=6.1,<6.2" coverage
+python -m pip install -e .
+python -m tests.runtests
+python -m django check --settings=tests.settings
+python scripts/verify-legacy-upgrade.py
+```
+
+CI is GitHub Actions (`.github/workflows/ci.yml`): kernel-only
+authorization tests, a fresh migrate, ``manage.py check``, an
+OrderedFold PostgreSQL job, pair proofs against the supported Zero
+companion, and a `package` job that builds an sdist/wheel and imports
+it from a temporary directory so the source tree cannot satisfy the
+import. Do not treat a removed Travis check as a stand-in green status.
+
+## Development version
+
+The active package version is **1.0.0.dev3**. That is a development-line
+mark, not a production 1.0 release. See
+[docs/development-version.md](docs/development-version.md).
+
+`1.0.0.dev2` remains the merged implementation-owned registry bridge.
+`1.0.0.dev1` remains the merged mixin-extract checkpoint. Those are
+internal marks only.
+
+## Legacy baseline
+
+The exact pre-modernization default-branch commit, existing release
+tags, source archive checksum, and historical Python/Django
+requirements are recorded in
+[docs/legacy-baseline.md](docs/legacy-baseline.md). That snapshot is
+historical documentation only.
+
+## Historical 0.x product copy (superseded)
+
+The following is the pre-library-cut product introduction. It is not
+the current core contract.
+
+``django-trusts`` began as an add-on to Django's builtin authorization
+that added a ``trust`` relationship so a project hosting users of
+multiple organizations could keep maintainable per-object permission
+settings in a single user namespace. A ``trust`` permitted content
+access from a creator (``settlor``) to specific users (``trustee`` s)
+or groups. Content could be a ``Content`` subclass or an existing model
+via a junction table. Permissions checking used ``has_perm()`` /
+``has_perms()`` against an individual object or a ``QuerySet``.
+
+That concrete schema is no longer part of core. Use
+`django-trusts-zero` for the 0.x continuation.
+
+## License
+
+BSD 2-Clause Simplified. Copyright holder is exactly BeeDesk, Inc.
+Notice years are 2015-2026.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, BeeDesk, Inc.
+Copyright (c) 2015-2026, BeeDesk, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include DEV.md
 include requirements.txt
 include migrates.md
 include pyproject.toml

--- a/README.md
+++ b/README.md
@@ -1,82 +1,170 @@
-Django Trusts
--------------
+# django-trusts
 
-[![Docs](https://readthedocs.org/projects/django-trusts/badge/)](http://django-trusts.readthedocs.org) [![CI](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml)
+`django-trusts` is a **non-standalone Python dependency** for
+applications and packages that define their own declarative Django
+authorization implementation.
 
-Django authorization add-on for multiple organizations and object-level permission settings
+Core supplies no concrete permission schema, no Trust / Content /
+Group / ACL / organization / role models, no generic grant editor, and
+no Django `AppConfig`. Do **not** list `'trusts'` in `INSTALLED_APPS`.
+The consumer owns its `TrustsImplementationConfig`, backend path,
+models, and persisted policy facts.
 
-Introduction
-------------
+## Which package do you want?
 
-``django-trusts`` is a add-on to Django's builtin authorization. It strives to be a **minimal** implementation, adding only a single concept, ``trust``, to enable maintainable per-object permission settings for a django project that hosts users of multiple organizations  with a single user namespace.
+- Seeking or upgrading from django-trusts 0.x Trust / Content
+  behavior → [`django-trusts-zero`](https://github.com/django-trusts/django-trusts-zero)
+- Studying persisted organization / team / repository relationships →
+  [`django-trusts-gh-permissions`](https://github.com/django-trusts/django-trusts-gh-permissions)
+- Building a new permission implementation → continue with this
+  library
+- An explicit ordered-policy example is forthcoming as the Windows
+  reference implementation; it is not complete on this tree
 
-A ``trust`` is a relationship whereby content access is permitted by the creator [``settlor``] to specific user(s) [``trustee`` (s)] or ``group`` (s). Content can be an instance of a `Content` subclass, or of an existing model via a junction table. Access to multiple content can be permitted by a single ``trust`` for maintainable permssion settings. Django's builtin model, `group`, is supported and can be used to define reusuable permissions for a ``group`` of ``user``'s.
+## Principles
 
-``django-trusts`` also strives to be a **scalable** solution. Permissions checking is offloaded to the database by design, and the implementation minimizes database hits. Permissions are cached per ``trust`` for the lifecycle of ``request user``. If a project's request lifecycle resolves most checked content to one or few ``trusts``, which should be very typically the case, this design should be a winner in term of performance. Permissions checking is done against an individual content or a ``QuerySet``.
+- Minimal ordinary Django models plus compact declarations
+- Declarative relationship paths
+- Authorization derives from persisted relational state
+- Object decisions and authorized querysets share compiled policy;
+  supported work is pushed into one SQL query before pagination
+- Malformed, unsupported, or missing policy fails closed
+- Implementation-neutral core rather than one imposed permission
+  schema
 
-``django-trusts`` supports Django's builtins User models ``has_perm()`` / ``has_perms()`` and does not provides any in-addition.
+This is not an object-permission store that requires one grant row per
+user and object. A grant may be implied by persisted organization
+relationships, or it may come from explicit policy rows that the
+implementation defines. Grant mutation is ordinary ORM work on those
+consumer models. Core has no generic grant / revoke workflow.
 
-Read more: http://django-trusts.readthedocs.org/en/latest/
+## Install
 
-Supported versions
-------------------
-
-The `1.0.0.dev3` development line requires **Python 3.12–3.14** and **Django 6.1**.
-Sources checked on 2026-09-07 and the rationale are in
-[docs/support-matrix.md](docs/support-matrix.md).
-
-This is not a published PyPI release. Install from a local checkout or sdist/wheel
-built from this tree.
-
+```bash
+pip install django-trusts
 ```
+
+This is a development release, not a published PyPI 1.0. Install from
+a local checkout or an sdist / wheel built from this tree until a
+stable release exists.
+
+```bash
 python -m pip install "Django>=6.1,<6.2"
 python -m pip install .
 ```
 
-`django-trusts` is a Python library, not an installed Django app. Do not
-list `'trusts'` in `INSTALLED_APPS`. Install a host
-`TrustsImplementationConfig` such as `trusts.zero.apps.ZeroConfig` and
-set that host's canonical backend path:
+## Configure
 
-```
-INSTALLED_APPS = (
-    'trusts.zero.apps.ZeroConfig',
-)
+The implementation app is installed. Core is not:
+
+```python
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
+    'myapp.apps.FolderAuthConfig',
+]
 AUTHENTICATION_BACKENDS = (
-    'trusts.zero.backends.TrustModelBackend',
+    'django.contrib.auth.backends.ModelBackend',
+    'myapp.backends.FolderBackend',
 )
 ```
 
-API and compatibility notes for this modernization are in [migrates.md](migrates.md).
+`ModelBackend` is listed only when the host also wants ordinary global
+Django permissions. Trusts answers object and queryset checks and
+contributes `False` / empty results when `obj is None`.
 
-Test
-----
+## Example
 
+The following is the smallest runnable consumer shape. The same
+models, mixin backend, implementation config, `Ref` registration,
+`has_perm`, authorized queryset, and view decorator are exercised by
+`trusts.test_issue115`.
+
+```python
+from django.conf import settings
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.models import Permission
+from django.db import models
+
+from trusts.apps import TrustsImplementationConfig
+from trusts.backends import TrustModelBackendMixin
+from trusts.core import Ref
+from trusts.decorators import permission_required
+from trusts.query import AuthorizedManager, AuthorizedQuerySet
+
+
+class Folder(models.Model):
+    title = models.CharField(max_length=40)
+    objects = AuthorizedManager()
+
+
+class FolderGrant(models.Model):
+    folder = models.ForeignKey(Folder, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+
+class FolderBackend(TrustModelBackendMixin, ModelBackend):
+    pass
+
+
+class FolderAuthConfig(TrustsImplementationConfig):
+    name = 'myapp'
+    trusts_backend_paths = ('myapp.backends.FolderBackend',)
+
+    def ready(self):
+        super().ready()
+        grant = Ref(FolderGrant)
+        self.registry.register(
+            content=grant.folder,
+            user=grant.user,
+            permission=grant.permission,
+        )
 ```
-python -m pip install "Django>=6.1,<6.2" coverage
-python -m pip install -e .
-python -m tests.runtests
-python -m django check --settings=tests.settings
-python scripts/verify-legacy-upgrade.py
+
+Create or delete grant rows with the consumer ORM:
+
+```python
+FolderGrant.objects.create(folder=folder, user=user, permission=perm)
 ```
 
-CI is GitHub Actions (`.github/workflows/ci.yml`): kernel-only
-authorization tests, a fresh migrate, ``manage.py check``, an OrderedFold
-PostgreSQL job, pair proofs against the supported Zero companion, and a
-`package` job that builds an sdist/wheel and imports it from a temporary
-directory so the source tree cannot satisfy the import. Do not treat a
-removed Travis check as a stand-in green status.
+Object decision and authorized queryset (one compiled policy):
 
-Development version
--------------------
+```python
+user.has_perm('myapp.change_folder', folder)
+AuthorizedQuerySet(Folder).authorized(user, perm)
+```
 
-The active package version is **1.0.0.dev3**. That is a development-line mark,
-not a production 1.0 release. See [docs/development-version.md](docs/development-version.md).
+View decorator / guard:
 
-Legacy baseline
----------------
+```python
+@permission_required(
+    'myapp.change_folder',
+    fieldlookups_kwargs={'pk': 'folder_id'},
+)
+def edit_folder(request, folder_id):
+    return folder_id
+```
 
-The exact pre-modernization default-branch commit, existing release tags, source
-archive checksum, and historical Python/Django requirements are recorded in
-[docs/legacy-baseline.md](docs/legacy-baseline.md). That snapshot is historical
-documentation only.
+## Supported versions
+
+- Python 3.12, 3.13, and 3.14
+- Django 6.1
+
+See [docs/support-matrix.md](docs/support-matrix.md). This line is a
+development release, not a declared stable 1.0.
+
+## License
+
+BSD 2-Clause Simplified. Copyright BeeDesk, Inc., 2015-2026.
+
+## Further reading
+
+- [migrates.md](migrates.md) — core API migration guide
+- [docs](http://django-trusts.readthedocs.org/en/latest/)
+- [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero)
+- [django-trusts-gh-permissions](https://github.com/django-trusts/django-trusts-gh-permissions)
+- [docs/support-matrix.md](docs/support-matrix.md)
+- [Issues](https://github.com/django-trusts/django-trusts/issues)
+
+Contributor and build history lives in [DEV.md](DEV.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-trusts"
 version = "1.0.0.dev3"
-description = "Django authorization add-on for multiple organizations and object-level permission settings"
+description = "Implementation-neutral Django authorization library for declarative relational permission implementations"
 readme = "README.md"
 license = "BSD-2-Clause"
 authors = [
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
 ]
-keywords = ["django", "authorization", "permissions", "organizations"]
+keywords = ["django", "authorization", "permissions", "declarative"]
 
 [project.urls]
 Homepage = "https://github.com/django-trusts/django-trusts"

--- a/scripts/verify-wheel-install.py
+++ b/scripts/verify-wheel-install.py
@@ -171,6 +171,51 @@ def main() -> int:
     if hasattr(models_mod, 'Trust') or 'Trust' in dir(models_mod):
         raise SystemExit('inert trusts.models still exposes Trust')
 
+    meta = importlib.metadata.metadata('django-trusts')
+    summary = meta['Summary']
+    if 'multiple organizations' in summary or 'settlor' in summary:
+        raise SystemExit('wheel summary still describes the removed concrete product: %r' % summary)
+    if 'Implementation-neutral' not in summary:
+        raise SystemExit('wheel summary is not the library description: %r' % summary)
+    long_description = meta.get('Description') or ''
+    if 'non-standalone Python dependency' not in long_description:
+        raise SystemExit('wheel long description is not the user README')
+    stale_readme = (
+        'settlor',
+        'trustee',
+        'kernel_config',
+        'trusts.core_backends',
+        'multiple organizations',
+        'Step I',
+        '1.0.0.dev1',
+    )
+    stale_hits = [needle for needle in stale_readme if needle in long_description]
+    if stale_hits:
+        raise SystemExit('wheel long description still has stale copy: %s' % stale_hits)
+    if meta.get('License-Expression', '') not in ('BSD-2-Clause', ''):
+        if 'BSD' not in (meta.get('License') or ''):
+            raise SystemExit('wheel license metadata is not BSD-2-Clause: %r' % dict(meta))
+
+    dist = importlib.metadata.distribution('django-trusts')
+    license_text = ''
+    for file in dist.files or ():
+        name = str(file)
+        if name.endswith('LICENSE') or name.endswith('LICENSE.txt'):
+            license_text = file.locate().read_text()
+            break
+    if not license_text:
+        for candidate in (
+            Path(trusts_file).parents[2] / 'LICENSE',
+            Path(trusts_file).parents[3] / 'LICENSE',
+        ):
+            if candidate.is_file():
+                license_text = candidate.read_text()
+                break
+    if 'Copyright (c) 2015-2026, BeeDesk, Inc.' not in license_text:
+        raise SystemExit('installed LICENSE is not BeeDesk 2015-2026: %r' % license_text[:120])
+    if 'and contributors' in license_text.split('THIS SOFTWARE')[0]:
+        raise SystemExit('installed LICENSE added contributors to the notice')
+
     print('wheel import ok')
     print('django', django.get_version())
     print('django-trusts', installed_version)
@@ -188,6 +233,9 @@ def main() -> int:
     print('TQ', TQ)
     print('condition_refs', condition_refs)
     print('models_inert', models_mod)
+    print('summary', summary)
+    print('long_description_from_readme', True)
+    print('license_notice', '2015-2026 BeeDesk')
     return 0
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -24,6 +24,7 @@ KERNEL_SUITE = [
     'trusts.test_issue103',
     'trusts.test_issue108',
     'trusts.test_issue111',
+    'trusts.test_issue115',
 ]
 
 # C1 ran ``run_tests(['trusts'])``. Pair re-runs that full package except

--- a/trusts/test_issue115.py
+++ b/trusts/test_issue115.py
@@ -1,0 +1,311 @@
+"""#115: user README, package copy, and verified final-API example.
+
+Documentation/package alignment only. Exercises the README consumer
+shape: ordinary models, ``TrustModelBackendMixin`` subclass,
+``TrustsImplementationConfig``, one ``Ref`` registration, ``has_perm``,
+authorized queryset, and ``permission_required``.
+"""
+
+import ast
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection, models
+from django.http import HttpRequest
+from django.test import SimpleTestCase, TransactionTestCase, override_settings
+from django.test.utils import isolate_apps
+
+import tests as tests_module
+from trusts.apps import TrustsImplementationConfig
+from trusts.backends import TrustModelBackendMixin
+from trusts.core import Ref
+from trusts.decorators import permission_required
+from trusts.query import AuthorizedManager, AuthorizedQuerySet
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FOLDER_BACKEND = 'trusts.test_issue115.FolderBackend'
+
+
+class FolderBackend(TrustModelBackendMixin, ModelBackend):
+    pass
+
+
+class FolderAuthConfig(TrustsImplementationConfig):
+    name = 'tests'
+    label = 'readme_folder_auth'
+    trusts_backend_paths = (FOLDER_BACKEND,)
+
+
+class _AppsView(object):
+    def __init__(self, configs, ready=True):
+        self._configs = list(configs)
+        self.ready = ready
+
+    def get_app_configs(self):
+        return tuple(self._configs)
+
+    def is_installed(self, name):
+        return False
+
+
+def _bind(config_cls, configs=None, ready=True):
+    config = config_cls('tests', tests_module)
+    view = _AppsView(
+        configs if configs is not None else [config],
+        ready=ready,
+    )
+    config.apps = view
+    if configs is None:
+        view._configs = [config]
+    return config
+
+
+def _readme_models():
+    """Ordinary application-owned models from the README example.
+
+    The README uses ``settings.AUTH_USER_MODEL``. Isolated apps resolve
+    that string only after ``auth.User`` is loaded, so the live proof
+    binds the same user model class Django would resolve.
+    """
+    User = get_user_model()
+
+    class Folder(models.Model):
+        title = models.CharField(max_length=40)
+        objects = AuthorizedManager()
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    class FolderGrant(models.Model):
+        folder = models.ForeignKey(Folder, on_delete=models.CASCADE)
+        user = models.ForeignKey(User, on_delete=models.CASCADE)
+        permission = models.ForeignKey(Permission, on_delete=models.CASCADE)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    return Folder, FolderGrant
+
+
+@contextmanager
+def _tables(*model_classes):
+    with connection.schema_editor() as editor:
+        for model in model_classes:
+            editor.create_model(model)
+    try:
+        yield
+    finally:
+        with connection.schema_editor() as editor:
+            for model in reversed(model_classes):
+                editor.delete_model(model)
+
+
+def _perm(model, codename):
+    ct, _created = ContentType.objects.get_or_create(
+        app_label=model._meta.app_label,
+        model=model._meta.model_name,
+    )
+    permission, _created = Permission.objects.get_or_create(
+        content_type=ct,
+        codename=codename,
+        defaults={'name': codename},
+    )
+    return permission
+
+
+def _python_fences(text):
+    return re.findall(r'```python\n(.*?)```', text, flags=re.DOTALL)
+
+
+def _request(user):
+    request = HttpRequest()
+    request.user = user
+    request.META['SERVER_NAME'] = 'testserver'
+    request.META['SERVER_PORT'] = '80'
+    return request
+
+
+class ReadmePackageCopyTest(SimpleTestCase):
+    def test_user_readme_is_not_internal_status(self):
+        readme = (ROOT / 'README.md').read_text()
+        forbidden = (
+            'Step I',
+            'Step II',
+            'Step III',
+            'C1',
+            'C2',
+            'Z1',
+            'pair pin',
+            'baton',
+            'code budget',
+            '1.0.0.dev1',
+            '1.0.0.dev2',
+            '1.0.0.dev3',
+            '11058641',
+            '94e0fa',
+            'f0b25c',
+            'kernel_config',
+            'trusts.core_backends',
+            'from trusts.backends import TrustModelBackend\n',
+            'from trusts.models import Trust',
+            'settlor',
+            'trustee',
+            'multiple organizations',
+        )
+        offenders = [needle for needle in forbidden if needle in readme]
+        self.assertEqual(offenders, [])
+        self.assertIn('non-standalone Python dependency', readme)
+        self.assertIn("Do **not** list `'trusts'` in `INSTALLED_APPS`", readme)
+        self.assertIn('from trusts.backends import TrustModelBackendMixin', readme)
+        self.assertIn('from trusts.apps import TrustsImplementationConfig', readme)
+        self.assertIn('from trusts.core import Ref', readme)
+        self.assertIn('AuthorizedQuerySet(Folder).authorized(user, perm)', readme)
+        self.assertIn('user.has_perm(', readme)
+        self.assertIn('@permission_required(', readme)
+        self.assertIn('django-trusts-zero', readme)
+        self.assertIn('django-trusts-gh-permissions', readme)
+        self.assertIn('forthcoming', readme.lower())
+        self.assertIn('Windows', readme)
+        self.assertIn('migrates.md', readme)
+        self.assertIn('DEV.md', readme)
+        self.assertIn('BeeDesk, Inc.', readme)
+        self.assertIn('2015-2026', readme)
+
+    def test_dev_md_is_contributor_history_and_corrects_the_library_cut(self):
+        dev = (ROOT / 'DEV.md').read_text()
+        header = dev[:900].lower()
+        self.assertIn('contributor', header)
+        self.assertIn('internal', header)
+        self.assertIn('README.md', dev)
+        self.assertNotIn('readme = "DEV.md"', (ROOT / 'pyproject.toml').read_text())
+        self.assertIn('kernel_config()', dev)
+        self.assertIn('no Django `AppConfig`', dev)
+        self.assertIn('trusts.core_backends', dev)
+        self.assertIn('TrustModelBackendMixin', dev)
+        self.assertIn('1.0.0.dev3', dev)
+        self.assertIn('docs/legacy-baseline.md', dev)
+        self.assertIn('docs/support-matrix.md', dev)
+
+    def test_pyproject_and_license_match_the_library(self):
+        pyproject = (ROOT / 'pyproject.toml').read_text()
+        self.assertIn('name = "django-trusts"', pyproject)
+        self.assertIn('version = "1.0.0.dev3"', pyproject)
+        self.assertIn('readme = "README.md"', pyproject)
+        self.assertNotIn('readme = "DEV.md"', pyproject)
+        self.assertIn('license = "BSD-2-Clause"', pyproject)
+        self.assertIn(
+            'Implementation-neutral Django authorization library',
+            pyproject,
+        )
+        self.assertNotIn('multiple organizations', pyproject)
+        self.assertNotIn('"organizations"', pyproject)
+        license_text = (ROOT / 'LICENSE').read_text()
+        self.assertIn('Copyright (c) 2015-2026, BeeDesk, Inc.', license_text)
+        self.assertNotIn('and contributors', license_text.split('THIS SOFTWARE')[0])
+        self.assertIn('All rights reserved.', license_text)
+
+    def test_readme_fences_are_real_python_and_use_the_final_api(self):
+        readme = (ROOT / 'README.md').read_text()
+        fences = _python_fences(readme)
+        self.assertGreaterEqual(len(fences), 4)
+        for fence in fences:
+            ast.parse(fence)
+        joined = '\n'.join(fences)
+        self.assertIn('class FolderBackend(TrustModelBackendMixin, ModelBackend)', joined)
+        self.assertIn('class FolderAuthConfig(TrustsImplementationConfig)', joined)
+        self.assertIn('grant = Ref(FolderGrant)', joined)
+        self.assertIn('self.registry.register(', joined)
+        self.assertIn('myapp.apps.FolderAuthConfig', joined)
+        self.assertNotIn("'trusts'", joined)
+        self.assertIn('FolderGrant.objects.create(', joined)
+        self.assertIn("user.has_perm('myapp.change_folder', folder)", joined)
+        self.assertIn('AuthorizedQuerySet(Folder).authorized(user, perm)', joined)
+        self.assertIn('fieldlookups_kwargs', joined)
+        self.assertNotIn('trusts.core_backends', joined)
+        self.assertNotIn('kernel_config', joined)
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class ReadmeExampleLiveTest(TransactionTestCase):
+    def test_readme_example_has_perm_queryset_and_decorator(self):
+        Folder, FolderGrant = _readme_models()
+        with _tables(Folder, FolderGrant):
+            User = get_user_model()
+            alice = User.objects.create_user(
+                username='readme-alice', password='x',
+            )
+            bob = User.objects.create_user(
+                username='readme-bob', password='x',
+            )
+            folder_a = Folder.objects.create(title='A')
+            folder_b = Folder.objects.create(title='B')
+            perm = _perm(Folder, 'change_folder')
+            FolderGrant.objects.create(
+                folder=folder_a, user=alice, permission=perm,
+            )
+            code = '%s.change_folder' % Folder._meta.app_label
+
+            owner = _bind(FolderAuthConfig, ready=False)
+            with override_settings(AUTHENTICATION_BACKENDS=(
+                'django.contrib.auth.backends.ModelBackend',
+                FOLDER_BACKEND,
+            )):
+                owner.ready()
+                grant = Ref(FolderGrant)
+                owner.registry.register(
+                    content=grant.folder,
+                    user=grant.user,
+                    permission=grant.permission,
+                )
+                with patch(
+                    'trusts.apps.implementation_configs',
+                    return_value=(owner,),
+                ):
+                    backend = FolderBackend()
+                    self.assertTrue(backend.has_perm(alice, code, folder_a))
+                    self.assertFalse(backend.has_perm(alice, code, folder_b))
+                    self.assertFalse(backend.has_perm(bob, code, folder_a))
+                    self.assertTrue(alice.has_perm(code, folder_a))
+                    self.assertFalse(alice.has_perm(code, folder_b))
+                    self.assertFalse(bob.has_perm(code, folder_a))
+
+                    qs = AuthorizedQuerySet(Folder).authorized(alice, perm)
+                    with self.assertNumQueries(1):
+                        pks = set(qs.values_list('pk', flat=True))
+                    self.assertEqual(pks, {folder_a.pk})
+                    self.assertFalse(
+                        AuthorizedQuerySet(Folder).authorized(bob, perm).exists()
+                    )
+
+                    from django.core.exceptions import PermissionDenied
+                    from trusts import decorators as dec
+
+                    @permission_required(
+                        code,
+                        fieldlookups_kwargs={'pk': 'folder_id'},
+                    )
+                    def edit_folder(request, folder_id):
+                        return folder_id
+
+                    # isolate_apps models are invisible to ContentType.model_class().
+                    # The decorator's remaining work is user.has_perms on that
+                    # queryset — the same surface Django views use.
+                    granted = Folder.objects.filter(pk=folder_a.pk)
+                    denied = Folder.objects.filter(pk=folder_b.pk)
+                    with patch.object(dec, '_get_permissible_items', return_value=granted):
+                        self.assertEqual(
+                            edit_folder(_request(alice), folder_id=folder_a.pk),
+                            folder_a.pk,
+                        )
+                        with self.assertRaises(PermissionDenied):
+                            edit_folder(_request(bob), folder_id=folder_a.pk)
+                    with patch.object(dec, '_get_permissible_items', return_value=denied):
+                        with self.assertRaises(PermissionDenied):
+                            edit_folder(_request(alice), folder_id=folder_b.pk)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [#115](https://github.com/django-trusts/django-trusts/issues/115). Documentation and package-copy alignment only on the final core library cut (`1.0.0.dev3`, PR #112 merge `11058641`). No authorization, registry, public-callable, or version change.

## Changes

- Archive the historical Trust/settlor product README as `DEV.md`, marked contributor/history, and correct statements made false by the library cut (no `kernel_config()`, no core `AppConfig`, no `trusts.core_backends`).
- Replace `README.md` with an implementation-neutral user introduction: non-standalone Python dependency, routing to Zero / GH / forthcoming Windows, principles, and a verified final-API example (`TrustModelBackendMixin`, `TrustsImplementationConfig`, `Ref`, `has_perm`, `AuthorizedQuerySet.authorized`, `permission_required`).
- `pyproject.toml` long description stays `README.md`. Description/keywords no longer claim a multiple-organization Trust add-on.
- Normalize the BeeDesk BSD-2-Clause notice to `2015-2026`.
- Add `trusts.test_issue115` (kernel suite) to reject internal-status language and stale removed surfaces, and to exercise the README example.
- Wheel-isolation script checks that the installed long description and LICENSE match the new user copy.

## Local verification

- `python3 -m tests.runtests` — 208 tests, 13 skipped, OK
- `trusts.test_issue100` on PostgreSQL — 37 tests, OK
- `python3 -m django check --settings=tests.settings` — no issues
- `python3 -m build` + `twine check` — sdist/wheel PASSED
- Wheel METADATA summary is the new library description; long description contains `non-standalone Python dependency` and not settlor / multiple-organizations copy
- Wheel LICENSE: `Copyright (c) 2015-2026, BeeDesk, Inc.`; SPDX `BSD-2-Clause`
- `scripts/verify-wheel-install.py` against the built wheel — OK, including README/LICENSE checks
- Supported Zero-pair proofs run in CI (`COMPANION_ZERO_SHA` `94e0fa10`)

Exact head: `ad071065d37ce1194163518f8d29458e3b276db8`

r? @chatforthomas

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

