### PR TITLE
#135: emit repository-relative Cobertura paths for Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = trusts
+source = .
 omit =
     */tests/*
     */trusts/zero/*
@@ -8,3 +8,7 @@ omit =
     */docs/*
     */scripts/*
     */.deps/*
+
+[report]
+include =
+    trusts/*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Core half of #135. Zero companion is a separate PR: [django-trusts-zero#25](https://github.com/django-trusts/django-trusts-zero/pull/25).

Coveralls source navigation fails because Cobertura currently emits bare filenames such as `core.py` (`source = trusts`). This PR fixes the producer so XML class paths are repository-relative and begin with `trusts/`.

Do **not** use Coveralls `base-path: trusts`. Repository-relative XML removes the need for dashboard mapping.

## Change

`.coveragerc` only:

```ini
[run]
branch = True
source = .
omit =
    */tests/*
    */trusts/zero/*
    */django-trusts-zero/*
    */docs/*
    */scripts/*
    */.deps/*

[report]
include =
    trusts/*
```

Existing omit rules remain effective (tests, trusts.zero / django-trusts-zero, docs, scripts, .deps).

No runtime API, schema, migration, package version, or authorization behavior changes. No CI Coveralls `base-path`. Zero-example / Windows work is left alone.

## Local verification

Exact HEAD: `94bdde762dab6186d05f85458a0a52b8c047ac84`

Full kernel run (`coverage run -m tests.runtests`): **343 tests, 13 skipped, OK**.

`coverage.xml` source is the repository root. Class filenames are repository-relative and begin with `trusts/`. Sample:

```xml
<source>/workspace</source>
<class name="core.py" filename="trusts/core.py" ...>
```

All 16 class filenames:

`trusts/__init__.py`, `trusts/apps.py`, `trusts/backends.py`, `trusts/checks.py`, `trusts/conditions.py`, `trusts/core.py`, `trusts/decorators.py`, `trusts/models.py`, `trusts/ordered_fold.py`, `trusts/query.py`, `trusts/utils.py`, `trusts/management/__init__.py`, `trusts/management/commands/__init__.py`, `trusts/management/commands/create_trust_root.py`, `trusts/management/commands/grandfather_trust_group_permissions.py`, `trusts/management/commands/update_roles_permissions.py`

No `tests/`, `trusts/zero/`, `django-trusts-zero/`, `docs/`, `scripts/`, or `.deps/` classes leaked into the report.

| Metric | Covered | Valid | Rate |
| --- | --- | --- | --- |
| Lines | 2313 | 3117 | 74.21% |
| Branches | 780 | 1246 | 62.60% |
| Combined (`coverage report`) | | | 71% |

These totals match the issue's pre-change local full kernel baseline exactly.

## CI

All six jobs are green on HEAD `94bdde762dab6186d05f85458a0a52b8c047ac84` ([run 34709613543](https://github.com/django-trusts/django-trusts/actions/runs/34709613543)):

- tests kernel-only (Python 3.12)
- tests kernel-only (Python 3.13)
- tests kernel-only (Python 3.14)
- tests OrderedFold PostgreSQL
- pair with Zero
- package

## Coordination

Zero's equivalent `source = .` + `[report] include = trusts/zero/*` change is [django-trusts-zero#25](https://github.com/django-trusts/django-trusts-zero/pull/25). This PR does not start that work. Merging this PR must not close #135; Zero verification and fresh Coveralls source navigation remain on the shared issue.

r? @chatforthomas

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f9ade0-dbca-452c-81b4-21db7d2b721f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f9ade0-dbca-452c-81b4-21db7d2b721f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

