### PR TITLE
#142 Stage A: registration-time condition builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,27 @@ user.has_perm('myapp.change_document', document)
 Document.objects.authorized(user, change_permission)
 ```
 
+Named queryable conditions are registration-time builders. Core invokes
+the callable once with symbolic ``(u, p, o)``, stores only normalized
+IR, and never runs the callable during ``has_perm`` or
+``.authorized()``.
+
+```python
+handle = apps.get_app_config('myapp').configured_backend()
+handle.register_permission_condition(
+    Document,
+    'non_confidential',
+    lambda u, p, o: o.confidential != True,
+)
+handle.register_permission_condition(
+    Document,
+    'own',
+    lambda u, p, o: u == o.owner,
+)
+user.has_perm('myapp.change_document:non_confidential', document)
+Document.objects.authorized(user, 'myapp.change_document:non_confidential')
+```
+
 View guard for the same permission:
 
 ```python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -248,6 +248,32 @@ Protect a view with the same permission:
 Object checks, permission enumeration, queryset filtering, and view protection
 all use the registered permission relationship.
 
+Named queryable conditions
+--------------------------
+
+A named ``:condition`` is a trusted registration-time builder. Core
+invokes it once with symbolic ``(u, p, o)``, stores only normalized IR,
+and never calls it during ``has_perm`` or authorized querysets.
+
+.. code-block:: python
+
+   handle = apps.get_app_config("documents").configured_backend()
+   handle.register_permission_condition(
+       Document,
+       "non_confidential",
+       lambda u, p, o: o.confidential != True,
+   )
+   handle.register_permission_condition(
+       Document,
+       "own",
+       lambda u, p, o: u == o.owner,
+   )
+
+   user.has_perm("documents.change_document:non_confidential", document)
+   Document.objects.authorized(
+       user, "documents.change_document:non_confidential",
+   )
+
 More expressive permission policies
 -----------------------------------
 

--- a/migrates.md
+++ b/migrates.md
@@ -3220,4 +3220,92 @@ is unchanged (source-archive check, not an upgrade runner).
       `trusts.models`, backends, decorators, conditions, registry/query
       APIs, or `OrderedFold`.
 
