### PR TITLE
Restore core Coveralls reporting on the dev line

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = trusts
+omit =
+    */tests/*
+    */trusts/zero/*
+    */django-trusts-zero/*
+    */docs/*
+    */scripts/*
+    */.deps/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [dev]
   pull_request:
 
 permissions:
@@ -35,6 +35,17 @@ jobs:
       run: |
         coverage run -m tests.runtests
         coverage report
+    - name: Generate Cobertura coverage.xml
+      if: matrix.python-version == '3.12'
+      run: coverage xml
+    - name: Upload coverage to Coveralls
+      if: matrix.python-version == '3.12'
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        file: coverage.xml
+        format: cobertura
+        compare-ref: dev
     - name: Fresh migrate (no Trusts schema)
       run: python -m django migrate --noinput --settings=tests.settings
     - name: System checks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # django-trusts
 
+[![Coverage](https://coveralls.io/repos/github/django-trusts/django-trusts/badge.svg?branch=dev)](https://coveralls.io/github/django-trusts/django-trusts?branch=dev)
+
 `django-trusts` is a **non-standalone Python dependency** for applications
 and packages that define their own declarative Django authorization
 implementation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #125.

r? @chatforthomas

Restore hosted coverage for the schema-neutral core library. Core is still executable library code; its coverage stays separate from Zero.

## Changes

1. Add a repository-owned `.coveragerc` with branch coverage, `source = trusts`, and omit rules so tests, companion Zero (`trusts.zero` / `django-trusts-zero`), generated docs, and checkout helpers (`.deps/`, `scripts/`) stay out of the denominator.
2. Keep the Python 3.12–3.14 kernel matrix. Only the canonical Python 3.12 kernel job writes Cobertura `coverage.xml` and uploads it.
3. Upload with `coverallsapp/github-action@v2` and the built-in `GITHUB_TOKEN` (not a repository secret).
4. Compare pull-request coverage against `dev` (`compare-ref: dev`).
5. Change the workflow push trigger from `master` to `dev` so merged commits establish the active branch baseline.
6. Add a Coveralls badge to the user README, scoped to `dev`.

## Policy

Coverage is evidence, not a merge gate:

- no percentage threshold;
- the coverage-generation step fails if the test run or XML generation fails;
- the Coveralls action uses its normal failure behavior (`fail-on-error` default).

No runtime API, schema, migration, package version, or authorization behavior changes.

## Coverage baseline

Exact-head Python 3.12 kernel job on `7aaa261a774fda2cb95c6f67a05e1226791e08b5` (CI run [34678831926](https://github.com/django-trusts/django-trusts/actions/runs/34678831926); Coveralls [job 187799893](https://coveralls.io/jobs/187799893)):

| Metric | Covered | Valid | Rate |
| --- | --- | --- | --- |
| Lines | 2313 | 3117 | 74.21% |
| Branches | 780 | 1246 | 62.60% |
| Combined (`coverage report`) | | | 71% |

The report listed only production `trusts` modules (including leftover management commands that the kernel suite does not exercise). It did not include `tests/`, Zero, `docs/`, `scripts/`, or `.deps/`. CI totals match the local preview. The first merge/push to `dev` is what establishes the hosted branch baseline for later PRs.

All six CI jobs are green (kernel 3.12/3.13/3.14, OrderedFold PostgreSQL, pair with Zero, package).

## Badge destination

The README uses the current-org placeholder:

`https://coveralls.io/github/django-trusts/django-trusts?branch=dev`

First upload succeeded and created Coveralls job `https://coveralls.io/jobs/187799893`. @chatforthomas should confirm that project URL after review; I did not keep the obsolete `beedesk/django-trusts?branch=master` destination.

## Coordination

django-trusts-zero #23 stays parked until this pattern is reviewed and merged. This PR does not start Zero companion work.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4677ea64-8d57-4160-99d8-559b1cca9a87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4677ea64-8d57-4160-99d8-559b1cca9a87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

