### PR TITLE
#131 C1-fold: BackendHandle.register_strategy public OrderedFold API

### DIFF
--- a/migrates.md
+++ b/migrates.md
@@ -63,7 +63,11 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
 `handle.registry` remains temporarily so unconverted consumers still
 compile. `handle.register_strategy` is the public OrderedFold entry.
 The positional source model is required; do not call
-`register_strategy(OrderedFold(...))` without that root.
+`register_strategy(OrderedFold(...))` without that root. A non-empty
+`descriptor` is content-relative; the derived source descriptor is the
+content path plus those segments (`content="node"`,
+`descriptor="security_descriptor"` → internal
+`Ace.node.security_descriptor`).
 
 Migration-bot search list:
 

--- a/migrates.md
+++ b/migrates.md
@@ -34,7 +34,9 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
 2. Provide `TrustsImplementationConfig` and a backend that subclasses
    `TrustModelBackendMixin`. Call `super().ready()`.
 3. Register protected models through `handle.register(root, user=...,
-   permission=..., content=...)` and named-condition **builders** through
+   permission=..., content=...)`, ordered strategies through
+   `handle.register_strategy(source_model, OrderedFold(...))`, and
+   named-condition **builders** through
    `handle.register_permission_condition` in `AppConfig.ready()` before
    finalization.
 4. Import only the six public `trusts.conditions` names:
@@ -56,9 +58,12 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
 | Relation register | `from trusts.core import Ref` + `handle.registry.register(content=j.document, ...)` | `handle.register(DocumentGrant, user="user", permission="permission", content="document")` |
 | Along | `along=Along(j.parent, 8)` | `along=("parent", 8)` |
 | Closed condition | `Equal(t.team.organization, t.repository.organization)` | `Equal("team__organization", "repository__organization")` |
+| OrderedFold | `.registry.register_strategy(OrderedFold(...Ref...))` | `handle.register_strategy(Ace, OrderedFold(content="document", descriptor="", order="ace_order", polarity=PolarityMap("ace_type", allow_value=ALLOW, deny_value=DENY), mask="access_mask", trustee="user", token=FlatToken(principal=User, principal_user="", principal_identity=""), domain=PermissionMaskDomain(Permission, masks)))` |
 
 `handle.registry` remains temporarily so unconverted consumers still
-compile. `handle.register_strategy` is not a public method yet.
+compile. `handle.register_strategy` is the public OrderedFold entry.
+The positional source model is required; do not call
+`register_strategy(OrderedFold(...))` without that root.
 
 Migration-bot search list:
 
@@ -67,6 +72,8 @@ Migration-bot search list:
 - `.registry.register(`
 - `.registry.register_strategy(`
 - `Along(`
+- `OrderedFold(`
+- `register_strategy(OrderedFold`
 
 This file is the Core 1.x router only. It does not document concrete
 Zero schema, UI, admin, or management-command steps.

--- a/tests/core/test_issue122.py
+++ b/tests/core/test_issue122.py
@@ -84,7 +84,10 @@ class FinalDocumentationSurfaceTest(SimpleTestCase):
         self.assertIn('.registry.register(', text)
         self.assertIn('.registry.register_strategy(', text)
         self.assertIn('Along(', text)
+        self.assertIn('OrderedFold(', text)
+        self.assertIn('register_strategy(OrderedFold', text)
         self.assertIn('handle.register(DocumentGrant', text)
+        self.assertIn('handle.register_strategy(Ace, OrderedFold(', text)
         self.assertIn('## Archaeology', text)
         self.assertIn(
             'https://github.com/django-trusts/django-trusts-zero/blob/dev/migrates.md',

--- a/tests/core/test_issue131.py
+++ b/tests/core/test_issue131.py
@@ -1,32 +1,43 @@
-"""#131 C1: BackendHandle.register public AnyPath string API.
+"""#131 C1 / C1-fold: BackendHandle public AnyPath and OrderedFold APIs.
 
-Handle-bound Django ``__`` paths, string condition leaves, and
-``along=(path, bound)``. ``Ref`` input is TypeError. Freeze raises
-before path resolution. Dual handles stay isolated. Internal
-``TrustsRegistry.register(Ref)`` remains. ``register_strategy`` is
-not public on the handle.
+Handle-bound Django ``__`` paths, string condition leaves,
+``along=(path, bound)``, and ``register_strategy(source_model,
+OrderedFold(...))``. ``Ref`` input is TypeError. Freeze raises before
+path resolution. Dual handles stay isolated. Internal
+``TrustsRegistry.register(Ref)`` and ``register_strategy(OrderedFold)``
+remain for compiler tests.
 """
 
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
+from django.db import models
 from django.test import SimpleTestCase
 from django.test.utils import isolate_apps
 
+from tests.core.test_issue100 import ALLOW, DENY, _direct_models, _register_direct
 from tests.myapp.models import Document, DocumentGrant
 from trusts.core import (
     All,
     Along,
     BackendHandle,
     Equal,
+    FlatToken,
+    MaskEntry,
+    OrderedFold,
+    PermissionMaskDomain,
     PlanQueryCompiler,
+    PolarityMap,
     Ref,
     TrustsConfigurationError,
     TrustsRegistry,
     _public_path_segments,
+    _resolve_forward_singles,
     _resolve_path,
     _validate_condition,
     permission_in,
 )
+from trusts.ordered_fold import validate_ordered_fold
 
 
 def _handle(registry=None, path='tests.core.handle-a'):
@@ -40,10 +51,12 @@ def _handle(registry=None, path='tests.core.handle-a'):
 
 
 class HandleRegisterSurfaceTest(SimpleTestCase):
-    def test_register_strategy_is_not_a_handle_method(self):
-        self.assertFalse(hasattr(BackendHandle, 'register_strategy'))
+    def test_register_and_register_strategy_are_handle_methods(self):
         handle = _handle()
-        self.assertFalse(hasattr(handle, 'register_strategy'))
+        self.assertTrue(hasattr(BackendHandle, 'register'))
+        self.assertTrue(hasattr(BackendHandle, 'register_strategy'))
+        self.assertTrue(hasattr(handle, 'register'))
+        self.assertTrue(hasattr(handle, 'register_strategy'))
         self.assertTrue(hasattr(handle.registry, 'register'))
         self.assertTrue(hasattr(handle.registry, 'register_strategy'))
 
@@ -294,3 +307,506 @@ class HandleConditionAndAlongTest(SimpleTestCase):
         self.assertEqual(record, expected)
         self.assertEqual(record.along.shape, 'S')
         self.assertEqual(record.along.bound, 8)
+
+
+def _public_direct_fold(Ace, Permission, Document, *, token=None):
+    User = get_user_model()
+    if token is None:
+        token = FlatToken(
+            principal=User,
+            principal_user='',
+            principal_identity='',
+        )
+    return OrderedFold(
+        content='document',
+        descriptor='',
+        order='ace_order',
+        polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+        mask='access_mask',
+        trustee='user',
+        token=token,
+        domain=PermissionMaskDomain(Permission, (
+            MaskEntry('read', 0x1),
+            MaskEntry('write', 0x2),
+            MaskEntry('readwrite', 0x3),
+        )),
+    )
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class HandleRegisterStrategySurfaceTest(SimpleTestCase):
+    def test_no_root_form_is_type_error(self):
+        Permission, Document, Ace = _direct_models()
+        handle = _handle()
+        strategy = _public_direct_fold(Ace, Permission, Document)
+        with self.assertRaises(TypeError):
+            handle.register_strategy(strategy)
+        self.assertEqual(handle.registry.strategies, ())
+
+    def test_string_strategy_matches_internal_ref_record(self):
+        Permission, Document, Ace = _direct_models()
+        via_ref = TrustsRegistry()
+        expected = _register_direct(via_ref, Ace, Permission, Document)
+        handle = _handle()
+        compiled = handle.register_strategy(
+            Ace, _public_direct_fold(Ace, Permission, Document),
+        )
+        self.assertEqual(compiled, expected)
+        self.assertIs(compiled.content_model, Document)
+        self.assertIs(compiled.source_model, Ace)
+        self.assertTrue(compiled.principal_is_user)
+        self.assertIsNone(compiled.member_model)
+
+    def test_public_ref_input_is_type_error(self):
+        Permission, Document, Ace = _direct_models()
+        handle = _handle()
+        ace = Ref(Ace)
+        doc = Ref(Document)
+        user = Ref(get_user_model())
+        with self.assertRaises(TypeError):
+            handle.register_strategy(
+                ace, _public_direct_fold(Ace, Permission, Document),
+            )
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content=doc,
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=get_user_model(),
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='document',
+                descriptor='',
+                source=ace,
+                source_descriptor=ace.document,
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=get_user_model(),
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap(ace.ace_type, allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=get_user_model(),
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=user,
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        self.assertEqual(handle.registry.strategies, ())
+
+    def test_invalid_public_path_grammar_is_rejected(self):
+        Permission, Document, Ace = _direct_models()
+        handle = _handle()
+        for path in (
+            '',
+            '__document',
+            'document__',
+            'wrapper.document',
+            'document____title',
+            1,
+            None,
+            ['document'],
+        ):
+            with self.subTest(path=path):
+                with self.assertRaises(TrustsConfigurationError):
+                    handle.register_strategy(Ace, OrderedFold(
+                        content=path,
+                        descriptor='',
+                        order='ace_order',
+                        polarity=PolarityMap(
+                            'ace_type', allow_value=ALLOW, deny_value=DENY,
+                        ),
+                        mask='access_mask',
+                        trustee='user',
+                        token=FlatToken(
+                            principal=get_user_model(),
+                            principal_user='',
+                            principal_identity='',
+                        ),
+                        domain=PermissionMaskDomain(
+                            Permission, (MaskEntry('read', 1),),
+                        ),
+                    ))
+        self.assertEqual(handle.registry.strategies, ())
+
+    def test_string_principal_or_member_is_type_error(self):
+        Permission, Document, Ace = _direct_models()
+        handle = _handle()
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal='auth.User',
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        User = get_user_model()
+
+        class Membership(models.Model):
+            member = models.ForeignKey(User, related_name='+', on_delete=models.CASCADE)
+            group = models.ForeignKey(User, related_name='+', on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        with self.assertRaises(TypeError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=User,
+                    principal_user='',
+                    principal_identity='',
+                    member='Membership',
+                    member_identity='member',
+                    member_group='group',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        self.assertEqual(handle.registry.strategies, ())
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class HandleRegisterStrategyTokenTest(SimpleTestCase):
+    def _principal_member_graph(self):
+        User = get_user_model()
+
+        class Identity(models.Model):
+            code = models.CharField(max_length=16, unique=True)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Permission(models.Model):
+            codename = models.CharField(max_length=64)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Document(models.Model):
+            title = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Wrapper(models.Model):
+            document = models.ForeignKey(Document, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Holder(models.Model):
+            identity = models.ForeignKey(
+                Identity, to_field='code', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Ace(models.Model):
+            wrapper = models.ForeignKey(Wrapper, on_delete=models.CASCADE)
+            holder = models.ForeignKey(Holder, on_delete=models.CASCADE)
+            ace_order = models.IntegerField()
+            ace_type = models.IntegerField()
+            access_mask = models.BigIntegerField()
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Profile(models.Model):
+            user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Card(models.Model):
+            identity = models.ForeignKey(
+                Identity, to_field='code', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Principal(models.Model):
+            profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+            card = models.ForeignKey(Card, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Person(models.Model):
+            identity = models.ForeignKey(
+                Identity, to_field='code', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Team(models.Model):
+            identity = models.ForeignKey(
+                Identity, to_field='code', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Membership(models.Model):
+            person = models.ForeignKey(Person, on_delete=models.CASCADE)
+            group = models.ForeignKey(Team, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        return (
+            Permission, Document, Ace, Principal, Membership, Identity,
+        )
+
+    def test_distinct_principal_member_roots_match_ref_form(self):
+        Permission, Document, Ace, Principal, Membership, Identity = (
+            self._principal_member_graph()
+        )
+        via_ref = TrustsRegistry()
+        ace = Ref(Ace)
+        document = Ref(Document)
+        principal = Ref(Principal)
+        member = Ref(Membership)
+        expected = via_ref.register_strategy(OrderedFold(
+            content=document,
+            descriptor=document,
+            source=ace,
+            source_descriptor=ace.wrapper.document,
+            order=ace.ace_order,
+            polarity=PolarityMap(ace.ace_type, allow_value=ALLOW, deny_value=DENY),
+            mask=ace.access_mask,
+            trustee=ace.holder.identity,
+            token=FlatToken(
+                principal=principal,
+                principal_user=principal.profile.user,
+                principal_identity=principal.card.identity,
+                member=member,
+                member_identity=member.person.identity,
+                member_group=member.group.identity,
+            ),
+            domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+        ))
+        handle = _handle()
+        compiled = handle.register_strategy(Ace, OrderedFold(
+            content='wrapper__document',
+            descriptor='',
+            order='ace_order',
+            polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+            mask='access_mask',
+            trustee='holder__identity',
+            token=FlatToken(
+                principal=Principal,
+                principal_user='profile__user',
+                principal_identity='card__identity',
+                member=Membership,
+                member_identity='person__identity',
+                member_group='group__identity',
+            ),
+            domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+        ))
+        self.assertEqual(compiled, expected)
+        self.assertIs(compiled.principal_model, Principal)
+        self.assertIs(compiled.member_model, Membership)
+        self.assertGreater(len(compiled.principal_user_hops), 1)
+        self.assertGreater(len(compiled.member_identity_hops), 1)
+        self.assertGreater(len(compiled.member_group_hops), 1)
+        self.assertEqual(compiled.identity_attname, 'code')
+
+    def test_misbound_member_paths_are_rejected(self):
+        Permission, Document, Ace, Principal, Membership, Identity = (
+            self._principal_member_graph()
+        )
+        handle = _handle()
+        with self.assertRaises(TrustsConfigurationError):
+            handle.register_strategy(Ace, OrderedFold(
+                content='wrapper__document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='holder__identity',
+                token=FlatToken(
+                    principal=Principal,
+                    principal_user='profile__user',
+                    principal_identity='card__identity',
+                    member=Membership,
+                    member_identity='profile__user',
+                    member_group='card__identity',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        self.assertEqual(handle.registry.strategies, ())
+
+    def test_member_triad_is_all_or_none(self):
+        Permission, Document, Ace, Principal, Membership, Identity = (
+            self._principal_member_graph()
+        )
+        handle = _handle()
+        with self.assertRaisesRegex(TrustsConfigurationError, r'member triad'):
+            handle.register_strategy(Ace, OrderedFold(
+                content='wrapper__document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='holder__identity',
+                token=FlatToken(
+                    principal=Principal,
+                    principal_user='profile__user',
+                    principal_identity='card__identity',
+                    member=Membership,
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        with self.assertRaisesRegex(TrustsConfigurationError, r'member triad'):
+            handle.register_strategy(Ace, OrderedFold(
+                content='wrapper__document',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='holder__identity',
+                token=FlatToken(
+                    principal=Principal,
+                    principal_user='profile__user',
+                    principal_identity='card__identity',
+                    member_identity='person__identity',
+                    member_group='group__identity',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        self.assertEqual(handle.registry.strategies, ())
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class HandleRegisterStrategyFreezeTest(SimpleTestCase):
+    def test_freeze_raises_before_path_resolution(self):
+        Permission, Document, Ace = _direct_models()
+        registry = TrustsRegistry()
+        handle = _handle(registry)
+        registry.freeze()
+        with patch(
+            'trusts.core._public_path_segments',
+            wraps=_public_path_segments,
+        ) as segments:
+            with patch(
+                'trusts.core._resolve_forward_singles',
+                wraps=_resolve_forward_singles,
+            ) as resolve:
+                with patch(
+                    'trusts.core._resolve_path',
+                    wraps=_resolve_path,
+                ) as anypath:
+                    with patch(
+                        'trusts.ordered_fold.validate_ordered_fold',
+                        wraps=validate_ordered_fold,
+                    ) as validate:
+                        with self.assertRaises(TrustsConfigurationError) as ctx:
+                            handle.register_strategy(
+                                Ace,
+                                _public_direct_fold(Ace, Permission, Document),
+                            )
+        self.assertIn('frozen', str(ctx.exception).lower())
+        segments.assert_not_called()
+        resolve.assert_not_called()
+        anypath.assert_not_called()
+        validate.assert_not_called()
+        self.assertEqual(registry.strategies, ())
+
+    def test_freeze_wins_over_invalid_grammar(self):
+        Permission, Document, Ace = _direct_models()
+        registry = TrustsRegistry()
+        handle = _handle(registry)
+        registry.freeze()
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            handle.register_strategy(Ace, OrderedFold(
+                content='',
+                descriptor='',
+                order='ace_order',
+                polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+                mask='access_mask',
+                trustee='user',
+                token=FlatToken(
+                    principal=get_user_model(),
+                    principal_user='',
+                    principal_identity='',
+                ),
+                domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+            ))
+        self.assertIn('frozen', str(ctx.exception).lower())
+        self.assertEqual(registry.strategies, ())
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class HandleRegisterStrategyIsolationTest(SimpleTestCase):
+    def test_dual_handle_string_strategy_does_not_leak(self):
+        Permission, Document, Ace = _direct_models()
+        left = _handle(path='tests.core.fold-left')
+        right = _handle(path='tests.core.fold-right')
+        left.register_strategy(
+            Ace, _public_direct_fold(Ace, Permission, Document),
+        )
+        self.assertEqual(len(left.registry.strategies), 1)
+        self.assertEqual(right.registry.strategies, ())
+        right.register_strategy(
+            Ace, _public_direct_fold(Ace, Permission, Document),
+        )
+        self.assertEqual(len(left.registry.strategies), 1)
+        self.assertEqual(len(right.registry.strategies), 1)
+        self.assertIsNot(
+            left.registry.strategies[0], right.registry.strategies[0],
+        )
+        self.assertEqual(
+            left.registry.strategies[0], right.registry.strategies[0],
+        )

--- a/tests/core/test_issue131.py
+++ b/tests/core/test_issue131.py
@@ -466,6 +466,82 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
                     ))
         self.assertEqual(handle.registry.strategies, ())
 
+    def test_nonempty_descriptor_matches_internal_ref_record(self):
+        User = get_user_model()
+
+        class SecurityDescriptor(models.Model):
+            name = models.CharField(max_length=40)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Node(models.Model):
+            title = models.CharField(max_length=40)
+            security_descriptor = models.ForeignKey(
+                SecurityDescriptor, on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Ace(models.Model):
+            node = models.ForeignKey(Node, on_delete=models.CASCADE)
+            ace_order = models.IntegerField()
+            ace_type = models.IntegerField()
+            access_mask = models.BigIntegerField()
+            user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        class Permission(models.Model):
+            codename = models.CharField(max_length=64)
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        via_ref = TrustsRegistry()
+        ace = Ref(Ace)
+        node = Ref(Node)
+        user = Ref(User)
+        expected = via_ref.register_strategy(OrderedFold(
+            content=node,
+            descriptor=node.security_descriptor,
+            source=ace,
+            source_descriptor=ace.node.security_descriptor,
+            order=ace.ace_order,
+            polarity=PolarityMap(ace.ace_type, allow_value=ALLOW, deny_value=DENY),
+            mask=ace.access_mask,
+            trustee=ace.user,
+            token=FlatToken(
+                principal=user, principal_user=user, principal_identity=user,
+            ),
+            domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+        ))
+        handle = _handle()
+        compiled = handle.register_strategy(Ace, OrderedFold(
+            content='node',
+            descriptor='security_descriptor',
+            order='ace_order',
+            polarity=PolarityMap('ace_type', allow_value=ALLOW, deny_value=DENY),
+            mask='access_mask',
+            trustee='user',
+            token=FlatToken(
+                principal=User,
+                principal_user='',
+                principal_identity='',
+            ),
+            domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
+        ))
+        self.assertEqual(compiled, expected)
+        self.assertIs(compiled.content_model, Node)
+        self.assertEqual(compiled.content_desc_path, ('security_descriptor',))
+        self.assertGreater(len(compiled.source_desc_hops), 1)
+        self.assertEqual(
+            tuple(hop.name for hop in compiled.source_desc_hops),
+            ('node', 'security_descriptor'),
+        )
+
     def test_string_principal_or_member_is_type_error(self):
         Permission, Document, Ace = _direct_models()
         handle = _handle()

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -18,12 +18,13 @@ exactly one terminal M2M membership hop after zero or more forward
 single-valued hops. Validation is registration-time ``_meta`` only
 (zero SQL).
 
-``register_strategy(OrderedFold(...))`` is a parallel closed family.
-Ordinary ``register()`` stays the AnyPath ``EXISTS`` fast path. One
-content terminal may use AnyPath xor one OrderedFold. The first
-OrderedFold renderer is PostgreSQL; other vendors fail closed before
-fold SQL. Import ``OrderedFold``, ``PermissionMaskDomain``,
-``MaskEntry``, ``PolarityMap``, and ``FlatToken`` from ``trusts.core``.
+``handle.register_strategy(source_model, OrderedFold(...))`` is a
+parallel closed family. Ordinary ``handle.register()`` stays the
+AnyPath ``EXISTS`` fast path. One content terminal may use AnyPath xor
+one OrderedFold. The first OrderedFold renderer is PostgreSQL; other
+vendors fail closed before fold SQL. Import ``OrderedFold``,
+``PermissionMaskDomain``, ``MaskEntry``, ``PolarityMap``, and
+``FlatToken`` from ``trusts.core``.
 
 Import from ``trusts.core``. This slice does not re-export a process-global
 registry from ``trusts``. Generic compiler protocol, the default plan
@@ -2543,7 +2544,7 @@ class TrustsRegistry(object):
         ).filter_content(queryset, user, permission)
 
 
-def _public_path_segments(value, role):
+def _public_path_segments(value, role, *, allow_empty=False):
     """Split a public Django ``__`` path. Reject before ``Ref`` / resolve."""
     if isinstance(value, Ref):
         raise TypeError(
@@ -2553,9 +2554,15 @@ def _public_path_segments(value, role):
         raise TrustsConfigurationError(
             '%s must be a Django path string, not %r.' % (role, value)
         )
+    if not value:
+        if allow_empty:
+            return ()
+        raise TrustsConfigurationError(
+            '%s path %r is not a valid Django __ relationship path.'
+            % (role, value)
+        )
     if (
-        not value
-        or value.startswith('__')
+        value.startswith('__')
         or value.endswith('__')
         or '.' in value
     ):
@@ -2572,8 +2579,147 @@ def _public_path_segments(value, role):
     return tuple(segments)
 
 
-def _public_ref(root, value, role):
-    return Ref(root, _public_path_segments(value, role))
+def _public_ref(root, value, role, *, allow_empty=False):
+    return Ref(root, _public_path_segments(
+        value, role, allow_empty=allow_empty,
+    ))
+
+
+def _public_model_class(value, role):
+    if isinstance(value, Ref):
+        raise TypeError(
+            '%s must be a Django model class, not a Ref.' % (role,)
+        )
+    if isinstance(value, str):
+        raise TypeError(
+            '%s must be a Django model class, not a path string.' % (role,)
+        )
+    if not _is_model_class(value):
+        raise TrustsConfigurationError(
+            '%s must be a Django model class, not %r.' % (role, value)
+        )
+    return value
+
+
+def _reject_public_ref(value, role):
+    if isinstance(value, Ref):
+        raise TypeError(
+            '%s must be a Django path string, not a Ref.' % (role,)
+        )
+    return value
+
+
+def _bind_public_flat_token(token):
+    """Bind public FlatToken model/path fields to independent Ref roots."""
+    from trusts.ordered_fold import FlatToken
+
+    if not isinstance(token, FlatToken):
+        return token
+    principal = _public_model_class(token.principal, 'principal')
+    principal_user = _public_ref(
+        principal, token.principal_user, 'principal_user', allow_empty=True,
+    )
+    principal_identity = _public_ref(
+        principal, token.principal_identity, 'principal_identity',
+        allow_empty=True,
+    )
+    member = token.member
+    member_identity = token.member_identity
+    member_group = token.member_group
+    if member is None and member_identity is None and member_group is None:
+        return FlatToken(
+            principal=Ref(principal),
+            principal_user=principal_user,
+            principal_identity=principal_identity,
+        )
+    if member is None:
+        _reject_public_ref(member_identity, 'member_identity')
+        _reject_public_ref(member_group, 'member_group')
+        return FlatToken(
+            principal=Ref(principal),
+            principal_user=principal_user,
+            principal_identity=principal_identity,
+            member=None,
+            member_identity=member_identity,
+            member_group=member_group,
+        )
+    member = _public_model_class(member, 'member')
+    if member_identity is not None:
+        member_identity = _public_ref(
+            member, member_identity, 'member_identity',
+        )
+    else:
+        _reject_public_ref(member_identity, 'member_identity')
+    if member_group is not None:
+        member_group = _public_ref(member, member_group, 'member_group')
+    else:
+        _reject_public_ref(member_group, 'member_group')
+    return FlatToken(
+        principal=Ref(principal),
+        principal_user=principal_user,
+        principal_identity=principal_identity,
+        member=Ref(member),
+        member_identity=member_identity,
+        member_group=member_group,
+    )
+
+
+def _bind_public_polarity(source_model, polarity):
+    from trusts.ordered_fold import PolarityMap
+
+    if not isinstance(polarity, PolarityMap):
+        return polarity
+    if isinstance(polarity.field, Ref):
+        raise TypeError(
+            'PolarityMap.field must be a Django path string, not a Ref.'
+        )
+    return PolarityMap(
+        _public_ref(source_model, polarity.field, 'polarity'),
+        allow_value=polarity.allow_value,
+        deny_value=polarity.deny_value,
+    )
+
+
+def _bind_public_ordered_fold(source_model, strategy):
+    """Normalize public OrderedFold strings to today's internal Refs."""
+    from trusts.ordered_fold import OrderedFold
+
+    if not isinstance(strategy, OrderedFold):
+        raise TrustsConfigurationError(
+            'register_strategy requires OrderedFold, not %r.' % (strategy,)
+        )
+    if isinstance(strategy.source, Ref) or isinstance(
+        strategy.source_descriptor, Ref,
+    ):
+        raise TypeError(
+            'register_strategy does not accept Ref fields; pass Django '
+            'path strings.'
+        )
+    if strategy.source is not None or strategy.source_descriptor is not None:
+        raise TrustsConfigurationError(
+            'source and source_descriptor are derived from the source '
+            'model and content path.'
+        )
+    content_path = _public_path_segments(strategy.content, 'content')
+    _path, related, _lookup, _target = _resolve_forward_singles(
+        source_model, content_path, 'content',
+    )
+    content_model = related._meta.concrete_model
+    return OrderedFold(
+        content=Ref(content_model),
+        descriptor=_public_ref(
+            content_model, strategy.descriptor, 'descriptor',
+            allow_empty=True,
+        ),
+        source=Ref(source_model),
+        source_descriptor=Ref(source_model, content_path),
+        order=_public_ref(source_model, strategy.order, 'order'),
+        polarity=_bind_public_polarity(source_model, strategy.polarity),
+        mask=_public_ref(source_model, strategy.mask, 'mask'),
+        trustee=_public_ref(source_model, strategy.trustee, 'trustee'),
+        token=_bind_public_flat_token(strategy.token),
+        domain=strategy.domain,
+    )
 
 
 def _bind_public_condition(condition, root):
@@ -2655,6 +2801,41 @@ class BackendHandle:
             permission=_public_ref(root, permission, 'permission'),
             condition=_bind_public_condition(condition, root),
             along=_bind_public_along(root, along),
+        )
+
+    def register_strategy(self, source_model, strategy=None):
+        """Application API: register one OrderedFold plan on this handle.
+
+        The positional source model is required. Public ``content``,
+        ``order``, ``mask``, ``trustee``, and ``PolarityMap.field`` are
+        Django ``__`` paths on that source. ``content`` also supplies
+        the content terminal; ``descriptor`` is a path on that terminal
+        and may be ``""``. ``FlatToken.principal`` and optional
+        ``member`` are independent model classes. Passing a ``Ref`` is
+        ``TypeError``. A frozen handle raises
+        ``TrustsConfigurationError`` before path parsing.
+        """
+        if getattr(self.registry, 'frozen', False):
+            raise TrustsConfigurationError(
+                'Cannot register on a frozen TrustsRegistry.'
+            )
+        if strategy is None:
+            raise TypeError(
+                'register_strategy requires (source_model, OrderedFold); '
+                'the no-root form is not supported.'
+            )
+        if isinstance(source_model, Ref):
+            raise TypeError(
+                'register_strategy source must be a Django model class, '
+                'not a Ref.'
+            )
+        if not _is_model_class(source_model):
+            raise TrustsConfigurationError(
+                'register_strategy source must be a Django model class, '
+                'not %r.' % (source_model,)
+            )
+        return self.registry.register_strategy(
+            _bind_public_ordered_fold(source_model, strategy),
         )
 
     def register_permission_condition(self, model, code, builder):

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -2698,21 +2698,21 @@ def _bind_public_ordered_fold(source_model, strategy):
     if strategy.source is not None or strategy.source_descriptor is not None:
         raise TrustsConfigurationError(
             'source and source_descriptor are derived from the source '
-            'model and content path.'
+            'model, content path, and descriptor.'
         )
     content_path = _public_path_segments(strategy.content, 'content')
+    descriptor_path = _public_path_segments(
+        strategy.descriptor, 'descriptor', allow_empty=True,
+    )
     _path, related, _lookup, _target = _resolve_forward_singles(
         source_model, content_path, 'content',
     )
     content_model = related._meta.concrete_model
     return OrderedFold(
         content=Ref(content_model),
-        descriptor=_public_ref(
-            content_model, strategy.descriptor, 'descriptor',
-            allow_empty=True,
-        ),
+        descriptor=Ref(content_model, descriptor_path),
         source=Ref(source_model),
-        source_descriptor=Ref(source_model, content_path),
+        source_descriptor=Ref(source_model, content_path + descriptor_path),
         order=_public_ref(source_model, strategy.order, 'order'),
         polarity=_bind_public_polarity(source_model, strategy.polarity),
         mask=_public_ref(source_model, strategy.mask, 'mask'),
@@ -2808,9 +2808,10 @@ class BackendHandle:
 
         The positional source model is required. Public ``content``,
         ``order``, ``mask``, ``trustee``, and ``PolarityMap.field`` are
-        Django ``__`` paths on that source. ``content`` also supplies
-        the content terminal; ``descriptor`` is a path on that terminal
-        and may be ``""``. ``FlatToken.principal`` and optional
+        Django ``__`` paths on that source. ``content`` supplies the
+        content terminal. ``descriptor`` is a path on that terminal and
+        may be ``""``; the derived source descriptor is the content
+        path plus those segments. ``FlatToken.principal`` and optional
         ``member`` are independent model classes. Passing a ``Ref`` is
         ``TypeError``. A frozen handle raises
         ``TrustsConfigurationError`` before path parsing.

--- a/trusts/ordered_fold.py
+++ b/trusts/ordered_fold.py
@@ -97,7 +97,13 @@ class FlatToken:
 
 @dataclass(frozen=True)
 class OrderedFold:
-    """Closed typed remaining-bits strategy for one content terminal."""
+    """Closed typed remaining-bits strategy for one content terminal.
+
+    ``BackendHandle.register_strategy(source_model, OrderedFold(...))``
+    derives ``source`` and ``source_descriptor`` from the positional
+    source model and the public ``content`` path. Isolated registry
+    tests still pass those fields as root-relative ``Ref`` values.
+    """
 
     content: object
     descriptor: object
@@ -109,6 +115,31 @@ class OrderedFold:
     trustee: object
     token: object
     domain: object
+
+    def __init__(
+        self,
+        content,
+        descriptor,
+        source=None,
+        source_descriptor=None,
+        *,
+        order,
+        polarity,
+        mask,
+        trustee,
+        token,
+        domain,
+    ):
+        object.__setattr__(self, 'content', content)
+        object.__setattr__(self, 'descriptor', descriptor)
+        object.__setattr__(self, 'source', source)
+        object.__setattr__(self, 'source_descriptor', source_descriptor)
+        object.__setattr__(self, 'order', order)
+        object.__setattr__(self, 'polarity', polarity)
+        object.__setattr__(self, 'mask', mask)
+        object.__setattr__(self, 'trustee', trustee)
+        object.__setattr__(self, 'token', token)
+        object.__setattr__(self, 'domain', domain)
 
 
 @dataclass(frozen=True, slots=True)

--- a/trusts/ordered_fold.py
+++ b/trusts/ordered_fold.py
@@ -100,9 +100,11 @@ class OrderedFold:
     """Closed typed remaining-bits strategy for one content terminal.
 
     ``BackendHandle.register_strategy(source_model, OrderedFold(...))``
-    derives ``source`` and ``source_descriptor`` from the positional
-    source model and the public ``content`` path. Isolated registry
-    tests still pass those fields as root-relative ``Ref`` values.
+    derives ``source`` from the positional source model and
+    ``source_descriptor`` from the public ``content`` path plus the
+    content-relative ``descriptor`` segments (empty ``descriptor``
+    keeps today's content path). Isolated registry tests still pass
+    those fields as root-relative ``Ref`` values.
     """
 
     content: object


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
C1-fold only for #131. Baseline: Core `dev` `e9fd4cd4f77624f3d5351b505808c1d6fa8bcbc4` (merged C1 / PR #158). Design: accepted r2 + r3 FlatToken correction, plus Chat’s non-empty descriptor source-path review.

**HEAD:** `37a7c9577a3e8723dab951327ce7c39f37cc01b5`  
CI **6/6 green** on this revision: https://github.com/django-trusts/django-trusts/actions/runs/34736177485

## What this PR does

- Adds the sole public ordered-strategy entry `BackendHandle.register_strategy(source_model, OrderedFold(...))`. The positional source model is required; there is no no-root overload.
- Accepts the existing Django `__` path grammar and normalizes before today’s validators:
  - `content`, `order`, `mask`, `trustee`, and `PolarityMap.field` are source-model-relative
  - the content terminal is derived from `content`
  - `descriptor` is relative to that content model and may be `""`
  - the derived source descriptor is `content_path + descriptor` segments (`content="node"`, `descriptor="security_descriptor"` → `Ace.node.security_descriptor`)
- Preserves `FlatToken`’s two independent roots: `principal` is a model class; optional `member` is a separate model class. The member triad remains all-set or all-`None`.
- Rejects public `Ref` inputs and invalid model/path shapes. Freeze raises before parsing or normalization. Zero SQL, then today’s registry validation/storage path.
- Same-PR `migrates.md` old/new spelling plus a migration-bot checklist covering `.registry.register_strategy(`, `Ref(`, `OrderedFold(`, and obsolete no-root forms.

## What this PR does not do

- `handle.registry` remains (temporary; unconverted consumers still need it).
- No W1 / C2 / #138 / #145 / #146 / #137 / #159/#160 / release work.
- Internal `TrustsRegistry.register_strategy(OrderedFold(...Ref...))` remains for compiler tests.

## Tests

- `tests/core/test_issue131.py` — string-vs-Ref equivalence (including non-empty descriptor / Windows-shaped source→content→descriptor), distinct principal/member roots, mis-bound member paths, all-or-none triad, invalid-path rejection, freeze-before-validation, dual-handle isolation, no-root TypeError.
- Existing SQLite/PostgreSQL ordered suite in `tests/core/test_issue100.py` is unchanged.

Do not merge. W1 / C2 stay parked.
<!-- CURSOR_AGENT_PR_BODY_END -->


<div><a href="https://cursor.com/agents/bc-44334f59-b581-465a-87cb-092f1f03b2a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44334f59-b581-465a-87cb-092f1f03b2a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