+# Issue #142 Stage A: registration-time condition builders (1.0.0.dev3)
+
+This record covers
+[django-trusts#142](https://github.com/django-trusts/django-trusts/issues/142)
+Stage A only. Package version stays **1.0.0.dev3**. No model, field,
+table, migration-loader key, content type, permission row, stored
+authorization fact, package identity, or app label changes.
+
+## Decision
+
+`register_permission_condition(..., callable)` now means a trusted
+startup builder. Core invokes it once with symbolic `(u, p, o)`,
+normalizes constants into durable IR, and stores only that IR. The
+callable is not the policy record and is never invoked during
+`has_perm`, enumeration, or queryset filtering. A transitional prebuilt
+`Expr` is still accepted so unconverted Zero `Trust:own` Meta trees
+keep loading.
+
+`BackendHandle.register_permission_condition` is the application API.
+`freeze()` seals condition registration and raises before the builder
+runs. Invalid fields, real booleans, and unsupported Python fail at
+register. `TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS` no longer enables
+callbacks; if still True it is `trusts.E007`.
+
+Stage B (not this PR) removes public `Expr` / `condition_refs` imports
+and rejects prebuilt `Expr`. Zero/example conversion is a later paired
+pin.
+
+## No change to these public call sites
+
+- `User.has_perm` / `has_perms` / `get_*_permissions` signatures
+- Relation `register(...)` / `Along` / `OrderedFold`
+- `permission_required` inference (queued on #138)
+- Public `condition_refs` / `Expr` / `django_trusts` construction
+  exports (removed in Stage B)
+- Package version `1.0.0.dev3`
+
+## Behavior
+
+| | |
+| --- | --- |
+| Previous | `register_permission_condition` type-dispatch: `Expr` from `condition_refs()` is queryable IR; a callable is an object-only runtime predicate, never invoked at register, gated by `TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS`. Field errors wait for `trusts.E001` / runtime. `freeze()` does not seal conditions. Registration is `handle.registry.register_permission_condition`. |
+| New | A callable is a builder: invoked once, IR stored, callable discarded from the record. Transitional `Expr` still accepted. Field/type validation and constant normalization run at register (zero SQL). `handle.register_permission_condition(...)`. Frozen handles reject writes before invoke. Leftover callback setting is `trusts.E007` and enables nothing. |
+| Replacement | `handle.register_permission_condition(Model, 'code', lambda u, p, o: ...)`. |
+| Affected | Core tests #4/#16/#29/#142; Core `Ticket.meta_own` fixture. Zero production `Trust:own` remains a prebuilt `Expr` until Z-convert. No GH/Windows application callers. |
+| Authorization | Object evaluate and queryset compile use the same stored IR. No fallback to the bare grant. |
+| Rollout | Merge Stage A; keep current `COMPANION_ZERO_SHA`. Do not merge Stage B until Z-convert and example conversion heads are green. |
+
+```python
+# Previous
+u, p, o = condition_refs()
+handle.registry.register_permission_condition(Document, 'own', u == o.owner)
+
+# New
+handle.register_permission_condition(
+    Document, 'own', lambda u, p, o: u == o.owner,
+)
+```
+
+## Schema
+
+No change.
+
+## Out of scope
+
+- Stage B public-import removal
+- Zero / example conversion
+- `TQ.contains`
+- #138 `require_authorized`
+- #137 coverage resume
+- #131 relation `handle.register(...)`
+
+## Migration-bot checklist
+
+- [ ] Do not apply a new Trusts schema or data migration; none was added.
+- [ ] Search for `register_permission_condition(..., callable)` used as
+      a runtime `has_perm` predicate. Rewrite as a builder that returns
+      a V1 comparison, or wait for Stage B / Z-convert.
+- [ ] Retarget application registration to
+      `configured_backend().register_permission_condition`.
+- [ ] Remove `TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS` from settings.
+      Leaving it True is `trusts.E007` and does not enable callbacks.
+- [ ] Do not import-delete `condition_refs` / `Expr` yet (Stage B).
+- [ ] Confirm first-party builders/donation add zero queries.
+- [ ] Leave package version at `1.0.0.dev3`.
+- [ ] Do not start Zero/example conversion, Stage B, #138, or #137 in
+      this PR.
+
 

--- a/tests/core/test_issue142.py
+++ b/tests/core/test_issue142.py
@@ -1,0 +1,232 @@
+"""#142 Stage A: registration-time condition builders."""
+
+from django.contrib.auth import get_user_model
+from django.core.checks import Error
+from django.db import connection, models
+from django.test import SimpleTestCase, TransactionTestCase, override_settings
+from django.test.utils import isolate_apps
+
+from trusts.checks import (
+    CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING,
+    leftover_legacy_callback_setting_messages,
+    permission_condition_check_messages,
+)
+from trusts.conditions import (
+    ModelIdentity,
+    PermissionConditionError,
+    condition_refs,
+)
+from trusts.core import BackendHandle, TrustsConfigurationError, TrustsRegistry
+
+
+def _note_model():
+    User = get_user_model()
+
+    class Note(models.Model):
+        title = models.CharField(max_length=40)
+        owner = models.ForeignKey(User, on_delete=models.CASCADE)
+        confidential = models.BooleanField(null=True)
+
+        class Meta:
+            app_label = 'trusts_tests'
+
+    return Note
+
+
+class _CallLog(object):
+    def __init__(self, impl):
+        self.impl = impl
+        self.calls = []
+
+    def __call__(self, user, perm, obj):
+        self.calls.append((user, perm, obj))
+        return self.impl(user, perm, obj)
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class StageABuilderRegistrationTest(SimpleTestCase):
+    def test_lambda_and_named_builder_are_identical(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+
+        def owned(u, p, o):
+            return u == o.owner
+
+        named = registry.register_permission_condition(Note, 'own', owned)
+        lam = TrustsRegistry().register_permission_condition(
+            Note, 'own', lambda u, p, o: u == o.owner,
+        )
+        self.assertEqual(named.expr.to_tuple(), lam.expr.to_tuple())
+        self.assertFalse(hasattr(named, 'func'))
+
+    def test_builder_invoked_once_and_not_during_evaluate_or_compile(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        log = _CallLog(lambda u, p, o: u == o.owner)
+        registry.register_permission_condition(Note, 'own', log)
+        self.assertEqual(len(log.calls), 1)
+        u, p, o = log.calls[0]
+        self.assertEqual(u.to_tuple(), ('ref', 'principal', ()))
+        self.assertEqual(p.to_tuple(), ('ref', 'permission', ()))
+        self.assertEqual(o.to_tuple(), ('ref', 'object', ()))
+        with self.assertRaises(AttributeError):
+            registry.evaluate_permission_condition(
+                Note, 'own', object(), 'change', object(),
+            )
+        self.assertEqual(len(log.calls), 1)
+
+    def test_real_bool_and_bare_ref_fail_at_register(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        with self.assertRaises(PermissionConditionError):
+            registry.register_permission_condition(
+                Note, 'yes', lambda u, p, o: True,
+            )
+        with self.assertRaises(PermissionConditionError):
+            registry.register_permission_condition(
+                Note, 'bare', lambda u, p, o: o.owner,
+            )
+
+    def test_unresolved_field_fails_at_register(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        with self.assertRaises(PermissionConditionError) as ctx:
+            registry.register_permission_condition(
+                Note, 'typo', lambda u, p, o: u == o.nope,
+            )
+        self.assertIn('nope', str(ctx.exception))
+
+    def test_frozen_registry_rejects_before_builder(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        registry.freeze()
+        log = _CallLog(lambda u, p, o: u == o.owner)
+        with self.assertRaises(TrustsConfigurationError):
+            registry.register_permission_condition(Note, 'own', log)
+        self.assertEqual(log.calls, [])
+
+    def test_handle_method_delegates(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        handle = BackendHandle(
+            path='tests.backends.HostTrustModelBackend',
+            registry=registry,
+            compiler=object(),
+        )
+        record = handle.register_permission_condition(
+            Note, 'own', lambda u, p, o: u == o.owner,
+        )
+        self.assertIs(
+            registry.get_permission_condition_record(Note, 'own'), record,
+        )
+
+    def test_transitional_expr_still_accepted(self):
+        Note = _note_model()
+        u, _p, o = condition_refs()
+        registry = TrustsRegistry()
+        expr = u == o.owner
+        record = registry.register_permission_condition(Note, 'own', expr)
+        self.assertEqual(record.expr.to_tuple(), expr.to_tuple())
+
+    def test_mutable_and_unsaved_constants_rejected(self):
+        Note = _note_model()
+        registry = TrustsRegistry()
+        with self.assertRaises(PermissionConditionError):
+            registry.register_permission_condition(
+                Note, 'flags', lambda u, p, o: o.title == ['x'],
+            )
+        User = get_user_model()
+        unsaved = User(username='unsaved-142')
+        with self.assertRaises(PermissionConditionError):
+            registry.register_permission_condition(
+                Note, 'unsaved', lambda u, p, o: o.owner == unsaved,
+            )
+
+    @override_settings(TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS=True)
+    def test_leftover_setting_is_check_error(self):
+        messages = leftover_legacy_callback_setting_messages()
+        self.assertEqual(len(messages), 1)
+        self.assertIsInstance(messages[0], Error)
+        self.assertEqual(messages[0].id, CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING)
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class StageANormalizationRuntimeTest(TransactionTestCase):
+    def test_saved_model_constant_is_identity_and_zero_sql_register(self):
+        Note = _note_model()
+        User = get_user_model()
+        with connection.schema_editor() as editor:
+            editor.create_model(Note)
+        try:
+            alice = User.objects.create_user(
+                'alice-142', 'alice-142@example.com', 'x',
+            )
+            keep = Note.objects.create(title='keep', owner=alice)
+            registry = TrustsRegistry()
+            with self.assertNumQueries(0):
+                record = registry.register_permission_condition(
+                    Note, 'alice', lambda u, p, o: o.owner == alice,
+                )
+            const = record.expr.right
+            self.assertIsInstance(const.value, ModelIdentity)
+            self.assertEqual(const.value.pk, alice.pk)
+            alice.username = 'mutated'
+            self.assertTrue(
+                registry.evaluate_permission_condition(
+                    Note, 'alice', alice, 'change', keep,
+                )
+            )
+            q = registry.compile_registered_condition_q(
+                Note, 'trusts_tests.change_note:alice', alice,
+            )
+            self.assertEqual(
+                list(Note.objects.filter(q).values_list('pk', flat=True)),
+                [keep.pk],
+            )
+        finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(Note)
+
+    def test_nullable_boolean_builder_and_checks_do_not_reinvoke(self):
+        Note = _note_model()
+        User = get_user_model()
+        with connection.schema_editor() as editor:
+            editor.create_model(Note)
+        try:
+            alice = User.objects.create_user(
+                'alice-142b', 'alice-142b@example.com', 'x',
+            )
+            open_note = Note.objects.create(
+                title='open', owner=alice, confidential=False,
+            )
+            secret = Note.objects.create(
+                title='secret', owner=alice, confidential=True,
+            )
+            unset = Note.objects.create(
+                title='unset', owner=alice, confidential=None,
+            )
+            log = _CallLog(lambda u, p, o: o.confidential != True)
+            registry = TrustsRegistry()
+            registry.register_permission_condition(Note, 'public', log)
+            self.assertEqual(len(log.calls), 1)
+            permission_condition_check_messages(registry.iter_permission_conditions())
+            self.assertEqual(len(log.calls), 1)
+            self.assertTrue(
+                registry.evaluate_permission_condition(
+                    Note, 'public', alice, 'change', open_note,
+                )
+            )
+            self.assertTrue(
+                registry.evaluate_permission_condition(
+                    Note, 'public', alice, 'change', unset,
+                )
+            )
+            self.assertFalse(
+                registry.evaluate_permission_condition(
+                    Note, 'public', alice, 'change', secret,
+                )
+            )
+            self.assertEqual(len(log.calls), 1)
+        finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(Note)

--- a/tests/core/test_issue16.py
+++ b/tests/core/test_issue16.py
@@ -9,15 +9,13 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.core.checks import Error, Warning as CheckWarning
+from django.core.checks import Error
 from django.db import connection, models
-from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
+from django.test import SimpleTestCase, TransactionTestCase
 from django.test.utils import isolate_apps
 
 from trusts.checks import (
     CHECK_ID_INVALID_EXPR,
-    CHECK_ID_LEGACY_CALLBACK,
-    CHECK_ID_LEGACY_CALLBACK_WARNING,
     check_permission_conditions,
     iter_live_permission_conditions,
     permission_condition_check_messages,
@@ -27,12 +25,10 @@ from trusts.conditions import (
     ConditionRecord,
     ConditionRegistry,
     PermissionConditionError,
-    PermissionConditionNotQueryable,
     RegistryConditionLookup,
     condition_refs,
-    legacy_permission_callbacks_allowed,
 )
-from trusts.core import TrustsRegistry
+from trusts.core import TrustsConfigurationError, TrustsRegistry
 
 
 def _note_models():
@@ -109,7 +105,7 @@ class ConditionRegistryShapeTest(SimpleTestCase):
         record = registry.register_permission_condition(Note, 'owned', expr)
         self.assertIsInstance(record, ConditionRecord)
         self.assertIs(record.expr, expr)
-        self.assertIsNone(record.func)
+        self.assertFalse(hasattr(record, 'func'))
         self.assertIs(record.model, Note)
         self.assertIs(
             registry.get_permission_condition_record(Note, 'owned'), record,
@@ -117,17 +113,17 @@ class ConditionRegistryShapeTest(SimpleTestCase):
         self.assertIsNone(registry.get_permission_condition_record(Note, 'missing'))
         self.assertIsNone(registry.get_permission_condition_record(Memo, 'owned'))
 
-        log = _CallLog()
+        log = _CallLog(lambda user, perm, obj: user == obj.owner)
         callable_record = registry.register_permission_condition(Note, 'spy', log)
-        self.assertIsNone(callable_record.expr)
-        self.assertIs(callable_record.func, log)
-        self.assertEqual(log.calls, [])
+        self.assertIsNotNone(callable_record.expr)
+        self.assertFalse(hasattr(callable_record, 'func'))
+        self.assertEqual(len(log.calls), 1)
 
         with self.assertRaises(PermissionConditionError):
             registry.register_permission_condition(Note, 'bare', o.owner)
         with self.assertRaises(TypeError):
             registry.register_permission_condition(Note, 'bad', 'not-a-condition')
-        self.assertEqual(log.calls, [])
+        self.assertEqual(len(log.calls), 1)
 
     def test_duplicate_condition_overwrites_same_identity(self):
         Note, _Memo = _note_models()
@@ -175,29 +171,30 @@ class ConditionRegistryShapeTest(SimpleTestCase):
         third = ConditionRegistry()
         self.assertIsNone(third.get_permission_condition_record(Note, 'own'))
 
-    def test_freeze_does_not_seal_condition_registration(self):
+    def test_freeze_seals_condition_registration_before_builder(self):
         Note, _Memo = _note_models()
-        u, _p, o = condition_refs()
         registry = TrustsRegistry()
         registry.freeze()
-        record = registry.register_permission_condition(Note, 'own', u == o.owner)
-        self.assertIs(record.model, Note)
+        log = _CallLog(lambda user, perm, obj: user == obj.owner)
+        with self.assertRaises(TrustsConfigurationError):
+            registry.register_permission_condition(Note, 'own', log)
+        self.assertEqual(log.calls, [])
 
     def test_generic_lookup_binds_without_invoking(self):
         Note, _Memo = _note_models()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        log = _CallLog()
+        log = _CallLog(lambda user, perm, obj: user == obj.owner)
         registry.register_permission_condition(Note, 'spy', log)
         lookup = RegistryConditionLookup(registry)
         self.assertIsInstance(lookup, ConditionLookup)
         registry.set_condition_lookup(lookup)
         self.assertIs(registry.condition_lookup, lookup)
-        self.assertIs(lookup.record_for(Note, 'spy').func, log)
-        self.assertEqual(log.calls, [])
-        with self.assertRaises(PermissionConditionNotQueryable):
-            lookup.compile_q(Note, 'trusts_tests.change_note:spy', None)
-        self.assertEqual(log.calls, [])
+        self.assertIsNotNone(lookup.record_for(Note, 'spy').expr)
+        self.assertEqual(len(log.calls), 1)
+        q = lookup.compile_q(Note, 'trusts_tests.change_note:spy', None)
+        self.assertIsNotNone(q)
+        self.assertEqual(len(log.calls), 1)
 
 
 @isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
@@ -239,8 +236,7 @@ class ConditionRegistryRuntimeTest(TransactionTestCase):
             self.assertIn('owner', sql.lower())
             self.assertIn('status', sql.lower())
 
-    def test_default_rejects_callable_without_invoking(self):
-        self.assertFalse(legacy_permission_callbacks_allowed())
+    def test_builder_is_not_reinvoked_by_evaluate_or_compile(self):
         Note, _Memo = _note_models()
         User = get_user_model()
         with _tables(Note):
@@ -248,46 +244,21 @@ class ConditionRegistryRuntimeTest(TransactionTestCase):
                 'alice-16c', 'alice-16c@example.com', 'x',
             )
             note = Note.objects.create(title='n', owner=alice)
-            log = _CallLog(lambda user, perm, obj: True)
-            registry = TrustsRegistry()
-            registry.register_permission_condition(Note, 'spy', log)
-            with self.assertRaises(PermissionConditionNotQueryable):
-                registry.compile_registered_condition_q(
-                    Note, 'trusts_tests.change_note:spy', alice,
-                )
-            with self.assertRaises(PermissionConditionError) as ctx:
-                registry.evaluate_permission_condition(
-                    Note, 'spy', alice, 'trusts_tests.change_note', note,
-                )
-            self.assertIn('TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS', str(ctx.exception))
-            self.assertEqual(log.calls, [])
-
-    @override_settings(TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS=True)
-    def test_opt_in_callback_is_object_only(self):
-        self.assertTrue(legacy_permission_callbacks_allowed())
-        Note, _Memo = _note_models()
-        User = get_user_model()
-        with _tables(Note):
-            alice = User.objects.create_user(
-                'alice-16o', 'alice-16o@example.com', 'x',
-            )
-            note = Note.objects.create(title='n', owner=alice)
             log = _CallLog(lambda user, perm, obj: user == obj.owner)
             registry = TrustsRegistry()
             registry.register_permission_condition(Note, 'spy', log)
-            with self.assertRaises(PermissionConditionNotQueryable):
-                registry.compile_registered_condition_q(
-                    Note, 'trusts_tests.change_note:spy', alice,
-                )
-            self.assertEqual(log.calls, [])
+            self.assertEqual(len(log.calls), 1)
+            q = registry.compile_registered_condition_q(
+                Note, 'trusts_tests.change_note:spy', alice,
+            )
             self.assertTrue(
                 registry.evaluate_permission_condition(
                     Note, 'spy', alice, 'trusts_tests.change_note', note,
                 )
             )
             self.assertEqual(len(log.calls), 1)
-            self.assertEqual(log.calls[0][0], alice)
-            self.assertEqual(log.calls[0][2], note)
+            self.assertIn(note.pk, Note.objects.filter(q).values_list('pk', flat=True))
+
 
     def test_unknown_malformed_and_unbound_fail_closed(self):
         Note, _Memo = _note_models()
@@ -308,16 +279,9 @@ class ConditionRegistryRuntimeTest(TransactionTestCase):
                 registry.evaluate_permission_condition(
                     Note, 'missing', alice, 'trusts_tests.change_note', note,
                 )
-            registry.register_permission_condition(Note, 'typo', u == o.nope)
             with self.assertRaises(PermissionConditionError) as typo:
-                registry.compile_registered_condition_q(
-                    Note, 'trusts_tests.change_note:typo', alice,
-                )
+                registry.register_permission_condition(Note, 'typo', u == o.nope)
             self.assertIn('nope', str(typo.exception))
-            with self.assertRaises(PermissionConditionError):
-                registry.evaluate_permission_condition(
-                    Note, 'typo', alice, 'trusts_tests.change_note', note,
-                )
             empty = ConditionRecord(model=Note)
             registry.conditions._records[
                 (Note._meta.label, 'empty')
@@ -331,58 +295,36 @@ class ConditionRegistryRuntimeTest(TransactionTestCase):
 
 @isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
 class ConditionRegistryCheckTest(SimpleTestCase):
-    def test_checks_never_invoke_callables(self):
+    def test_checks_do_not_reinvoke_builder(self):
         Note, _Memo = _note_models()
-        exploding = _CallLog(lambda user, perm, obj: (_ for _ in ()).throw(
-            AssertionError('callable must not run during checks')
-        ))
+        log = _CallLog(lambda user, perm, obj: user == obj.owner)
         registry = ConditionRegistry()
-        registry.register_permission_condition(Note, 'boom', exploding)
+        registry.register_permission_condition(Note, 'own', log)
+        self.assertEqual(len(log.calls), 1)
         messages = permission_condition_check_messages(
             registry.iter_permission_conditions()
         )
-        self.assertEqual(exploding.calls, [])
-        self.assertEqual(len([m for m in messages if m.id == CHECK_ID_LEGACY_CALLBACK]), 1)
+        self.assertEqual(len(log.calls), 1)
+        self.assertEqual([m for m in messages if m.id == CHECK_ID_INVALID_EXPR], [])
 
-    def test_invalid_expr_is_check_error_not_registration_error(self):
+
+    def test_invalid_expr_raises_at_registration(self):
         Note, _Memo = _note_models()
         u, _p, o = condition_refs()
         registry = ConditionRegistry()
         expr = u == o.not_a_field
-        record = registry.register_permission_condition(Note, 'missing', expr)
-        self.assertIs(record.expr, expr)
-        errors = [
-            m for m in permission_condition_check_messages(
-                registry.iter_permission_conditions()
-            )
-            if m.id == CHECK_ID_INVALID_EXPR
-        ]
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], Error)
-        self.assertIn('not_a_field', errors[0].msg)
+        with self.assertRaises(PermissionConditionError) as ctx:
+            registry.register_permission_condition(Note, 'missing', expr)
+        self.assertIn('not_a_field', str(ctx.exception))
 
-    @override_settings(TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS=True)
-    def test_opt_in_emits_warning_without_invoking(self):
-        Note, _Memo = _note_models()
-        log = _CallLog()
-        registry = ConditionRegistry()
-        registry.register_permission_condition(Note, 'spy', log)
-        messages = permission_condition_check_messages(
-            registry.iter_permission_conditions()
-        )
-        warnings = [m for m in messages if m.id == CHECK_ID_LEGACY_CALLBACK_WARNING]
-        self.assertEqual(len(warnings), 1)
-        self.assertIsInstance(warnings[0], CheckWarning)
-        self.assertEqual(
-            [m for m in messages if m.id == CHECK_ID_LEGACY_CALLBACK], [],
-        )
-        self.assertEqual(log.calls, [])
 
     def test_check_permission_conditions_reads_handle_registry(self):
         Note, _Memo = _note_models()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'typo', u == o.nope)
+        registry.conditions._records[(Note._meta.label, 'typo')] = ConditionRecord(
+            expr=u == o.nope, model=Note,
+        )
 
         class _Handle(object):
             def __init__(self, store):
@@ -408,7 +350,9 @@ class ConditionRegistryCheckTest(SimpleTestCase):
         owner_a = TrustsRegistry()
         owner_b = TrustsRegistry()
         owner_a.register_permission_condition(Note, 'own', u == o.owner)
-        owner_b.register_permission_condition(Note, 'own', u == o.nope)
+        owner_b.conditions._records[(Note._meta.label, 'own')] = ConditionRecord(
+            expr=u == o.nope, model=Note,
+        )
 
         class _Handle(object):
             def __init__(self, store):

--- a/tests/core/test_issue29.py
+++ b/tests/core/test_issue29.py
@@ -1,33 +1,31 @@
 """#29: generic registration / check-ID / validation lifecycle.
 
 Live Trust/Content runtime stay on Zero ``tests/legacy/test_issue29.py``.
-This module proves the library check IDs and register-then-check
-lifecycle on an isolated ``ConditionRegistry`` / handle registry.
+Stage A raises invalid builders at registration; ``trusts.E001`` remains
+a defense-in-depth scan of stored IR.
 """
 
 from io import StringIO
 from unittest.mock import patch
 
-from django.apps import apps
 from django.contrib.auth import get_user_model
-from django.core.checks import Error, Warning as CheckWarning
+from django.core.checks import Error
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.db import models
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.test.utils import isolate_apps
 
 from trusts.checks import (
     CHECK_ID_INVALID_EXPR,
-    CHECK_ID_LEGACY_CALLBACK,
-    CHECK_ID_LEGACY_CALLBACK_WARNING,
+    CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING,
     check_permission_conditions,
     permission_condition_check_messages,
 )
 from trusts.conditions import (
+    ConditionRecord,
     PermissionConditionError,
     condition_refs,
-    legacy_permission_callbacks_allowed,
 )
 from trusts.core import TrustsRegistry
 
@@ -50,26 +48,25 @@ def _messages_with_id(messages, check_id):
     return [m for m in messages if m.id == check_id]
 
 
-class _CallLog(object):
-    def __init__(self, impl=None):
-        self.impl = impl or (lambda user, perm, obj: True)
-        self.calls = []
-
-    def __call__(self, user, perm, obj):
-        self.calls.append((user, perm, obj))
-        return self.impl(user, perm, obj)
-
-
 @isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
 class PermissionConditionCheckLifecycleTest(SimpleTestCase):
-    def test_semantic_invalid_expr_does_not_raise_at_registration(self):
+    def test_semantic_invalid_expr_raises_at_registration(self):
         Note = _note_model()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        expr = u == o.not_a_field
-        record = registry.register_permission_condition(Note, 'missing', expr)
-        self.assertIs(record.expr, expr)
-        self.assertIs(record.model, Note)
+        with self.assertRaises(PermissionConditionError) as ctx:
+            registry.register_permission_condition(
+                Note, 'missing', u == o.not_a_field,
+            )
+        self.assertIn('not_a_field', str(ctx.exception))
+
+    def test_injected_invalid_ir_is_still_e001(self):
+        Note = _note_model()
+        u, _p, o = condition_refs()
+        registry = TrustsRegistry()
+        registry.conditions._records[(Note._meta.label, 'missing')] = (
+            ConditionRecord(expr=u == o.not_a_field, model=Note)
+        )
         errors = _messages_with_id(
             permission_condition_check_messages(
                 registry.iter_permission_conditions(),
@@ -80,7 +77,9 @@ class PermissionConditionCheckLifecycleTest(SimpleTestCase):
         self.assertIsInstance(errors[0], Error)
         self.assertIn('not_a_field', errors[0].msg)
 
-    def test_registration_before_models_ready_retains_identity(self):
+    def test_valid_registration_before_models_ready(self):
+        from django.apps import apps
+
         Note = _note_model()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
@@ -89,8 +88,7 @@ class PermissionConditionCheckLifecycleTest(SimpleTestCase):
             record = registry.register_permission_condition(
                 Note, 'deferred_own', expr,
             )
-        self.assertIs(record.expr, expr)
-        self.assertIs(record.model, Note)
+        self.assertEqual(record.expr.to_tuple(), expr.to_tuple())
         self.assertEqual(
             _messages_with_id(
                 permission_condition_check_messages(
@@ -100,24 +98,17 @@ class PermissionConditionCheckLifecycleTest(SimpleTestCase):
             ),
             [],
         )
-        bad = u == o.deferred_missing
-        with patch.object(apps, 'models_ready', False):
-            registry.register_permission_condition(Note, 'deferred_bad', bad)
-        errors = _messages_with_id(
-            permission_condition_check_messages(
-                registry.iter_permission_conditions(),
-            ),
-            CHECK_ID_INVALID_EXPR,
-        )
-        self.assertTrue(any('deferred_missing' in m.msg for m in errors))
-        self.assertTrue(any("'deferred_bad'" in m.msg for m in errors))
 
     def test_multiple_dynamic_errors_are_aggregated(self):
         Note = _note_model()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'typo', u == o.nope)
-        registry.register_permission_condition(Note, 'types', o.status == 1)
+        registry.conditions._records[(Note._meta.label, 'typo')] = (
+            ConditionRecord(expr=u == o.nope, model=Note)
+        )
+        registry.conditions._records[(Note._meta.label, 'types')] = (
+            ConditionRecord(expr=o.status == 1, model=Note)
+        )
         errors = _messages_with_id(
             permission_condition_check_messages(
                 registry.iter_permission_conditions(),
@@ -129,57 +120,13 @@ class PermissionConditionCheckLifecycleTest(SimpleTestCase):
         self.assertIn('typo', msgs)
         self.assertIn('types', msgs)
 
-    def test_default_legacy_callback_is_check_error(self):
-        self.assertFalse(legacy_permission_callbacks_allowed())
-        Note = _note_model()
-        log = _CallLog()
-        registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'spy', log)
-        errors = _messages_with_id(
-            permission_condition_check_messages(
-                registry.iter_permission_conditions(),
-            ),
-            CHECK_ID_LEGACY_CALLBACK,
-        )
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], Error)
-        self.assertIn('spy', errors[0].msg)
-        self.assertEqual(log.calls, [])
-
-    @override_settings(TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS=True)
-    def test_legacy_opt_in_emits_warning_without_invoking(self):
-        self.assertTrue(legacy_permission_callbacks_allowed())
-        Note = _note_model()
-        log = _CallLog()
-        registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'spy', log)
-        messages = permission_condition_check_messages(
-            registry.iter_permission_conditions(),
-        )
-        warnings = _messages_with_id(messages, CHECK_ID_LEGACY_CALLBACK_WARNING)
-        self.assertEqual(len(warnings), 1)
-        self.assertIsInstance(warnings[0], CheckWarning)
-        self.assertEqual(_messages_with_id(messages, CHECK_ID_LEGACY_CALLBACK), [])
-        self.assertEqual(log.calls, [])
-
-    def test_checks_never_invoke_callables(self):
-        Note = _note_model()
-        exploding = _CallLog(lambda user, perm, obj: (_ for _ in ()).throw(
-            AssertionError('callable must not run during checks')
-        ))
-        registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'boom', exploding)
-        messages = permission_condition_check_messages(
-            registry.iter_permission_conditions(),
-        )
-        self.assertEqual(exploding.calls, [])
-        self.assertEqual(len(_messages_with_id(messages, CHECK_ID_LEGACY_CALLBACK)), 1)
-
-    def test_handle_check_and_ready_do_not_raise_on_invalid_expr(self):
+    def test_handle_check_and_ready_do_not_raise_on_injected_invalid_ir(self):
         Note = _note_model()
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        registry.register_permission_condition(Note, 'typo', u == o.nope)
+        registry.conditions._records[(Note._meta.label, 'typo')] = (
+            ConditionRecord(expr=u == o.nope, model=Note)
+        )
 
         class _Handle(object):
             def __init__(self, store):
@@ -215,14 +162,16 @@ class ManagePyCheckLifecycleTest(SimpleTestCase):
     def test_manage_py_check_passes_for_valid_library_suite(self):
         output = self._output()
         self.assertNotIn(CHECK_ID_INVALID_EXPR, output)
-        self.assertNotIn(CHECK_ID_LEGACY_CALLBACK, output)
+        self.assertNotIn(CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING, output)
 
     def test_manage_py_check_reports_invalid_registration_via_handle(self):
         from tests.myapp.models import Document
 
         u, _p, o = condition_refs()
         registry = TrustsRegistry()
-        registry.register_permission_condition(Document, 'typo-29', u == o.nope)
+        registry.conditions._records[(Document._meta.label, 'typo-29')] = (
+            ConditionRecord(expr=u == o.nope, model=Document)
+        )
 
         class _Handle(object):
             def __init__(self, store):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,10 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import Group, User
 
-from trusts.conditions import condition_refs
-
-_u, _p, _o = condition_refs()
-
 from django.conf import settings
 
 _ZERO_LISTED = any(
@@ -105,7 +101,7 @@ if Content is not None:
         class Meta:
             default_permissions = ('add', 'read', 'change', 'delete')
             permission_conditions = (
-                ('meta_own', _u == _o.owner),
+                ('meta_own', lambda u, p, o: u == o.owner),
             )
 
         def __str__(self):

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -10,9 +10,7 @@ from django.db.models import Model, QuerySet, Subquery
 
 from trusts.conditions import (
     PermissionConditionError,
-    PermissionConditionNotQueryable,
     evaluate_registered_expression,
-    legacy_permission_callbacks_allowed,
     permission_has_condition,
 )
 from trusts.query import (
@@ -135,14 +133,10 @@ class TrustModelBackendMixin(object):
         return self._instance_permissions(user_obj, obj, kind='complete')
 
     def permission_condition_met(self, record, user_obj, perm, obj):
-        if isinstance(obj, QuerySet) and record.expr is None:
-            raise PermissionConditionNotQueryable(
-                'ContentQuerySet.permitted does not support permission '
-                'condition on %s. Register an Expr from condition_refs() '
-                'to compile a V1 declarative expression. Callables remain '
-                'object-only via has_perm; this queryset API refuses them so '
-                'the underlying grant cannot be returned without the '
-                'condition.' % obj.model._meta.label
+        if record.expr is None:
+            raise PermissionConditionError(
+                'Permission condition on %s is unbound.'
+                % getattr(getattr(obj, 'model', None), '_meta', getattr(obj, '_meta', None))
             )
         if isinstance(obj, QuerySet):
             objs = obj.all()
@@ -154,22 +148,12 @@ class TrustModelBackendMixin(object):
             objs = [obj]
             model = obj.__class__
 
-        if record.expr is not None:
-            return all([
-                evaluate_registered_expression(
-                    record.expr, user_obj, perm, o, model=model or o.__class__
-                )
-                for o in objs
-            ])
-        if not legacy_permission_callbacks_allowed():
-            raise PermissionConditionError(
-                'Callable permission conditions are disabled. Set '
-                'TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS = True to use '
-                'the object-only has_perm path, or register an Expr from '
-                'condition_refs(). Silencing trusts.E002 does not enable '
-                'the callback.'
+        return all([
+            evaluate_registered_expression(
+                record.expr, user_obj, perm, o, model=model or o.__class__
             )
-        return all([record.func(user_obj, perm, o) for o in objs])
+            for o in objs
+        ])
 
     def _bound_condition_lookup(self, obj):
         """Bound ``ConditionLookup`` on the coordinating / own registry.

--- a/trusts/checks.py
+++ b/trusts/checks.py
@@ -17,18 +17,17 @@ from django.core import checks as django_checks
 
 from trusts.conditions import (
     PermissionConditionError,
-    legacy_permission_callbacks_allowed,
+    leftover_legacy_callback_setting_enabled,
     validate_expression,
 )
 
 
 CHECK_ID_INVALID_EXPR = 'trusts.E001'
-CHECK_ID_LEGACY_CALLBACK = 'trusts.E002'
 CHECK_ID_MISSING_DECLARATION = 'trusts.E003'
 CHECK_ID_MISSING_COMPILER = 'trusts.E004'
 CHECK_ID_ALONG_RENDERER = 'trusts.E005'
 CHECK_ID_ORDERED_FOLD_RENDERER = 'trusts.E006'
-CHECK_ID_LEGACY_CALLBACK_WARNING = 'trusts.W001'
+CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING = 'trusts.E007'
 
 _SILENCE_DOES_NOT_ENABLE_HINT = (
     'Silencing this check ID suppresses only the early diagnostic. '
@@ -80,33 +79,15 @@ def _messages_for_expr(model, cond_code, expr):
     return []
 
 
-def _messages_for_callable(model, cond_code):
-    label = _model_label(model)
-    if legacy_permission_callbacks_allowed():
-        return [django_checks.Warning(
-            'Callable permission condition %r on %s is a deprecated '
-            'object-only escape hatch. Rewrite it as an Expr from '
-            'condition_refs() for queryable policy. ContentQuerySet.permitted() '
-            'still refuses callables.' % (cond_code, label),
-            hint=(
-                'TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS is True, so '
-                'has_perm() may invoke this callback with real values. '
-                'Rewrite the condition as an Expr to drop this warning.'
-            ),
-            obj=model,
-            id=CHECK_ID_LEGACY_CALLBACK_WARNING,
-        )]
+def leftover_legacy_callback_setting_messages():
+    if not leftover_legacy_callback_setting_enabled():
+        return []
     return [django_checks.Error(
-        'Callable permission condition %r on %s is disabled. Set '
-        'TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS = True to keep the '
-        'object-only has_perm path, or rewrite it as an Expr from '
-        'condition_refs().' % (cond_code, label),
-        hint=(
-            'Enabling TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS is the only '
-            'way to run the callback. ' + _SILENCE_DOES_NOT_ENABLE_HINT
-        ),
-        obj=model,
-        id=CHECK_ID_LEGACY_CALLBACK,
+        'TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS is set. Callable '
+        'permission conditions are registration-time builders only; '
+        'this setting does not enable runtime callbacks. Remove it.',
+        hint=_SILENCE_DOES_NOT_ENABLE_HINT,
+        id=CHECK_ID_REMOVED_LEGACY_CALLBACK_SETTING,
     )]
 
 
@@ -365,8 +346,6 @@ def permission_condition_check_messages(entries):
     for model, cond_code, record in entries:
         if getattr(record, 'expr', None) is not None:
             messages.extend(_messages_for_expr(model, cond_code, record.expr))
-        elif getattr(record, 'func', None) is not None:
-            messages.extend(_messages_for_callable(model, cond_code))
     return messages
 
 
@@ -379,8 +358,10 @@ def check_permission_conditions(app_configs, **kwargs):
     ``manage.py check trusts`` still reports project-model conditions.
     Callables are never inspected or invoked. No database queries.
     """
-    return permission_condition_check_messages(
-        iter_live_permission_conditions()
+    return leftover_legacy_callback_setting_messages() + (
+        permission_condition_check_messages(
+            iter_live_permission_conditions()
+        )
     )
 
 

--- a/trusts/conditions.py
+++ b/trusts/conditions.py
@@ -1,12 +1,15 @@
-"""Restricted declarative permission conditions (issue #4 V1).
+"""Restricted declarative permission conditions (issue #4 V1 / #142 A).
 
-Register an ``Expr`` tree built from ``condition_refs()`` (``u``, ``p``,
-``o``). That tree is policy data: ``has_perm`` evaluates it and
-``.permitted()`` compiles it to SQL. Django ``Q`` is one compiler
-target, not the canonical representation.
+Register a named condition as a **trusted startup builder** (lambda or
+``def``). Core invokes it once with symbolic ``(u, p, o)``, validates
+and normalizes the returned predicate, and stores only IR. The callable
+is not the policy record and is never invoked during ``has_perm``,
+enumeration, or queryset filtering. A transitional prebuilt ``Expr`` is
+still accepted in Stage A so unconverted Zero Meta trees keep loading.
 
-A callable argument is the legacy object-only predicate. Registration
-dispatches by type and never invokes a callable with symbolic refs.
+Builders are trusted configuration, not a sandbox: Core does not parse
+AST/bytecode and cannot stop a named function from querying or doing
+I/O. Core-owned registration itself adds zero SQL.
 
 Permission-condition records live on an instantiable
 ``ConditionRegistry`` (also exposed on each ``TrustsRegistry``). There
@@ -15,12 +18,10 @@ records so owners cannot share or overwrite each other.
 
 V1 grammar: principal/object field refs and relationship traversal
 (``_meta`` fields on the content model and the entity/user model; not
-Python properties); literal constants; ``==`` / ``!=``; nested ``&`` /
-``|``. Operand types must match without Django field coercion:
-``CharField`` compares to ``str``, relations compare to model instances
-(not raw primary keys). Missing attribute names fail closed; they are
-not treated as ``NULL``. Python ``and`` / ``or`` / ``not`` and chained
-comparisons cannot be overloaded and raise
+Python properties); normalized constants; ``==`` / ``!=``; nested ``&``
+/ ``|``. Operand types must match without Django field coercion.
+Missing attribute names fail closed at registration. Python ``and`` /
+``or`` / ``not`` and chained comparisons raise
 ``PermissionConditionBooleanError``.
 """
 
@@ -104,12 +105,11 @@ def permission_condition_code(perm):
     return perm.split(':', 1)[1]
 
 
-def legacy_permission_callbacks_allowed():
-    """True only when ``TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS`` is set.
+def leftover_legacy_callback_setting_enabled():
+    """True when the removed callback setting is still set.
 
-    Read at call time so ``override_settings`` works. Missing or False
-    means registered callables are a system-check error and runtime
-    fail-closed (the callback is never invoked).
+    The setting never enables runtime callbacks. System checks report it
+    as ``trusts.E007``. Read at call time so ``override_settings`` works.
     """
     from django.conf import settings as django_settings
 
@@ -266,11 +266,56 @@ class Ref(Expr):
         return '%s.%s' % (name, '.'.join(self.path))
 
 
+class ModelIdentity(object):
+    """Durable saved-model constant: concrete model identity plus PK.
+
+    Not a live instance. Equality compares ``(app_label, model_name, pk)``
+    so later mutation of a captured Python object cannot change policy.
+    """
+
+    __slots__ = ('app_label', 'model_name', 'pk')
+
+    def __init__(self, app_label, model_name, pk):
+        self.app_label = app_label
+        self.model_name = model_name
+        self.pk = pk
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        if isinstance(other, ModelIdentity):
+            return (
+                self.app_label, self.model_name, self.pk
+            ) == (other.app_label, other.model_name, other.pk)
+        if isinstance(other, Model):
+            meta = other._meta.concrete_model._meta
+            return (
+                self.app_label, self.model_name, self.pk
+            ) == (meta.app_label, meta.model_name, other.pk)
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.app_label, self.model_name, self.pk))
+
+    def __repr__(self):
+        return 'ModelIdentity(%s.%s, pk=%r)' % (
+            self.app_label, self.model_name, self.pk,
+        )
+
+
 class Const(Expr):
     def __init__(self, value):
         self.value = value
 
     def to_tuple(self):
+        if isinstance(self.value, ModelIdentity):
+            return (
+                'const',
+                ('model', self.value.app_label, self.value.model_name, self.value.pk),
+            )
         return ('const', self.value)
 
     def __repr__(self):
@@ -348,13 +393,103 @@ def is_predicate(node):
     return isinstance(node, (Eq, Ne, And, Or))
 
 
+_IMMUTABLE_EXTRA = None
+
+
+def _immutable_extra_types():
+    global _IMMUTABLE_EXTRA
+    if _IMMUTABLE_EXTRA is None:
+        from datetime import date, datetime, time, timedelta
+        from decimal import Decimal
+        from uuid import UUID
+
+        _IMMUTABLE_EXTRA = (Decimal, UUID, datetime, date, time, timedelta)
+    return _IMMUTABLE_EXTRA
+
+
+def _normalize_const_value(value):
+    """Copy an allowed constant into durable IR, or raise.
+
+    Scalars are stored by value. A saved model instance becomes
+    ``ModelIdentity``. Mutable, lazy, request, queryset, and unsaved
+    captures are rejected so later Python mutation cannot change policy.
+    """
+    if isinstance(value, ModelIdentity):
+        return value
+    if isinstance(value, _LITERAL_TYPES):
+        return value
+    if isinstance(value, _immutable_extra_types()):
+        return value
+    if isinstance(value, Model):
+        adding = getattr(getattr(value, '_state', None), 'adding', True)
+        if adding or value.pk is None:
+            raise PermissionConditionError(
+                'Unsaved model instance cannot be a permission-condition '
+                'constant; save it and register the identity (model + pk).'
+            )
+        meta = value._meta.concrete_model._meta
+        return ModelIdentity(meta.app_label, meta.model_name, value.pk)
+
+    from django.db.models.manager import BaseManager
+    from django.db.models.query import QuerySet
+    from django.http import HttpRequest
+    from django.utils.functional import LazyObject, Promise
+
+    if isinstance(value, (list, dict, set, bytearray)):
+        raise PermissionConditionError(
+            'Mutable container %s cannot be a permission-condition '
+            'constant; snapshot an immutable scalar or saved model.'
+            % type(value).__name__
+        )
+    if isinstance(value, (QuerySet, BaseManager)):
+        raise PermissionConditionError(
+            'QuerySet/Manager captures cannot be permission-condition '
+            'constants.'
+        )
+    if isinstance(value, (HttpRequest, LazyObject, Promise)):
+        raise PermissionConditionError(
+            'Lazy or request objects cannot be permission-condition '
+            'constants.'
+        )
+    if callable(value) and not isinstance(value, type):
+        raise PermissionConditionError(
+            'Callables cannot be permission-condition constants.'
+        )
+    raise PermissionConditionError(
+        'Constant of type %s is not a durable permission-condition value.'
+        % type(value).__name__
+    )
+
+
+def normalize_expression(node):
+    """Rewrite ``Const`` values to durable IR; keep identical nodes when possible."""
+    if isinstance(node, Const):
+        normalized = _normalize_const_value(node.value)
+        if normalized is node.value:
+            return node
+        return Const(normalized)
+    if isinstance(node, (Eq, Ne, And, Or)):
+        left = normalize_expression(node.left)
+        right = normalize_expression(node.right)
+        if left is node.left and right is node.right:
+            return node
+        return type(node)(left, right)
+    if isinstance(node, Ref):
+        return node
+    return node
+
+
 def as_node(value):
     if isinstance(value, Expr):
         return value
+    if isinstance(value, ModelIdentity):
+        return Const(value)
     if isinstance(value, _LITERAL_TYPES):
+        return Const(_normalize_const_value(value))
+    if isinstance(value, _immutable_extra_types()):
         return Const(value)
     if isinstance(value, Model):
-        return Const(value)
+        return Const(_normalize_const_value(value))
     _unsupported('Constant of type %s' % type(value).__name__)
 
 
@@ -552,6 +687,11 @@ def _spec_from_field(field):
 def _spec_from_const(value):
     if value is None:
         return ('null', None, 'None')
+    if isinstance(value, ModelIdentity):
+        from django.apps import apps as django_apps
+
+        model = django_apps.get_model(value.app_label, value.model_name)
+        return ('instance', model, '%s.%s' % (value.app_label, value.model_name))
     if isinstance(value, Model):
         return ('instance', value.__class__, value._meta.label)
     if isinstance(value, bool):
@@ -731,6 +871,15 @@ def _resolve_runtime(node, user, perm, obj, model):
     )
 
 
+def _values_equal(left, right):
+    """Equality that honors ``ModelIdentity`` from either side."""
+    if isinstance(left, ModelIdentity):
+        return left == right
+    if isinstance(right, ModelIdentity):
+        return right == left
+    return left == right
+
+
 def evaluate_expression(node, user, perm, obj, model=None):
     """Evaluate a captured expression against a real principal/permission/object."""
     if model is None:
@@ -744,12 +893,14 @@ def evaluate_expression(node, user, perm, obj, model=None):
             evaluate_expression(node.right, user, perm, obj, model)
         )
     if isinstance(node, Eq):
-        return _resolve_runtime(node.left, user, perm, obj, model) == (
-            _resolve_runtime(node.right, user, perm, obj, model)
+        return _values_equal(
+            _resolve_runtime(node.left, user, perm, obj, model),
+            _resolve_runtime(node.right, user, perm, obj, model),
         )
     if isinstance(node, Ne):
-        return _resolve_runtime(node.left, user, perm, obj, model) != (
-            _resolve_runtime(node.right, user, perm, obj, model)
+        return not _values_equal(
+            _resolve_runtime(node.left, user, perm, obj, model),
+            _resolve_runtime(node.right, user, perm, obj, model),
         )
     raise PermissionConditionError(
         'Permission condition did not produce a comparison expression.'
@@ -795,7 +946,14 @@ def _always_false():
     return Q(pk__in=())
 
 
+def _sql_const(value):
+    if isinstance(value, ModelIdentity):
+        return value.pk
+    return value
+
+
 def _q_eq_lookup(lookup, value):
+    value = _sql_const(value)
     if value is None:
         return Q(**{'%s__isnull' % lookup: True})
     return Q(**{lookup: value})
@@ -803,6 +961,7 @@ def _q_eq_lookup(lookup, value):
 
 def _q_ne_lookup(lookup, value):
     # Match Python: ``None != x`` is True when ``x is not None``.
+    value = _sql_const(value)
     if value is None:
         return Q(**{'%s__isnull' % lookup: False})
     return Q(**{'%s__isnull' % lookup: True}) | ~Q(**{lookup: value})
@@ -837,7 +996,9 @@ def _compile_comparison(node, model, user, perm):
     right = _classify(node.right, model, user, perm)
     equal = isinstance(node, Eq)
     if isinstance(left, _Bound) and isinstance(right, _Bound):
-        matches = (left.value == right.value) if equal else (left.value != right.value)
+        matches = _values_equal(left.value, right.value)
+        if not equal:
+            matches = not matches
         return _always_true() if matches else _always_false()
     if isinstance(left, _Unbound) and isinstance(right, _Bound):
         lookup, value = left.lookup, right.value
@@ -912,19 +1073,44 @@ def _unknown_condition_error(model, cond_code):
 
 
 class ConditionRecord(object):
-    """Registered condition: an ``Expr`` tree or a legacy callable.
+    """Registered condition: normalized ``Expr`` IR only.
 
     ``model`` is retained so a registration can be validated by the
     system check after all apps have loaded. This record is
-    implementation-neutral: it does not name Zero nouns.
+    implementation-neutral: it does not name Zero nouns. The builder
+    callable is never stored.
     """
 
-    __slots__ = ('expr', 'func', 'model')
+    __slots__ = ('expr', 'model')
 
-    def __init__(self, expr=None, func=None, model=None):
+    def __init__(self, expr=None, model=None):
         self.expr = expr
-        self.func = func
         self.model = model
+
+
+def _invoke_condition_builder(builder):
+    """Invoke a trusted registration-time builder exactly once."""
+    u, p, o = condition_refs()
+    try:
+        expr = builder(u, p, o)
+    except PermissionConditionError:
+        raise
+    except TypeError as exc:
+        raise PermissionConditionError(
+            'Permission condition builder must accept symbolic (u, p, o): %s'
+            % exc
+        ) from exc
+    except Exception as exc:
+        raise PermissionConditionError(
+            'Permission condition builder failed: %s' % exc
+        ) from exc
+    if isinstance(expr, bool) or not isinstance(expr, Expr):
+        raise PermissionConditionError(
+            'Permission condition builder must return a V1 comparison '
+            '(==, != combined with & / |), not %r.'
+            % (type(expr).__name__,)
+        )
+    return expr
 
 
 class ConditionRegistry(object):
@@ -935,9 +1121,9 @@ class ConditionRegistry(object):
     condition code on *this* instance, so two registries never share or
     overwrite each other.
 
-    Registration dispatches by type and never invokes a callable.
-    Model-aware semantic validation is a system check, not an exception
-    from ``register_permission_condition``.
+    A callable is a registration-time builder: invoked once with
+    symbolic refs, then discarded. A transitional prebuilt ``Expr`` is
+    still accepted. Field/type validation runs here (zero SQL).
     """
 
     def __init__(self):
@@ -946,31 +1132,31 @@ class ConditionRegistry(object):
     def register_permission_condition(self, model, cond_code, condition):
         """Register a ``:cond_code`` condition on ``model``.
 
-        Pass an ``Expr`` built from ``condition_refs()`` to opt into V1
-        compile/evaluate. Pass a callable to keep the historical
-        object-only ``has_perm`` path. Dispatch is by type: callables
-        are never invoked with symbolic ``Ref`` arguments.
-
-        Construction-time shape errors (bare non-predicate ``Expr``, a
-        value that is neither ``Expr`` nor callable) still raise here.
-        Model-aware semantic validation is reported by the registered
-        Django system check as ``CheckMessage``s, not raised from this
-        method, so ``SILENCED_SYSTEM_CHECKS`` can filter the diagnostic.
+        Pass a builder ``callable(u, p, o)`` or, in Stage A, a prebuilt
+        ``Expr``. The builder is invoked exactly once. The stored record
+        is normalized IR only.
         """
         if isinstance(condition, Expr):
-            if not is_predicate(condition):
-                raise PermissionConditionError(
-                    'Registered expression must be a V1 comparison '
-                    '(==, != combined with & / |), not %r.' % (condition,)
-                )
-            record = ConditionRecord(expr=condition, model=model)
+            expr = condition
         elif callable(condition):
-            record = ConditionRecord(func=condition, model=model)
+            expr = _invoke_condition_builder(condition)
         else:
             raise TypeError(
-                'register_permission_condition expected an Expr or a '
-                'callable, got %r.' % (type(condition).__name__,)
+                'register_permission_condition expected a builder callable '
+                'or a transitional Expr, got %r.'
+                % (type(condition).__name__,)
             )
+        if not is_predicate(expr):
+            raise PermissionConditionError(
+                'Registered expression must be a V1 comparison '
+                '(==, != combined with & / |), not %r.' % (expr,)
+            )
+        expr = normalize_expression(expr)
+        from django.apps import apps as django_apps
+
+        if getattr(model, '_meta', None) is not None and django_apps.models_ready:
+            validate_expression(expr, model)
+        record = ConditionRecord(expr=expr, model=model)
         self._records[(_condition_model_key(model), cond_code)] = record
         return record
 
@@ -990,9 +1176,8 @@ class ConditionRegistry(object):
     def compile_registered_condition_q(self, model, perm, user):
         """Compile a ``:condition`` suffix to ``Q``, or raise fail-closed.
 
-        Unregistered codes raise ``AttributeError``. Callables raise
-        ``PermissionConditionNotQueryable`` without being invoked.
-        Registered ``Expr`` trees that are not valid V1 fail closed.
+        Unregistered codes raise ``AttributeError``. Unbound records
+        raise ``PermissionConditionError``. Invalid stored IR fails closed.
         """
         cond = permission_condition_code(perm)
         record = self.get_permission_condition_record(model, cond)
@@ -1000,13 +1185,8 @@ class ConditionRegistry(object):
             raise _unknown_condition_error(model, cond)
         if record.expr is None:
             label = getattr(getattr(model, '_meta', None), 'label', model)
-            raise PermissionConditionNotQueryable(
-                'Queryable permission conditions do not support '
-                'condition %r on %s. Register an Expr from condition_refs() '
-                'to compile a V1 declarative expression. Callables remain '
-                'object-only via has_perm; queryset compilation refuses them '
-                'so the underlying grant cannot be returned without the '
-                'condition.' % (perm, label)
+            raise PermissionConditionError(
+                'Permission condition %r on %s is unbound.' % (perm, label)
             )
         grant = perm.split(':', 1)[0] if isinstance(perm, str) else perm
         return compile_expression_q(record.expr, model, user, grant)
@@ -1014,31 +1194,20 @@ class ConditionRegistry(object):
     def evaluate_permission_condition(self, model, cond_code, user, perm, obj):
         """Evaluate one registered condition against a real object.
 
-        Unregistered codes raise ``AttributeError``. Callables are
-        invoked only when ``TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS``
-        is True; otherwise they fail closed without being called.
+        Unregistered codes raise ``AttributeError``. The stored IR is
+        evaluated; builders are never invoked here.
         """
         record = self.get_permission_condition_record(model, cond_code)
         if record is None:
             raise _unknown_condition_error(model, cond_code)
-        if record.expr is not None:
-            return evaluate_registered_expression(
-                record.expr, user, perm, obj, model=model,
-            )
-        if record.func is None:
+        if record.expr is None:
             raise PermissionConditionError(
                 'Permission condition %r on %s is unbound.'
                 % (cond_code, getattr(getattr(model, '_meta', None), 'label', model))
             )
-        if not legacy_permission_callbacks_allowed():
-            raise PermissionConditionError(
-                'Callable permission conditions are disabled. Set '
-                'TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS = True to use '
-                'the object-only has_perm path, or register an Expr from '
-                'condition_refs(). Silencing trusts.E002 does not enable '
-                'the callback.'
-            )
-        return record.func(user, perm, obj)
+        return evaluate_registered_expression(
+            record.expr, user, perm, obj, model=model,
+        )
 
 
 from trusts.core import ConditionLookup  # noqa: E402

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -2224,11 +2224,15 @@ class TrustsRegistry(object):
     def register_permission_condition(self, model, cond_code, condition):
         """Register a ``:cond_code`` condition on ``model`` for this instance.
 
-        Ordinary registry method for AppConfig / module contribution.
-        Dispatch is by type: an ``Expr`` is queryable policy data; a
-        callable is the object-only escape hatch. Callables are never
-        invoked at registration. ``freeze()`` does not seal this method.
+        A callable is a registration-time builder. A transitional
+        prebuilt ``Expr`` is still accepted. ``freeze()`` seals this
+        method and raises before the builder is invoked.
         """
+        if self._frozen:
+            raise TrustsConfigurationError(
+                'Cannot register a permission condition on a frozen '
+                'TrustsRegistry.'
+            )
         return self.conditions.register_permission_condition(
             model, cond_code, condition,
         )
@@ -2256,7 +2260,11 @@ class TrustsRegistry(object):
         )
 
     def freeze(self):
-        """Seal this instance against further ``register`` / ``register_strategy`` writes."""
+        """Seal this instance against further writes.
+
+        Seals ``register``, ``register_strategy``, and
+        ``register_permission_condition``.
+        """
         self._frozen = True
 
     @property
@@ -2526,6 +2534,12 @@ class BackendHandle:
     path: str
     registry: object
     compiler: object
+
+    def register_permission_condition(self, model, cond_code, condition):
+        """Register a named queryable condition without using ``.registry``."""
+        return self.registry.register_permission_condition(
+            model, cond_code, condition,
+        )
 
     @property
     def historical_fallback(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements bounded **Core Stage A** of #142 from exact `dev` baseline `b93dfbe845592f78373534186f09a513d81d39c4`.

## What landed

- `register_permission_condition(..., callable)` is a trusted startup builder: invoked once with symbolic `(u, p, o)`, constants normalized to durable IR (scalars copied; saved models become `(app_label, model_name, pk)`), callable discarded from the record.
- Transitional prebuilt `Expr` still accepted so current Zero `Trust:own` Meta trees keep loading.
- `BackendHandle.register_permission_condition` is the application API (no `.registry` required).
- `freeze()` seals condition registration and raises **before** the builder runs.
- Field/type validation runs at register when `apps.models_ready` (zero SQL). Invalid builders fail closed.
- Runtime callback path, `ConditionRecord.func`, `trusts.E002` / `W001` removed. Leftover `TRUSTS_ALLOW_LEGACY_PERMISSION_CALLBACKS=True` is `trusts.E007` and enables nothing.
- Core `Ticket.meta_own` is a builder. New `tests/core/test_issue142.py` plus updated #16/#29.
- README / RST teach the builder spelling. Same-PR `migrates.md`.

## Explicitly not in this PR

- Stage B public-import removal (`condition_refs` / `Expr` still importable)
- Zero / example conversion
- `TQ.contains`
- #138 / #137 / #131 relation `handle.register(...)`

## Verification

Kernel condition tests (`test_issue142`, `test_issue16`, `test_issue29`, `test_issue4`) pass locally. Full kernel suite: 341 pass / 13 skip; 3 failures are the known `/workspace` editable `trusts.management` leak, not this change.

Pair CI keeps the current Zero pin. Zero spy/legacy-callback tests are expected to need Z-convert; production `Trust:own` remains a prebuilt `Expr`.

r? @chatforthomas

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

