### PR TITLE
Configure repository-owned Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
Read the Docs now rejects builds that do not include `.readthedocs.yaml` at the repository root.

This adds the smallest v2 configuration matching the documentation build already enforced by CI:

- Ubuntu 24.04
- Python 3.12
- Sphinx config at `docs/source/conf.py`
- warnings treated as build failures

The YAML parses successfully, and PR #123 already proved the same source tree with `sphinx-build -nW`.

The existing `v1.0.0.dev3` tag predates this file and remains immutable. This fixes `latest`/`dev` after merge and all future tags.