### PR TITLE
#131 C-unify: named path/request filters and trusts.check

### DIFF
--- a/django_trusts.py
+++ b/django_trusts.py
@@ -1,7 +1,9 @@
 """Public alias for django-trusts library helpers.
 
-The Django app package remains ``trusts``. Named conditions are
-registered as builders on ``BackendHandle.register_permission_condition``.
+The Django app package remains ``trusts``. Named request filters are
+registered as builders on ``BackendHandle.register_request_filter``
+(``register_permission_condition`` remains an unpublished forwarder).
+The Trusts object checker is ``trusts.check``.
 
 ``Expr``, ``Query`` / ``TQ``, and ``condition_refs`` are not exported
 here (issue #142 Stage B).

--- a/migrates.md
+++ b/migrates.md
@@ -35,10 +35,11 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
    `TrustModelBackendMixin`. Call `super().ready()`.
 3. Register protected models through `handle.register(root, user=...,
    permission=..., content=...)`, ordered strategies through
-   `handle.register_strategy(source_model, OrderedFold(...))`, and
-   named-condition **builders** through
-   `handle.register_permission_condition` in `AppConfig.ready()` before
-   finalization.
+   `handle.register_strategy(source_model, OrderedFold(...))`, named
+   path filters through `handle.register_path_filter`, and named
+   request filters through `handle.register_request_filter` (or the
+   unpublished `handle.register_permission_condition` forwarder) in
+   `AppConfig.ready()` before finalization.
 4. Import only the six public `trusts.conditions` names:
    `PermissionConditionBooleanError`, `PermissionConditionError`,
    `PermissionConditionNotQueryable`, `PermissionConditionUnsupported`,
@@ -78,6 +79,63 @@ Migration-bot search list:
 - `Along(`
 - `OrderedFold(`
 - `register_strategy(OrderedFold`
+
+## Named filters and `trusts.check` (#131 C-unify)
+
+| | Old | New |
+| --- | --- | --- |
+| `app.codename:own` / colon parse | `"app.codename"` + `filter=("own",)` on Trusts request APIs |
+| `"app.x:non_confidential:editable"` as one code | `filter=("non_confidential", "editable")` |
+| `user.has_perm("app.x:y", obj)` | `check(user, "app.x", obj, filter=("y",))` |
+| Core `@permission_required(...)` / inference | removed later (#138); `@require_authorization(Model, K(...), perm, filter=())` |
+| Core `P(perm, **fieldlookups)` | removed from Core 1.0 guard (#138) |
+| historical Zero decorator / `P` / `:own` | explicit `trusts.zero.*` import (`#138`) |
+| `register_permission_condition` | `register_request_filter` |
+| `register(..., condition=permission_in/All/Equal)` | `register_path_filter` + `register(..., filter="name")` |
+| `register(..., filter=lambda r: ...)` | illegal (named-only B) |
+| `trusts.check` vs `has_object_perm` / `instance_match` | public name is `trusts.check` |
+| bare Core guard via `user.has_perms` | Trusts-only `check` (loses ModelBackend / superuser) |
+| `where=` / `NamedConditions` / `conditions=` | never shipped; do not alias |
+
+`require_authorization` is #138 and is **not** implemented in C-unify.
+When it lands, the signature is identity-before-permission:
+
+```python
+require_authorization(
+    content_model,
+    candidate_identity,
+    permission,
+    filter=(),
+)
+```
+
+Direct object checks stay `check(user, permission, obj, filter=())`.
+`filter=` on request APIs is exactly `tuple[str, ...]`. A bare string,
+list, set, generator, or mapping is `TypeError` — do not coerce a
+string into characters. Path attach is named-only:
+`register(..., filter="name")`. Path-filter and request-filter stores
+are separate; there is no cross-store lookup and no colon grammar.
+
+Migration-bot search list:
+
+- `:non_confidential`
+- `:own`
+- `parse_perm_code`
+- `permission_has_condition`
+- `permission_condition_code`
+- `condition_code=`
+- `condition=`
+- `permission_in(`
+- `has_perm('...:`
+- `register_permission_condition(`
+- `register_strategy(`
+- `where=`
+- `NamedConditions`
+- `conditions=`
+- `.registry`
+- `Ref(`
+- `permission_required(`
+- `from trusts.decorators import P`
 
 This file is the Core 1.x router only. It does not document concrete
 Zero schema, UI, admin, or management-command steps.

--- a/tests/core/test_issue131_cunify.py
+++ b/tests/core/test_issue131_cunify.py
@@ -1,0 +1,584 @@
+"""#131 C-unify: path/request filter stores, named-only attach, trusts.check.
+
+Covers separate typed stores, option B named-only path attach, r9
+permission-path bind, tuple-only TypeError (including bare string),
+fail-closed unknown request names, dual-handle isolation, freeze,
+fingerprints/catalog, and the Trusts-only checker.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
+
+from tests.core import KernelHostRequiredMixin
+from tests.core.test_issue100 import _direct_models
+from tests.core.test_issue131 import _handle, _public_direct_fold
+from tests.core.test_issue54 import _change_document
+from tests.core.test_issue98 import _gh_models
+from tests.myapp.models import Document, DocumentGrant
+from trusts._filters import (
+    PathFilterBooleanError,
+    PathFilterUnsupported,
+    ir_digest,
+    query_filter_identity,
+    validate_request_filter_tuple,
+)
+from trusts.core import (
+    Equal,
+    TrustsConfigurationError,
+    TrustsRegistry,
+    all_match,
+    check,
+    filter_authorized_scopes,
+    granted,
+    instance_match,
+)
+
+
+def _pks(qs):
+    return set(qs.values_list('pk', flat=True))
+
+
+class RequestTupleBoundaryTest(SimpleTestCase):
+    def test_outer_value_is_validated_before_any_coercion(self):
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple('editable')
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple(['editable'])
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple({'editable'})
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple({'editable': True})
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple(name for name in ('editable',))
+        self.assertEqual(validate_request_filter_tuple(()), ())
+        self.assertEqual(
+            validate_request_filter_tuple(('non_confidential', 'editable')),
+            ('non_confidential', 'editable'),
+        )
+
+    def test_bare_string_is_not_expanded_to_characters(self):
+        with patch(
+            'trusts._filters.validate_filter_name',
+            side_effect=AssertionError('must not iterate a bare string'),
+        ):
+            with self.assertRaises(TypeError):
+                validate_request_filter_tuple('editable')
+
+    def test_duplicate_and_malformed_names_are_configuration_errors(self):
+        with self.assertRaises(TrustsConfigurationError):
+            validate_request_filter_tuple(('own', 'own'))
+        with self.assertRaises(TrustsConfigurationError):
+            validate_request_filter_tuple(('1bad',))
+        with self.assertRaises(TrustsConfigurationError):
+            validate_request_filter_tuple(('',))
+        with self.assertRaises(TypeError):
+            validate_request_filter_tuple((1,))
+
+    def test_query_identity_validates_then_sorts(self):
+        self.assertEqual(
+            query_filter_identity(('editable', 'non_confidential')),
+            ('editable', 'non_confidential'),
+        )
+        supplied = validate_request_filter_tuple(
+            ('editable', 'non_confidential'),
+        )
+        self.assertEqual(supplied, ('editable', 'non_confidential'))
+
+
+class NamedOnlyPathAttachTest(SimpleTestCase):
+    def test_callable_tuple_list_mapping_are_type_error(self):
+        handle = _handle()
+        for value in (
+            (lambda r: r),
+            ('team_aligned',),
+            ['team_aligned'],
+            {'team_aligned': True},
+        ):
+            with self.subTest(value=type(value).__name__):
+                with self.assertRaises(TypeError):
+                    handle.register(
+                        DocumentGrant,
+                        user='user',
+                        permission='permission',
+                        content='document',
+                        filter=value,
+                    )
+        self.assertEqual(handle.registry.records, ())
+
+    def test_strategy_and_filter_is_type_error(self):
+        handle = _handle()
+        with self.assertRaises(TypeError):
+            handle.register(
+                DocumentGrant,
+                user='user',
+                permission='permission',
+                content='document',
+                strategy=object(),
+                filter='team_aligned',
+            )
+        self.assertEqual(handle.registry.records, ())
+
+    @isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+    def test_register_strategy_rejects_filter(self):
+        Permission, DocumentModel, Ace = _direct_models()
+        handle = _handle()
+        with self.assertRaises(TypeError):
+            handle.register_strategy(
+                Ace,
+                _public_direct_fold(Ace, Permission, DocumentModel),
+                filter='bits',
+            )
+        self.assertEqual(handle.registry.strategies, ())
+
+
+class SeparateStoresTest(SimpleTestCase):
+    def test_path_lookup_never_reads_request_store(self):
+        handle = _handle()
+        handle.register_request_filter(
+            Document, 'own', lambda u, p, o: o.confidential != True,
+        )
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            handle.register(
+                DocumentGrant,
+                user='user',
+                permission='permission',
+                content='document',
+                filter='own',
+            )
+        self.assertIn('Unknown path filter', str(ctx.exception))
+        self.assertEqual(handle.registry.records, ())
+        self.assertIsNotNone(
+            handle.registry.get_request_filter_record(Document, 'own'),
+        )
+        self.assertIsNone(handle.registry.get_path_filter_record(DocumentGrant, 'own'))
+
+    def test_request_lookup_never_reads_path_store(self):
+        handle = _handle()
+        handle.register_path_filter(
+            DocumentGrant,
+            'own',
+            lambda r: r.user == r.user,
+        )
+        self.assertIsNone(handle.registry.get_request_filter_record(Document, 'own'))
+        self.assertIsNotNone(
+            handle.registry.get_path_filter_record(DocumentGrant, 'own'),
+        )
+
+    def test_same_name_may_exist_in_both_stores(self):
+        handle = _handle()
+        path = handle.register_path_filter(
+            DocumentGrant, 'own', lambda r: r.user == r.user,
+        )
+        request = handle.register_request_filter(
+            Document, 'own', lambda u, p, o: o.confidential != True,
+        )
+        self.assertIsNot(path, request)
+        self.assertIs(
+            handle.registry.get_path_filter_record(DocumentGrant, 'own'), path,
+        )
+        self.assertIs(
+            handle.registry.get_request_filter_record(Document, 'own'), request,
+        )
+
+    def test_permission_condition_forwards_onto_request_store(self):
+        handle = _handle()
+        record = handle.register_permission_condition(
+            Document, 'non_confidential',
+            lambda u, p, o: o.confidential != True,
+        )
+        self.assertIs(
+            handle.registry.get_request_filter_record(Document, 'non_confidential'),
+            record,
+        )
+        self.assertIsNone(
+            handle.registry.get_path_filter_record(DocumentGrant, 'non_confidential'),
+        )
+
+
+@isolate_apps('tests', 'django.contrib.auth', 'django.contrib.contenttypes')
+class PathFilterPhaseBindTest(SimpleTestCase):
+    def test_r9_membership_left_must_equal_permission_path(self):
+        models_ = _gh_models()
+        _Account, _Owner, Team, Operation, _Bundle, Repository = models_[:6]
+
+        class DualGrant(models.Model):
+            team = models.ForeignKey(
+                Team, related_name='dual_grants', on_delete=models.CASCADE,
+            )
+            repository = models.ForeignKey(
+                Repository, related_name='dual_grants', on_delete=models.CASCADE,
+            )
+            operation = models.ForeignKey(
+                Operation, related_name='dual_grants', on_delete=models.CASCADE,
+            )
+            also = models.ForeignKey(
+                Operation, related_name='dual_also', on_delete=models.CASCADE,
+            )
+
+            class Meta:
+                app_label = 'trusts_tests'
+
+        handle = _handle()
+        handle.register_path_filter(
+            DualGrant,
+            'wrong',
+            lambda r: r.also.in_(r.team.permission_bundles.operations),
+        )
+        with self.assertRaises(TrustsConfigurationError):
+            handle.register(
+                DualGrant,
+                user='team__members',
+                permission='operation',
+                content='repository',
+                filter='wrong',
+            )
+        self.assertEqual(handle.registry.records, ())
+
+    def test_matching_permission_path_binds(self):
+        models_ = _gh_models()
+        TeamRepoGrant = models_[6]
+        handle = _handle()
+        handle.register_path_filter(
+            TeamRepoGrant,
+            'team_aligned',
+            lambda r: (
+                r.operation.in_(r.team.permission_bundles.operations)
+                & (r.team.organization == r.repository.organization)
+            ),
+        )
+        record = handle.register(
+            TeamRepoGrant,
+            user='team__members',
+            permission='operation',
+            content='repository',
+            filter='team_aligned',
+        )
+        self.assertEqual(record.user_path, ('team', 'members'))
+        self.assertEqual(record.permission_path, ('operation',))
+        self.assertEqual(record.content_path, ('repository',))
+
+    def test_equality_only_has_no_membership_left_to_prove(self):
+        models_ = _gh_models()
+        TeamRepoGrant = models_[6]
+        handle = _handle()
+        handle.register_path_filter(
+            TeamRepoGrant,
+            'same_org',
+            lambda r: r.team.organization == r.repository.organization,
+        )
+        record = handle.register(
+            TeamRepoGrant,
+            user='team__members',
+            permission='operation',
+            content='repository',
+            filter='same_org',
+        )
+        self.assertEqual(len(handle.registry.records), 1)
+        self.assertEqual(record.permission_path, ('operation',))
+
+    def test_python_and_or_in_fail_loud(self):
+        models_ = _gh_models()
+        TeamRepoGrant = models_[6]
+        handle = _handle()
+        with self.assertRaises(PathFilterBooleanError):
+            handle.register_path_filter(
+                TeamRepoGrant,
+                'and_or',
+                lambda r: (
+                    (r.team.organization == r.repository.organization)
+                    and (r.operation == r.operation)
+                ),
+            )
+        with self.assertRaises(PathFilterUnsupported):
+            handle.register_path_filter(
+                TeamRepoGrant,
+                'py_in',
+                lambda r: r.operation in r.team.permission_bundles.operations,
+            )
+        self.assertEqual(handle.registry.filter_catalog(), ())
+
+    def test_duplicate_path_filter_fails_before_builder(self):
+        models_ = _gh_models()
+        TeamRepoGrant = models_[6]
+        handle = _handle()
+        calls = []
+
+        def builder(r):
+            calls.append(1)
+            return r.team.organization == r.repository.organization
+
+        handle.register_path_filter(TeamRepoGrant, 'same_org', builder)
+        self.assertEqual(calls, [1])
+        with self.assertRaises(TrustsConfigurationError):
+            handle.register_path_filter(TeamRepoGrant, 'same_org', builder)
+        self.assertEqual(calls, [1])
+
+    def test_unknown_path_name_stores_nothing(self):
+        models_ = _gh_models()
+        TeamRepoGrant = models_[6]
+        handle = _handle()
+        with self.assertRaises(TrustsConfigurationError):
+            handle.register(
+                TeamRepoGrant,
+                user='team__members',
+                permission='operation',
+                content='repository',
+                filter='missing',
+            )
+        self.assertEqual(handle.registry.records, ())
+
+
+class FilterCatalogFingerprintTest(SimpleTestCase):
+    def test_unused_names_appear_and_fingerprint_ignores_name(self):
+        handle = _handle()
+        handle.register_path_filter(
+            DocumentGrant, 'left', lambda r: r.user == r.user,
+        )
+        handle.register_path_filter(
+            DocumentGrant, 'right', lambda r: r.user == r.user,
+        )
+        handle.register_request_filter(
+            Document, 'editable', lambda u, p, o: o.confidential != True,
+        )
+        catalog = handle.filter_catalog()
+        kinds = {(entry.kind, entry.name, entry.consumed) for entry in catalog}
+        self.assertIn(('path', 'left', False), kinds)
+        self.assertIn(('path', 'right', False), kinds)
+        self.assertIn(('request', 'editable', False), kinds)
+        first = handle.register(
+            DocumentGrant,
+            user='user',
+            permission='permission',
+            content='document',
+            filter='left',
+        )
+        second_handle = _handle(path='tests.core.handle-b')
+        second_handle.register_path_filter(
+            DocumentGrant, 'alias', lambda r: r.user == r.user,
+        )
+        second = second_handle.register(
+            DocumentGrant,
+            user='user',
+            permission='permission',
+            content='document',
+            filter='alias',
+        )
+        self.assertEqual(
+            handle.record_fingerprint(first),
+            second_handle.record_fingerprint(second),
+        )
+        consumed = {
+            (entry.name, entry.consumed)
+            for entry in handle.filter_catalog()
+            if entry.kind == 'path'
+        }
+        self.assertIn(('left', True), consumed)
+        self.assertIn(('right', False), consumed)
+
+    def test_changing_ir_changes_fingerprint(self):
+        left = _handle(path='tests.core.fp-left')
+        right = _handle(path='tests.core.fp-right')
+        left.register_path_filter(
+            DocumentGrant, 'same', lambda r: r.user == r.user,
+        )
+        right.register_path_filter(
+            DocumentGrant, 'same',
+            lambda r: r.permission == r.permission,
+        )
+        a = left.register(
+            DocumentGrant,
+            user='user',
+            permission='permission',
+            content='document',
+            filter='same',
+        )
+        b = right.register(
+            DocumentGrant,
+            user='user',
+            permission='permission',
+            content='document',
+            filter='same',
+        )
+        self.assertNotEqual(
+            left.record_fingerprint(a), right.record_fingerprint(b),
+        )
+        self.assertNotEqual(ir_digest(a.condition), ir_digest(b.condition))
+
+
+class FilterFreezeIsolationTest(SimpleTestCase):
+    def test_freeze_raises_before_path_or_request_builder(self):
+        registry = TrustsRegistry()
+        handle = _handle(registry)
+        registry.freeze()
+        path_calls = []
+        request_calls = []
+        with self.assertRaises(TrustsConfigurationError) as ctx:
+            handle.register_path_filter(
+                DocumentGrant, 'same',
+                lambda r: path_calls.append(1) or (r.user == r.user),
+            )
+        self.assertIn('frozen', str(ctx.exception).lower())
+        with self.assertRaises(TrustsConfigurationError):
+            handle.register_request_filter(
+                Document, 'editable',
+                lambda u, p, o: request_calls.append(1) or (o.confidential != True),
+            )
+        self.assertEqual(path_calls, [])
+        self.assertEqual(request_calls, [])
+        self.assertEqual(handle.filter_catalog(), ())
+
+    def test_dual_handle_filters_do_not_leak(self):
+        left = _handle(path='tests.core.filter-left')
+        right = _handle(path='tests.core.filter-right')
+        left.register_path_filter(
+            DocumentGrant, 'same', lambda r: r.user == r.user,
+        )
+        left.register_request_filter(
+            Document, 'editable', lambda u, p, o: o.confidential != True,
+        )
+        self.assertEqual(len(left.filter_catalog()), 2)
+        self.assertEqual(right.filter_catalog(), ())
+        self.assertIsNone(
+            right.registry.get_path_filter_record(DocumentGrant, 'same'),
+        )
+        self.assertIsNone(
+            right.registry.get_request_filter_record(Document, 'editable'),
+        )
+
+
+class CheckAndRequestFilterLiveTest(KernelHostRequiredMixin, TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.alice = User.objects.create_user('alice-cunify', password='x')
+        self.bob = User.objects.create_user('bob-cunify', password='x')
+        self.change = _change_document()
+        self.open_doc = Document.objects.create(title='open', confidential=False)
+        self.secret = Document.objects.create(title='secret', confidential=True)
+        DocumentGrant.objects.create(
+            document=self.open_doc, user=self.alice, permission=self.change,
+        )
+        DocumentGrant.objects.create(
+            document=self.secret, user=self.alice, permission=self.change,
+        )
+
+    def test_check_bare_grant_is_trusts_only(self):
+        from trusts import check as imported_check
+
+        self.assertIs(imported_check, check)
+        self.assertTrue(check(self.alice, self.change, self.open_doc))
+        self.assertTrue(check(self.alice, 'myapp.change_document', self.secret))
+        self.assertFalse(check(self.bob, self.change, self.open_doc))
+        self.assertFalse(check(AnonymousUser(), self.change, self.open_doc))
+        self.alice.is_active = False
+        self.alice.save()
+        self.assertFalse(check(self.alice, self.change, self.open_doc))
+
+    def test_check_request_filter_and_unknown_name(self):
+        self.assertTrue(
+            check(
+                self.alice, self.change, self.open_doc,
+                filter=('non_confidential',),
+            )
+        )
+        self.assertFalse(
+            check(
+                self.alice, self.change, self.secret,
+                filter=('non_confidential',),
+            )
+        )
+        with self.assertRaises(AttributeError):
+            check(
+                self.alice, self.change, self.open_doc,
+                filter=('missing',),
+            )
+
+    def test_check_does_not_parse_colon(self):
+        self.assertFalse(
+            check(self.alice, 'myapp.change_document:non_confidential', self.open_doc)
+        )
+
+    def test_authorized_and_granted_accept_filter_tuple_only(self):
+        self.assertEqual(
+            _pks(Document.objects.authorized(
+                self.alice, self.change, filter=('non_confidential',),
+            )),
+            {self.open_doc.pk},
+        )
+        for bad in ('non_confidential', ['non_confidential'], {'non_confidential'}):
+            with self.subTest(bad=type(bad).__name__):
+                with self.assertRaises(TypeError):
+                    Document.objects.authorized(
+                        self.alice, self.change, filter=bad,
+                    )
+                with self.assertRaises(TypeError):
+                    granted(
+                        (), Document.objects.all(), self.alice, self.change,
+                        filter=bad,
+                    )
+                with self.assertRaises(TypeError):
+                    all_match(
+                        (), Document.objects.all(), self.alice, self.change,
+                        filter=bad,
+                    )
+                with self.assertRaises(TypeError):
+                    instance_match(
+                        _handle(), self.open_doc, self.alice, self.change,
+                        filter=bad,
+                    )
+                with self.assertRaises(TypeError):
+                    filter_authorized_scopes(
+                        Document.objects.all(), self.alice, self.change,
+                        content=Document, filter=bad,
+                    )
+                with self.assertRaises(TypeError):
+                    TrustsRegistry().filter_authorized(
+                        Document.objects.all(), self.alice, self.change,
+                        filter=bad,
+                    )
+
+    def test_instance_check_is_one_sql(self):
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                check(
+                    self.alice, self.change, self.open_doc,
+                    filter=('non_confidential',),
+                )
+            )
+
+    def test_queryset_check_is_one_sql(self):
+        qs = Document.objects.filter(pk__in=[self.open_doc.pk])
+        with self.assertNumQueries(1):
+            self.assertTrue(
+                check(
+                    self.alice, self.change, qs,
+                    filter=('non_confidential',),
+                )
+            )
+        secret_qs = Document.objects.filter(pk__in=[self.secret.pk])
+        with self.assertNumQueries(1):
+            self.assertFalse(
+                check(
+                    self.alice, self.change, secret_qs,
+                    filter=('non_confidential',),
+                )
+            )
+
+
+class LegacyConditionBaselineTest(SimpleTestCase):
+    def test_closed_tree_condition_still_registers(self):
+        handle = _handle()
+        record = handle.register(
+            DocumentGrant,
+            user='user',
+            permission='permission',
+            content='document',
+            condition=Equal('user', 'user'),
+        )
+        self.assertIsNotNone(record.condition)
+        self.assertEqual(handle.registry.records, (record,))

--- a/tests/core/test_issue16.py
+++ b/tests/core/test_issue16.py
@@ -155,19 +155,21 @@ class ConditionRegistryShapeTest(SimpleTestCase):
             registry.register_permission_condition(Note, 'bad', 'not-a-condition')
         self.assertEqual(len(log.calls), 1)
 
-    def test_duplicate_condition_overwrites_same_identity(self):
+    def test_duplicate_request_filter_leaves_store_unchanged(self):
         Note, _Memo = _note_models()
         registry = TrustsRegistry()
-        registry.register_permission_condition(
+        first = registry.register_permission_condition(
             Note, 'named', lambda u, p, o: u == o.owner,
         )
-        registry.register_permission_condition(
-            Note, 'named', lambda u, p, o: o.title == 'keep',
-        )
+        with self.assertRaises(TrustsConfigurationError):
+            registry.register_permission_condition(
+                Note, 'named', lambda u, p, o: o.title == 'keep',
+            )
         record = registry.get_permission_condition_record(Note, 'named')
+        self.assertIs(record, first)
         self.assertEqual(
             record.expr.to_tuple(),
-            ('eq', ('ref', 'object', ('title',)), ('const', 'keep')),
+            ('eq', ('ref', 'principal', ()), ('ref', 'object', ('owner',))),
         )
         rows = list(registry.iter_permission_conditions())
         self.assertEqual(len(rows), 1)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -41,6 +41,7 @@ KERNEL_SUITE = [
     'tests.core.test_issue122',
     'tests.core.test_issue129',
     'tests.core.test_issue131',
+    'tests.core.test_issue131_cunify',
     'tests.core.test_issue151',
 ]
 
@@ -71,6 +72,7 @@ PAIR_KERNEL_SUITE = [
     'tests.core.test_issue108',
     'tests.core.test_issue129',
     'tests.core.test_issue131',
+    'tests.core.test_issue131_cunify',
     'tests.core.test_issue151',
 ]
 

--- a/trusts/__init__.py
+++ b/trusts/__init__.py
@@ -1,2 +1,9 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
+
+
+def __getattr__(name):
+    if name == 'check':
+        from trusts.core import check
+        return check
+    raise AttributeError('module %r has no attribute %r' % (__name__, name))

--- a/trusts/_filters.py
+++ b/trusts/_filters.py
@@ -1,0 +1,619 @@
+"""Private #131 C-unify path-filter IR, request-tuple boundary, and catalog.
+
+Application code does not import this module. Path-filter builders receive
+the root proxy ``r``; request-filter builders keep symbolic ``(u, p, o)``.
+The two stores never consult each other.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+from django.db.models.base import ModelBase
+
+
+FILTER_NAME_RE = re.compile(r'^[A-Za-z][A-Za-z0-9_]*$')
+
+_BOOLEAN_ERROR_MESSAGE = (
+    "Python 'and'/'or'/'not' cannot be used in path filters "
+    "because they cannot be overloaded; chained comparisons such as "
+    "`0 < r.amount < 100` also truth-test a symbolic node. Use '&' and "
+    "'|' for conjunction and disjunction, and '!=' instead of combining "
+    "'not' with '=='. Membership uses .in_(), not Python 'in'."
+)
+
+
+def _is_model_class(value):
+    return isinstance(value, ModelBase)
+
+
+def _concrete_model(model):
+    meta = getattr(model, '_meta', None)
+    if meta is None:
+        return model
+    return meta.concrete_model
+
+
+def _model_label(model):
+    meta = getattr(getattr(model, '_meta', None), 'concrete_model', None)
+    if meta is not None:
+        return meta._meta.label
+    meta = getattr(model, '_meta', None)
+    if meta is not None:
+        return meta.label
+    return repr(model)
+
+
+def _model_key(model):
+    return _concrete_model(model)
+
+
+class PathFilterBooleanError(Exception):
+    """Raised when a path-filter node is truth-tested (``and`` / ``or`` / ``not``)."""
+
+
+class PathFilterUnsupported(Exception):
+    """Raised for operations outside the path-filter grammar."""
+
+
+def _boolean_error():
+    raise PathFilterBooleanError(_BOOLEAN_ERROR_MESSAGE)
+
+
+def _unsupported(what):
+    raise PathFilterUnsupported(
+        '%s is not supported in path filters.' % what
+    )
+
+
+def validate_filter_name(name, *, role='filter'):
+    """Require a declared/request filter name. Empty or malformed fail closed."""
+    if not isinstance(name, str):
+        raise TypeError(
+            '%s name must be a string, not %r.' % (role, type(name).__name__,)
+        )
+    if not name or FILTER_NAME_RE.match(name) is None:
+        from trusts.core import TrustsConfigurationError
+
+        raise TrustsConfigurationError(
+            '%s name %r is not a valid filter name '
+            '(must match %s).' % (role, name, FILTER_NAME_RE.pattern)
+        )
+    return name
+
+
+def validate_request_filter_tuple(value):
+    """Validate a request ``filter=`` value before any iteration or coercion.
+
+    Only a ``tuple`` whose members are strings proceeds. A bare ``str``,
+    list, set, generator, or mapping is ``TypeError``. Do not
+    ``tuple(value)`` a string into characters. Duplicate / empty /
+    malformed names are ``TrustsConfigurationError``.
+    """
+    if not isinstance(value, tuple):
+        raise TypeError(
+            'filter must be a tuple of strings, not %r.'
+            % (type(value).__name__,)
+        )
+    seen = []
+    for name in value:
+        if not isinstance(name, str):
+            raise TypeError(
+                'filter members must be strings, not %r.'
+                % (type(name).__name__,)
+            )
+        validate_filter_name(name, role='request filter')
+        if name in seen:
+            from trusts.core import TrustsConfigurationError
+
+            raise TrustsConfigurationError(
+                'Duplicate request filter name %r.' % (name,)
+            )
+        seen.append(name)
+    return value
+
+
+def query_filter_identity(value):
+    """Validate first, then sort for query/manifest identity.
+
+    Diagnostics keep the supplied order (the validated tuple). Identity
+    is the sorted tuple. No silent dedupe — duplicates already failed.
+    """
+    names = validate_request_filter_tuple(value)
+    return tuple(sorted(names))
+
+
+def validate_path_filter_attach(value):
+    """Named-only path attach: omitted / ``None``, or exactly one ``str``.
+
+    Callable, tuple, list, or mapping is ``TypeError`` (option B).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(
+            'register(..., filter=) accepts exactly one filter name string, '
+            'not %r.' % (type(value).__name__,)
+        )
+    return validate_filter_name(value, role='path filter')
+
+
+class PathNode(object):
+    """Private path-filter IR node. Not an application-facing import."""
+
+    def __eq__(self, other):
+        return PathEq(self, as_path_node(other))
+
+    def __ne__(self, other):
+        return PathNe(self, as_path_node(other))
+
+    def __and__(self, other):
+        return _path_bool(PathAnd, self, as_path_node(other), '&')
+
+    def __or__(self, other):
+        return _path_bool(PathOr, self, as_path_node(other), '|')
+
+    def __rand__(self, other):
+        return _path_bool(PathAnd, as_path_node(other), self, '&')
+
+    def __ror__(self, other):
+        return _path_bool(PathOr, as_path_node(other), self, '|')
+
+    def __bool__(self):
+        _boolean_error()
+
+    def __call__(self, *args, **kwargs):
+        _unsupported('Function or method calls')
+
+    def __getitem__(self, key):
+        _unsupported('Indexing')
+
+    def __iter__(self):
+        _unsupported('Iteration')
+
+    def __contains__(self, item):
+        _unsupported("'in' tests; use .in_()")
+
+    def __hash__(self):
+        return id(self)
+
+    def in_(self, collection):
+        _unsupported('.in_() on a predicate; call it on a field path')
+
+    def to_tuple(self):
+        raise NotImplementedError
+
+
+class PathRef(PathNode):
+    """Root-relative symbolic path built by attribute traversal on ``r``."""
+
+    def __init__(self, root, path=()):
+        if not _is_model_class(root):
+            from trusts.core import TrustsConfigurationError
+
+            raise TrustsConfigurationError(
+                'Path filter root must be a Django model class, not %r.'
+                % (root,)
+            )
+        self.root = root
+        self.path = tuple(path)
+
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            raise AttributeError(name)
+        return PathRef(self.root, self.path + (name,))
+
+    def __setattr__(self, name, value):
+        if name in ('root', 'path'):
+            object.__setattr__(self, name, value)
+            return
+        _unsupported('Assignment to symbolic fields')
+
+    def __delattr__(self, name):
+        _unsupported('Deletion of symbolic fields')
+
+    def in_(self, collection):
+        return PathIn(self, as_path_node(collection))
+
+    def to_tuple(self):
+        return ('ref', self.path)
+
+    def __repr__(self):
+        if not self.path:
+            return 'r'
+        return 'r.%s' % '.'.join(self.path)
+
+
+class _PathPredicate(PathNode):
+    """Predicate nodes compare structurally so stored IR can be equality-tested."""
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.to_tuple() == other.to_tuple()
+
+    def __hash__(self):
+        return hash((type(self), self.to_tuple()))
+
+    def __ne__(self, other):
+        if type(self) is type(other):
+            return self.to_tuple() != other.to_tuple()
+        return NotImplemented
+
+
+class PathEq(_PathPredicate):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def to_tuple(self):
+        return ('eq', self.left.to_tuple(), self.right.to_tuple())
+
+    def __repr__(self):
+        return '(%r == %r)' % (self.left, self.right)
+
+
+class PathNe(_PathPredicate):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def to_tuple(self):
+        return ('ne', self.left.to_tuple(), self.right.to_tuple())
+
+    def __repr__(self):
+        return '(%r != %r)' % (self.left, self.right)
+
+
+class PathAnd(_PathPredicate):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def to_tuple(self):
+        return ('and', self.left.to_tuple(), self.right.to_tuple())
+
+    def __repr__(self):
+        return '(%r & %r)' % (self.left, self.right)
+
+
+class PathOr(_PathPredicate):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def to_tuple(self):
+        return ('or', self.left.to_tuple(), self.right.to_tuple())
+
+    def __repr__(self):
+        return '(%r | %r)' % (self.left, self.right)
+
+
+class PathIn(_PathPredicate):
+    """Membership ``left.in_(right)``. Left is proved against ``permission=`` later."""
+
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def to_tuple(self):
+        return ('in', self.left.to_tuple(), self.right.to_tuple())
+
+    def __repr__(self):
+        return '%r.in_(%r)' % (self.left, self.right)
+
+
+def is_path_predicate(node):
+    return isinstance(node, (PathEq, PathNe, PathAnd, PathOr, PathIn))
+
+
+def is_path_filter_node(node):
+    return isinstance(node, PathNode) and is_path_predicate(node)
+
+
+def as_path_node(value):
+    if isinstance(value, PathNode):
+        return value
+    _unsupported('Constant of type %s' % type(value).__name__)
+
+
+def _path_bool(cls, left, right, op):
+    if not is_path_predicate(left) or not is_path_predicate(right):
+        raise PathFilterUnsupported(
+            "'%s' requires comparison operands (for example "
+            "`(r.team.organization == r.repository.organization) %s "
+            "r.operation.in_(r.team.operations)`)." % (op, op)
+        )
+    return cls(left, right)
+
+
+def path_root_proxy(root_model):
+    """Typed ``r`` for ``register_path_filter`` builders."""
+    return PathRef(_concrete_model(root_model))
+
+
+def _require_path_ref(node, role):
+    from trusts.core import TrustsConfigurationError
+
+    if not isinstance(node, PathRef):
+        raise TrustsConfigurationError(
+            '%s must be a root-relative path on r, not %r.' % (role, node)
+        )
+    return node
+
+
+def _phase1_validate(node, root):
+    """Resolve traversals. ``.in_()`` is locally compatible only. Zero SQL."""
+    from trusts.core import (
+        TrustsConfigurationError,
+        _resolve_forward_singles,
+        _resolve_permission_in_path,
+    )
+
+    if isinstance(node, (PathAnd, PathOr)):
+        _phase1_validate(node.left, root)
+        _phase1_validate(node.right, root)
+        return
+    if isinstance(node, (PathEq, PathNe)):
+        left = _require_path_ref(node.left, 'path filter left')
+        right = _require_path_ref(node.right, 'path filter right')
+        if left.root is not root or right.root is not root:
+            raise TrustsConfigurationError(
+                'Path filter equality must stay on the declaration root %s.'
+                % root._meta.label
+            )
+        _left_path, left_model, _left_field, left_target = (
+            _resolve_forward_singles(root, left.path, 'path filter left')
+        )
+        _right_path, right_model, _right_field, right_target = (
+            _resolve_forward_singles(root, right.path, 'path filter right')
+        )
+        if left_model is not right_model:
+            raise TrustsConfigurationError(
+                'Path filter equality paths must terminate on the same '
+                'model; got %s and %s.'
+                % (left_model._meta.label, right_model._meta.label)
+            )
+        if left_target != right_target:
+            raise TrustsConfigurationError(
+                'Path filter equality paths must share one resolved '
+                'comparison field; got %s.%s and %s.%s.'
+                % (
+                    left_model._meta.label, left_target,
+                    right_model._meta.label, right_target,
+                )
+            )
+        return
+    if isinstance(node, PathIn):
+        left = _require_path_ref(node.left, 'in_ left')
+        right = _require_path_ref(node.right, 'in_ right')
+        if left.root is not root or right.root is not root:
+            raise TrustsConfigurationError(
+                'Path filter membership must stay on the declaration root %s.'
+                % root._meta.label
+            )
+        _left_path, left_model, _left_field, left_target = (
+            _resolve_forward_singles(root, left.path, 'in_ left')
+        )
+        pk_attname = getattr(left_model._meta.pk, 'attname', None)
+        _resolve_permission_in_path(
+            root, right.path, 'in_ right', left_model,
+            permission_target=pk_attname,
+        )
+        return
+    raise TrustsConfigurationError(
+        'Path filter did not produce a comparison expression.'
+    )
+
+
+def invoke_path_filter_builder(builder, root_model, name):
+    """Phase 1 invoke: one call with typed ``r``, then discard the callable."""
+    from trusts.core import TrustsConfigurationError
+
+    root = _concrete_model(root_model)
+    r = path_root_proxy(root)
+    try:
+        result = builder(r)
+    except (PathFilterBooleanError, PathFilterUnsupported, TrustsConfigurationError):
+        raise
+    except Exception as exc:
+        raise TrustsConfigurationError(
+            'Path filter builder %r on %s raised %s: %s'
+            % (name, _model_label(root), type(exc).__name__, exc)
+        ) from exc
+    if isinstance(result, bool):
+        raise TrustsConfigurationError(
+            'Path filter builder %r on %s returned a boolean; return a '
+            'comparison of r (for example `r.team.organization == '
+            'r.repository.organization`).' % (name, _model_label(root))
+        )
+    if not is_path_filter_node(result):
+        raise TrustsConfigurationError(
+            'Path filter builder %r on %s did not return a path-filter '
+            'predicate, got %r.' % (name, _model_label(root), result)
+        )
+    _phase1_validate(result, root)
+    return result
+
+
+def _walk_membership(node, visitor):
+    if isinstance(node, (PathAnd, PathOr, PathEq, PathNe)):
+        _walk_membership(node.left, visitor)
+        _walk_membership(node.right, visitor)
+        return
+    if isinstance(node, PathIn):
+        visitor(node)
+
+
+def bind_path_filter_permission(expr, permission_path, permission_model,
+                                permission_target):
+    """Phase 2: every ``.in_()`` left path equals normalized ``permission=``.
+
+    RHS target must equal that permission terminal. Mismatch raises;
+    the caller stores nothing.
+    """
+    from trusts.core import TrustsConfigurationError, _resolve_permission_in_path
+
+    permission_path = tuple(permission_path)
+    mismatches = []
+
+    def _check(node):
+        left = node.left
+        right = node.right
+        if tuple(left.path) != permission_path:
+            mismatches.append(
+                'in_() left path %s != permission= %s'
+                % (left.path, permission_path)
+            )
+            return
+        try:
+            _resolve_permission_in_path(
+                left.root, right.path, 'in_ right', permission_model,
+                permission_target=permission_target,
+            )
+        except TrustsConfigurationError as exc:
+            mismatches.append(str(exc))
+
+    _walk_membership(expr, _check)
+    if mismatches:
+        raise TrustsConfigurationError(
+            'Path filter does not bind to permission path %s: %s'
+            % (permission_path, '; '.join(mismatches))
+        )
+    return expr
+
+
+def canonical_ir(node):
+    """Stable IR blob for fingerprints. Name strings do not participate."""
+    if node is None:
+        return None
+    to_tuple = getattr(node, 'to_tuple', None)
+    if callable(to_tuple):
+        return to_tuple()
+    predicates = getattr(node, 'predicates', None)
+    if predicates is not None:
+        return ('all',) + tuple(canonical_ir(item) for item in predicates)
+    refs = getattr(node, 'refs', None)
+    if refs is not None:
+        return ('permission_in',) + tuple(
+            getattr(ref, '_path', getattr(ref, 'path', ref)) for ref in refs
+        )
+    left = getattr(node, 'left', None)
+    right = getattr(node, 'right', None)
+    if left is not None and right is not None:
+        kind = type(node).__name__.lower()
+        return (kind, canonical_ir(left), canonical_ir(right))
+    path = getattr(node, '_path', getattr(node, 'path', None))
+    if path is not None:
+        return ('ref', tuple(path))
+    return repr(node)
+
+
+def ir_digest(node):
+    """SHA-256 of the canonical IR. Not Python ``hash()``."""
+    blob = json.dumps(canonical_ir(node), sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode('utf-8')).hexdigest()
+
+
+def _along_identity(along):
+    if along is None:
+        return None
+    return (
+        along.bound,
+        along.shape,
+        tuple(along.walk_path),
+        getattr(getattr(along.walk_model, '_meta', None), 'label', None),
+        along.walk_ident,
+        along.walk_field,
+        tuple(along.suffix_path),
+        along.suffix_field,
+        along.ident_family,
+        along.parent_attname,
+        getattr(getattr(along.edge_model, '_meta', None), 'label', None),
+        along.edge_parent_attname,
+        along.edge_child_attname,
+        along.rewrite_attname,
+    )
+
+
+def registration_fingerprint(record, *, strategy=None):
+    """Canonical path-registration identity.
+
+    Includes normalized root + three bindings + resolved path-filter IR
+    + along / strategy. The path-filter **name** is diagnostic only and
+    is not part of this digest.
+    """
+    payload = {
+        'root': _model_label(getattr(record, 'root', None)),
+        'user': tuple(getattr(record, 'user_path', ()) or ()),
+        'permission': tuple(getattr(record, 'permission_path', ()) or ()),
+        'content': tuple(getattr(record, 'content_path', ()) or ()),
+        'along': _along_identity(getattr(record, 'along', None)),
+        'filter_ir': canonical_ir(getattr(record, 'condition', None)),
+        'strategy': None if strategy is None else getattr(
+            strategy, 'content_model', strategy
+        ) and _model_label(getattr(strategy, 'content_model', strategy)),
+    }
+    blob = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode('utf-8')).hexdigest()
+
+
+class PathFilterRecord(object):
+    """Named path-filter declaration: normalized IR only. Callable discarded."""
+
+    __slots__ = ('root', 'name', 'expr', 'digest')
+
+    def __init__(self, root, name, expr):
+        self.root = root
+        self.name = name
+        self.expr = expr
+        self.digest = ir_digest(expr)
+
+
+class FilterCatalogEntry(object):
+    """One declared named filter, including unused options."""
+
+    __slots__ = ('kind', 'model_label', 'name', 'digest', 'consumed')
+
+    def __init__(self, kind, model_label, name, digest, consumed):
+        self.kind = kind
+        self.model_label = model_label
+        self.name = name
+        self.digest = digest
+        self.consumed = consumed
+
+    def as_tuple(self):
+        return (self.kind, self.model_label, self.name, self.digest, self.consumed)
+
+    def __eq__(self, other):
+        if not isinstance(other, FilterCatalogEntry):
+            return NotImplemented
+        return self.as_tuple() == other.as_tuple()
+
+    def __repr__(self):
+        return 'FilterCatalogEntry%s' % (self.as_tuple(),)
+
+
+def build_filter_catalog(path_records, request_records, consumed_path_names):
+    """List every declared named filter. Unused names still appear."""
+    entries = []
+    for record in path_records:
+        key = (_model_key(record.root), record.name)
+        entries.append(FilterCatalogEntry(
+            'path',
+            _model_label(record.root),
+            record.name,
+            record.digest,
+            key in consumed_path_names,
+        ))
+    for model, name, record in request_records:
+        digest = ir_digest(getattr(record, 'expr', None))
+        entries.append(FilterCatalogEntry(
+            'request',
+            _model_label(model),
+            name,
+            digest,
+            False,
+        ))
+    entries.sort(key=lambda item: (item.kind, item.model_label, item.name))
+    return tuple(entries)

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -29,12 +29,16 @@ vendors fail closed before fold SQL. Import ``OrderedFold``,
 Import from ``trusts.core``. This slice does not re-export a process-global
 registry from ``trusts``. Generic compiler protocol, the default plan
 compiler, ``any_plan_records()``, ``granted()``, ``all_match()``,
-``common_permissions()``, ``filter_authorized_scopes()``,
+``common_permissions()``, ``filter_authorized_scopes()``, ``check()``,
 ``ConditionLookup``, and configuration/compiler exceptions live here.
 Permission-condition *records* live on each ``TrustsRegistry`` via
 ``trusts.conditions._ir.ConditionRegistry``. Construction self-binds
 the private store adapter; ``set_condition_lookup`` remains for
 tests and explicit unbind.
+
+Named path filters and request filters use separate typed stores
+(``register_path_filter`` / ``register_request_filter``). Request
+``filter=`` is a tuple of strings validated before any coercion.
 """
 
 from dataclasses import dataclass
@@ -174,7 +178,65 @@ def any_plan_records(handles, content):
     return False
 
 
-def granted(handles, candidates, user, permission, *, kind='complete'):
+def _request_filter_records(handle, content_model, names):
+    """Look up request-filter records on ``handle`` only. Never the path store."""
+    getter = getattr(handle.registry, 'get_request_filter_record', None)
+    if getter is None:
+        getter = getattr(
+            handle.registry, 'get_permission_condition_record', None,
+        )
+    found = []
+    missing = []
+    if not callable(getter):
+        return found, list(names)
+    for name in names:
+        record = getter(content_model, name)
+        if record is None:
+            missing.append(name)
+        else:
+            found.append((name, record))
+    return found, missing
+
+
+def _compile_request_filter_q(content_model, user, permission, found):
+    from trusts.conditions import PermissionConditionError
+    from trusts.conditions._ir import compile_expression_q
+
+    parts = []
+    for name, record in found:
+        if getattr(record, 'expr', None) is None:
+            raise PermissionConditionError(
+                'Request filter %r on %s is unbound.'
+                % (name, content_model._meta.label)
+            )
+        parts.append(
+            compile_expression_q(record.expr, content_model, user, permission)
+        )
+    if not parts:
+        return None
+    compiled = parts[0]
+    for part in parts[1:]:
+        compiled &= part
+    return compiled
+
+
+def _require_known_request_filters(handles, content_model, names):
+    """Unknown request names fail closed. Path-filter stores are not consulted."""
+    from trusts.conditions._ir import _unknown_condition_error
+
+    known = {name: False for name in names}
+    for handle in handles:
+        _found, missing = _request_filter_records(handle, content_model, names)
+        for name in names:
+            if name not in missing:
+                known[name] = True
+    for name in names:
+        if not known[name]:
+            raise _unknown_condition_error(content_model, name)
+
+
+def granted(handles, candidates, user, permission, *, kind='complete',
+            filter=()):
     """OR each applicable handle compiler's complete (or group) predicate.
 
     Noun-blind: this builder does not know Trust, Group, Guardian, or
@@ -185,7 +247,19 @@ def granted(handles, candidates, user, permission, *, kind='complete'):
     ``permission`` may be a permission instance or an unevaluated lookup
     (``Subquery`` / ``OuterRef``). Expressions are not passed to
     ``plan_for``; the plan is selected by content and user terminals.
+
+    Keyword-only ``filter`` is a ``tuple`` of request-filter names,
+    validated before any iteration or coercion. Names AND onto each
+    applicable handle predicate. Unknown names fail closed and never
+    yield the bare grant. A handle that lacks a selected name does not
+    contribute an unfiltered predicate.
     """
+    from trusts._filters import validate_request_filter_tuple
+
+    names = validate_request_filter_tuple(filter)
+    content_model = _content_model(candidates) if names else None
+    if names:
+        _require_known_request_filters(handles, content_model, names)
     parts = []
     for handle in handles:
         plan = _plan_for_permission(handle, candidates, user, permission)
@@ -196,6 +270,17 @@ def granted(handles, candidates, user, permission, *, kind='complete'):
         part = _as_q(fn(plan, candidates, user, permission))
         if part is None:
             continue
+        if names:
+            found, missing = _request_filter_records(
+                handle, content_model, names,
+            )
+            if missing:
+                continue
+            overlay = _compile_request_filter_q(
+                content_model, user, permission, found,
+            )
+            if overlay is not None:
+                part = part & overlay
         parts.append(part)
     if not parts:
         return None
@@ -251,7 +336,8 @@ def _scope_prefix_lookups(record, scope_model):
     return tuple(lookups)
 
 
-def filter_authorized_scopes(queryset, user, permission, *, content, handles=None):
+def filter_authorized_scopes(queryset, user, permission, *, content, handles=None,
+                             filter=()):
     """Filter scope-model rows that appear as a proper prefix of ``content``.
 
     Fail closed unless ``queryset.model`` is a proper prefix node of some
@@ -275,11 +361,14 @@ def filter_authorized_scopes(queryset, user, permission, *, content, handles=Non
     and does not use a compiler's historical group
     OR. Group-as-trustee remains a later registered root.
     """
+    from trusts._filters import validate_request_filter_tuple
+
     if not isinstance(queryset, QuerySet):
         raise TrustsConfigurationError(
             'filter_authorized_scopes requires a QuerySet, not %r.'
             % (queryset,)
         )
+    names = validate_request_filter_tuple(filter)
     user = _require_instance(user, 'user')
     permission = _require_instance(permission, 'permission')
     if handles is None:
@@ -287,6 +376,9 @@ def filter_authorized_scopes(queryset, user, permission, *, content, handles=Non
         handles = configured_implementation_handles()
     if not handles:
         return queryset.none()
+    content_model = _content_model(content)
+    if names:
+        _require_known_request_filters(handles, content_model, names)
 
     scope_model = queryset.model._meta.concrete_model
 
@@ -304,17 +396,39 @@ def filter_authorized_scopes(queryset, user, permission, *, content, handles=Non
     if not parts:
         return queryset.none()
     granted_q = parts[0] if len(parts) == 1 else reduce(or_, parts)
+    if names and queryset.model._meta.concrete_model is content_model:
+        overlays = []
+        for handle in handles:
+            found, missing = _request_filter_records(
+                handle, content_model, names,
+            )
+            if missing:
+                continue
+            overlay = _compile_request_filter_q(
+                content_model, user, permission, found,
+            )
+            if overlay is not None:
+                overlays.append(overlay)
+        if overlays:
+            extra = overlays[0]
+            for part in overlays[1:]:
+                extra = extra | part
+            granted_q = granted_q & extra
     return queryset.filter(granted_q).distinct()
 
 
-def all_match(handles, candidates, user, permission, *, kind='complete', extra_q=None):
+def all_match(handles, candidates, user, permission, *, kind='complete',
+              extra_q=None, filter=()):
     """True iff candidates are nonempty and no row lacks the aggregate proof.
 
     One SQL. ``None`` when no handle applies so the caller may use the
     undeclared fallback. ``extra_q`` is an optional overlay (AND); it
-    never creates a grant.
+    never creates a grant. Keyword-only ``filter`` is the request-name
+    tuple; it is validated before any coercion.
     """
-    granted_q = granted(handles, candidates, user, permission, kind=kind)
+    granted_q = granted(
+        handles, candidates, user, permission, kind=kind, filter=filter,
+    )
     if granted_q is None:
         return None
     if extra_q is not None:
@@ -327,17 +441,82 @@ def all_match(handles, candidates, user, permission, *, kind='complete', extra_q
     return stats['total'] > 0 and stats['lacking'] == 0
 
 
-def instance_match(handle, obj, user, permission, *, kind='complete', extra_q=None):
+def instance_match(handle, obj, user, permission, *, kind='complete',
+                   extra_q=None, filter=()):
     """One grant EXISTS for ``obj`` through ``handle`` only.
 
     ``None`` when the handle is inapplicable. ``extra_q`` is an optional
-    overlay (AND); it never creates a grant.
+    overlay (AND); it never creates a grant. Keyword-only ``filter`` is
+    the request-name tuple; it is validated before any coercion.
     """
-    granted_q = granted((handle,), obj, user, permission, kind=kind)
+    granted_q = granted(
+        (handle,), obj, user, permission, kind=kind, filter=filter,
+    )
     if granted_q is None:
         return None
     if extra_q is not None:
         granted_q = granted_q & extra_q
+    return obj._meta.concrete_model._default_manager.filter(
+        pk=obj.pk,
+    ).filter(granted_q).exists()
+
+
+def _check_permission_binding(permission):
+    """Resolve ``app_label.codename`` or a permission instance. No colon parse."""
+    from django.contrib.auth.models import Permission
+    from django.db.models import Subquery
+
+    if isinstance(permission, Model):
+        return permission
+    if not isinstance(permission, str) or '.' not in permission:
+        raise TrustsConfigurationError(
+            'permission must be app_label.codename or a permission instance, '
+            'not %r.' % (permission,)
+        )
+    applabel, codename = permission.split('.', 1)
+    return Subquery(
+        Permission.objects.filter(
+            content_type__app_label=applabel.lower(),
+            codename=codename,
+        ).values('pk')[:1]
+    )
+
+
+def check(user, permission, obj, filter=()):
+    """Trusts-only object checker. Not ModelBackend. Not superuser-True.
+
+    ``filter`` is keyword-compatible and may be positional after the
+    first three arguments. It is exactly ``tuple[str, ...]``. A bare
+    string, list, set, generator, or mapping is ``TypeError``.
+
+    Instance → one ``EXISTS``. Queryset → one ``all_match`` aggregate.
+    Inactive / anonymous deny. Unknown request names fail closed.
+    ``None`` from every handle is ``False``.
+    """
+    from trusts._filters import validate_request_filter_tuple
+    from trusts.query import is_active_principal
+
+    names = validate_request_filter_tuple(filter)
+    if not is_active_principal(user):
+        return False
+    if not isinstance(obj, (Model, QuerySet)):
+        return False
+    from trusts.apps import configured_implementation_handles
+
+    handles = configured_implementation_handles()
+    binding = _check_permission_binding(permission)
+    if isinstance(obj, QuerySet):
+        matched = all_match(
+            handles, obj, user, binding, kind='complete', filter=names,
+        )
+        if matched is None:
+            return False
+        return matched
+    granted_q = granted(
+        handles, obj, user, binding, kind='complete', filter=names,
+    )
+    if granted_q is None:
+        return False
     return obj._meta.concrete_model._default_manager.filter(
         pk=obj.pk,
     ).filter(granted_q).exists()
@@ -1052,8 +1231,12 @@ def _validate_permission_in(predicate, root, permission_model,
 def _validate_condition(condition, root, permission_model,
                         permission_target=None):
     """Registration-time ``_meta`` validation. Zero SQL. None is a no-op."""
+    from trusts._filters import is_path_filter_node
+
     if condition is None:
         return None
+    if is_path_filter_node(condition):
+        return condition
     if isinstance(condition, All):
         if not condition.predicates:
             raise TrustsConfigurationError(
@@ -1080,8 +1263,38 @@ def _validate_condition(condition, root, permission_model,
 
 
 def _compile_predicate(node, record):
+    from trusts._filters import PathAnd, PathEq, PathIn, PathNe, PathOr
+
     if node is None:
         return None
+    if isinstance(node, PathAnd):
+        left = _compile_predicate(node.left, record)
+        right = _compile_predicate(node.right, record)
+        if left is None:
+            return right
+        if right is None:
+            return left
+        return left & right
+    if isinstance(node, PathOr):
+        left = _compile_predicate(node.left, record)
+        right = _compile_predicate(node.right, record)
+        if left is None:
+            return right
+        if right is None:
+            return left
+        return left | right
+    if isinstance(node, PathEq):
+        return Q(**{
+            _lookup_text(node.left.path): F(_lookup_text(node.right.path)),
+        })
+    if isinstance(node, PathNe):
+        return ~Q(**{
+            _lookup_text(node.left.path): F(_lookup_text(node.right.path)),
+        })
+    if isinstance(node, PathIn):
+        return Q(**{
+            _lookup_text(node.right.path): F(record.permission_field),
+        })
     if isinstance(node, All):
         parts = [
             _compile_predicate(predicate, record)
@@ -2185,7 +2398,8 @@ class TrustsRegistry(object):
     models, or when the same bindings use a different closed condition.
 
         Frozen state is instance-owned. ``freeze()`` is idempotent.
-        ``register``, ``register_strategy``, and
+        ``register``, ``register_strategy``,
+        ``register_path_filter``, ``register_request_filter``, and
         ``register_permission_condition`` on that exact frozen instance
         raise ``TrustsConfigurationError`` before validation, builder
         invoke, or mutation. Existing records, plans, compilers, and
@@ -2206,6 +2420,9 @@ class TrustsRegistry(object):
         self._order = []
         self._strategies = {}
         self._strategy_order = []
+        self._path_filters = {}
+        self._path_filter_order = []
+        self._consumed_path_filters = set()
         self._frozen = False
         self._condition_lookup = None
         self.conditions = ConditionRegistry()
@@ -2242,27 +2459,117 @@ class TrustsRegistry(object):
         self._condition_lookup = lookup
 
     def register_permission_condition(self, model, cond_code, condition):
-        """Register a ``:cond_code`` condition on ``model`` for this instance.
+        """Unpublished forwarder onto ``register_request_filter``."""
+        return self.register_request_filter(model, cond_code, condition)
 
-        A callable is a registration-time builder. A frozen instance
-        raises ``TrustsConfigurationError`` before the builder is
-        invoked. A prebuilt ``Expr`` is rejected by the condition
-        store with ``TypeError`` before mutation.
+    def register_request_filter(self, content_model, name, builder):
+        """Register a request-selected filter on the exact content type.
+
+        Store key is ``(this registry, exact concrete content type, name)``.
+        Never consults the path-filter store. A frozen instance raises
+        before the builder is invoked. Duplicate names fail and leave
+        the store unchanged.
         """
+        from trusts._filters import validate_filter_name
+
         if self._frozen:
             raise TrustsConfigurationError(
-                'Cannot register a permission condition on a frozen '
+                'Cannot register a request filter on a frozen '
                 'TrustsRegistry.'
             )
+        name = validate_filter_name(name, role='request filter')
+        model = content_model
+        if _is_model_class(content_model):
+            model = content_model._meta.concrete_model
+        existing = self.conditions.get_permission_condition_record(model, name)
+        if existing is not None:
+            raise TrustsConfigurationError(
+                'Duplicate request filter %r for %s.'
+                % (name, model._meta.label if getattr(model, '_meta', None) else model)
+            )
         return self.conditions.register_permission_condition(
-            model, cond_code, condition,
+            model, name, builder,
         )
+
+    def register_path_filter(self, root_model, name, builder):
+        """Phase 1: declare a named path filter on the exact root type.
+
+        Freeze and duplicate ``(root, name)`` fail before the builder
+        runs. The callable is invoked once with typed ``r``, normalized,
+        and discarded. Never consults the request-filter store.
+        """
+        from trusts._filters import (
+            PathFilterRecord,
+            invoke_path_filter_builder,
+            validate_filter_name,
+        )
+
+        if self._frozen:
+            raise TrustsConfigurationError(
+                'Cannot register a path filter on a frozen TrustsRegistry.'
+            )
+        if isinstance(root_model, Ref):
+            raise TypeError(
+                'register_path_filter root must be a Django model class, '
+                'not a Ref.'
+            )
+        if not _is_model_class(root_model):
+            raise TrustsConfigurationError(
+                'register_path_filter root must be a Django model class, '
+                'not %r.' % (root_model,)
+            )
+        name = validate_filter_name(name, role='path filter')
+        root = root_model._meta.concrete_model
+        key = (root, name)
+        if key in self._path_filters:
+            raise TrustsConfigurationError(
+                'Duplicate path filter %r for %s.' % (name, root._meta.label)
+            )
+        if not callable(builder):
+            raise TypeError(
+                'register_path_filter expected a builder callable, '
+                'got %r.' % (type(builder).__name__,)
+            )
+        expr = invoke_path_filter_builder(builder, root, name)
+        record = PathFilterRecord(root, name, expr)
+        self._path_filters[key] = record
+        self._path_filter_order.append(record)
+        return record
+
+    def get_path_filter_record(self, root_model, name):
+        """Return the path-filter record for ``(root, name)``, or ``None``."""
+        if not _is_model_class(root_model):
+            return None
+        return self._path_filters.get((root_model._meta.concrete_model, name))
+
+    def get_request_filter_record(self, model, name):
+        """Return the request-filter record for ``(content, name)``, or ``None``.
+
+        Does not consult the path-filter store.
+        """
+        if _is_model_class(model):
+            model = model._meta.concrete_model
+        return self.conditions.get_permission_condition_record(model, name)
 
     def get_permission_condition_record(self, model, cond_code):
         """Return this instance's record for ``(model, cond_code)``, or ``None``."""
-        return self.conditions.get_permission_condition_record(
-            model, cond_code,
+        return self.get_request_filter_record(model, cond_code)
+
+    def filter_catalog(self):
+        """Declared named filters, including unused path and request names."""
+        from trusts._filters import build_filter_catalog
+
+        return build_filter_catalog(
+            tuple(self._path_filter_order),
+            tuple(self.iter_permission_conditions()),
+            set(self._consumed_path_filters),
         )
+
+    def record_fingerprint(self, record):
+        """Registration fingerprint: resolved path-filter IR, name diagnostic only."""
+        from trusts._filters import registration_fingerprint
+
+        return registration_fingerprint(record)
 
     def iter_permission_conditions(self):
         """Yield ``(model, cond_code, record)`` registered on this instance."""
@@ -2281,7 +2588,7 @@ class TrustsRegistry(object):
         )
 
     def freeze(self):
-        """Seal relation, strategy, and condition registration on this instance."""
+        """Seal relation, strategy, path-filter, and request-filter registration."""
         self._frozen = True
 
     @property
@@ -2304,7 +2611,8 @@ class TrustsRegistry(object):
                 'No registration for %r.' % (getattr(root, '__name__', root),)
             )
 
-    def register(self, *, content, user, permission, condition=None, along=None):
+    def register(self, *, content, user, permission, condition=None, along=None,
+                 filter=None):
         """Register one permission-bearing relation from root-relative refs.
 
         Exact duplicate normalized registration raises
@@ -2323,10 +2631,19 @@ class TrustsRegistry(object):
         ``Equal``, ``permission_in``) compiled as an AND overlay on the
         same root row. Validation uses ``_meta`` only (zero SQL).
 
+        Optional ``filter`` is a registered path-filter name (option B).
+        Phase 2 binds every ``.in_()`` left path to this registration's
+        normalized ``permission=``. Mismatch stores nothing.
+
         A frozen instance raises ``TrustsConfigurationError`` before
         validation or mutation. This method does not inspect Django's
         global ``apps.ready``.
         """
+        from trusts._filters import (
+            bind_path_filter_permission,
+            validate_path_filter_attach,
+        )
+
         if self._frozen:
             raise TrustsConfigurationError(
                 'Cannot register on a frozen TrustsRegistry.'
@@ -2334,6 +2651,11 @@ class TrustsRegistry(object):
         if along is not None and not isinstance(along, Along):
             raise TrustsConfigurationError(
                 'along must be an Along instance or None, not %r.' % (along,)
+            )
+        filter_name = validate_path_filter_attach(filter)
+        if filter_name is not None and condition is not None:
+            raise TypeError(
+                'register() cannot take both condition= and filter=.'
             )
 
         content_ref = _require_ref(content, 'content')
@@ -2367,6 +2689,17 @@ class TrustsRegistry(object):
         if along is not None:
             along_walk = _build_along_walk(
                 root, content_path, content_model, along,
+            )
+        if filter_name is not None:
+            named = self.get_path_filter_record(root, filter_name)
+            if named is None:
+                raise TrustsConfigurationError(
+                    'Unknown path filter %r for %s.'
+                    % (filter_name, root._meta.label)
+                )
+            condition = bind_path_filter_permission(
+                named.expr, permission_path, permission_model,
+                permission_target,
             )
         condition = _validate_condition(
             condition, root, permission_model,
@@ -2418,6 +2751,8 @@ class TrustsRegistry(object):
         else:
             self._by_root[root] = [record]
         self._order.append(record)
+        if filter_name is not None:
+            self._consumed_path_filters.add((root, filter_name))
         return record
 
     def register_strategy(self, strategy):
@@ -2528,20 +2863,40 @@ class TrustsRegistry(object):
             content, user=user, permission=permission,
         ).has_permission(user, content, permission)
 
-    def filter_authorized(self, queryset, user, permission):
+    def filter_authorized(self, queryset, user, permission, *, filter=()):
         """Lazy queryset of rows ``user`` holds ``permission`` on.
 
         Consumes ``RelationPlan.content_exists`` through ``filter_content``.
+        Keyword-only ``filter`` is the request-name tuple.
         """
+        from trusts._filters import validate_request_filter_tuple
+
         if not isinstance(queryset, QuerySet):
             raise TrustsConfigurationError(
                 'filter_authorized requires a QuerySet, not %r.' % (queryset,)
             )
+        names = validate_request_filter_tuple(filter)
         user = _require_instance(user, 'user')
         permission = _require_instance(permission, 'permission')
-        return self.plan_for(
+        qs = self.plan_for(
             queryset, user=user, permission=permission,
         ).filter_content(queryset, user, permission)
+        if not names:
+            return qs
+        content_model = queryset.model._meta.concrete_model
+        handle = BackendHandle(
+            path='<registry>', registry=self, compiler=PlanQueryCompiler(),
+        )
+        _require_known_request_filters((handle,), content_model, names)
+        found, missing = _request_filter_records(handle, content_model, names)
+        if missing:
+            return qs.none()
+        overlay = _compile_request_filter_q(
+            content_model, user, permission, found,
+        )
+        if overlay is None:
+            return qs
+        return qs.filter(overlay)
 
 
 def _public_path_segments(value, role, *, allow_empty=False):
@@ -2779,18 +3134,29 @@ class BackendHandle:
     compiler: object
 
     def register(self, root, *, user, permission, content, condition=None,
-                 along=None):
+                 along=None, filter=None, strategy=None):
         """Application API: register one AnyPath relation on this handle.
 
         Public paths are Django ``__`` strings. ``condition`` leaves are
         path strings on ``Equal`` / ``permission_in`` / ``All``. ``along``
-        is ``(path, bound)``. Passing a ``Ref`` is ``TypeError``. A frozen
-        handle raises ``TrustsConfigurationError`` before path parsing.
+        is ``(path, bound)``. ``filter`` is exactly one path-filter name
+        or omitted. Passing a ``Ref`` is ``TypeError``. Callable / tuple
+        / list / mapping ``filter`` is ``TypeError``. ``strategy=`` with
+        ``filter=`` is ``TypeError``. A frozen handle raises
+        ``TrustsConfigurationError`` before path parsing.
         """
+        from trusts._filters import validate_path_filter_attach
+
         if getattr(self.registry, 'frozen', False):
             raise TrustsConfigurationError(
                 'Cannot register on a frozen TrustsRegistry.'
             )
+        if strategy is not None:
+            raise TypeError(
+                'register(..., strategy=..., filter=...) is not supported; '
+                'OrderedFold has no source-row overlay.'
+            )
+        validate_path_filter_attach(filter)
         if isinstance(root, Ref):
             raise TypeError(
                 'register root must be a Django model class, not a Ref.'
@@ -2801,9 +3167,10 @@ class BackendHandle:
             permission=_public_ref(root, permission, 'permission'),
             condition=_bind_public_condition(condition, root),
             along=_bind_public_along(root, along),
+            filter=filter,
         )
 
-    def register_strategy(self, source_model, strategy=None):
+    def register_strategy(self, source_model, strategy=None, *, filter=None):
         """Application API: register one OrderedFold plan on this handle.
 
         The positional source model is required. Public ``content``,
@@ -2815,10 +3182,16 @@ class BackendHandle:
         ``member`` are independent model classes. Passing a ``Ref`` is
         ``TypeError``. A frozen handle raises
         ``TrustsConfigurationError`` before path parsing.
+        ``filter=`` is ``TypeError`` (OrderedFold has no source-row overlay).
         """
         if getattr(self.registry, 'frozen', False):
             raise TrustsConfigurationError(
                 'Cannot register on a frozen TrustsRegistry.'
+            )
+        if filter is not None:
+            raise TypeError(
+                'register_strategy(..., filter=...) is not supported; '
+                'OrderedFold has no source-row overlay.'
             )
         if strategy is None:
             raise TypeError(
@@ -2839,16 +3212,43 @@ class BackendHandle:
             _bind_public_ordered_fold(source_model, strategy),
         )
 
-    def register_permission_condition(self, model, code, builder):
-        """Application API: register a named condition on this handle.
+    def register_path_filter(self, root_model, name, builder):
+        """Application API: declare a named path filter on this handle.
 
-        Thin-forwards to the handle registry. A frozen/finalized handle
-        raises ``TrustsConfigurationError`` before a builder is invoked.
-        A prebuilt ``Expr`` is not accepted.
+        Builder is ``lambda r: ...``. Freeze raises before invoke.
+        Does not consult the request-filter store.
         """
-        return self.registry.register_permission_condition(
-            model, code, builder,
+        if getattr(self.registry, 'frozen', False):
+            raise TrustsConfigurationError(
+                'Cannot register a path filter on a frozen TrustsRegistry.'
+            )
+        return self.registry.register_path_filter(root_model, name, builder)
+
+    def register_request_filter(self, content_model, name, builder):
+        """Application API: declare a named request filter on this handle.
+
+        Builder is ``lambda u, p, o: ...``. Freeze raises before invoke.
+        Does not consult the path-filter store.
+        """
+        if getattr(self.registry, 'frozen', False):
+            raise TrustsConfigurationError(
+                'Cannot register a request filter on a frozen TrustsRegistry.'
+            )
+        return self.registry.register_request_filter(
+            content_model, name, builder,
         )
+
+    def register_permission_condition(self, model, code, builder):
+        """Unpublished forwarder onto ``register_request_filter``."""
+        return self.register_request_filter(model, code, builder)
+
+    def filter_catalog(self):
+        """Declared named filters on this handle, including unused names."""
+        return self.registry.filter_catalog()
+
+    def record_fingerprint(self, record):
+        """Registration fingerprint for a record stored on this handle."""
+        return self.registry.record_fingerprint(record)
 
     @property
     def historical_fallback(self):

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -27,13 +27,15 @@ class AuthorizedQuerySet(QuerySet):
     *codenames* raise ``TrustsConfigurationError`` with zero SQL. This
     method does not parse ``:condition``, does not call
     ``is_active_principal``, and does not call ``get_permission``.
+    Keyword-only ``filter`` is a request-name tuple validated before
+    any iteration or coercion.
 
     Callers that need Django inactivity checks or string permissions wrap
     this; they do not belong on this class. There is no ``.permitted`` and
     no ``.get_permission``.
     """
 
-    def authorized(self, user, permission, extra_q=None):
+    def authorized(self, user, permission, extra_q=None, *, filter=()):
         from trusts.apps import configured_implementation_handles
         from trusts.core import TrustsConfigurationError, granted
 
@@ -43,7 +45,7 @@ class AuthorizedQuerySet(QuerySet):
             )
         granted_q = granted(
             configured_implementation_handles(),
-            self, user, permission, kind='complete',
+            self, user, permission, kind='complete', filter=filter,
         )
         if granted_q is None:
             return self.none()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
C-unify @chatforthomas

Implements the accepted #131 r13 packet plus the identity-before-permission erratum, on Core only.

**Review target:** https://github.com/django-trusts/django-trusts/issues/131#issuecomment-5651175501  
**Errata:** https://github.com/django-trusts/django-trusts/issues/131#issuecomment-5651196493 · https://github.com/django-trusts/django-trusts/issues/131#issuecomment-5651197249  
**Baton:** https://github.com/django-trusts/django-trusts/pull/93#issuecomment-5651196425  
**Baseline:** Core `dev` `671c7624a32a292d72c47582b6afd8a319ccf040`

## In this PR
- Separate typed stores: `register_path_filter(root, name, builder)` and `register_request_filter(content, name, builder)`. No cross-store lookup, no arity guessing.
- Named-only path attach (`filter="name"`). Callable / tuple / list / mapping is `TypeError` (option B).
- Root proxy `r`: attribute traversal, `==` / `!=`, `&` / `|`; Python `and` / `or` / `in` fail loud; membership via `.in_()`.
- Private closed IR and r9 two-phase bind. Phase 2 requires every `.in_()` left path to equal normalized `permission=`; mismatch stores nothing.
- `register(..., strategy=..., filter=...)` remains `TypeError`.
- `trusts.check(user, permission, obj, filter=())` — Trusts handles only; no ModelBackend / superuser; no colon parse.
- Keyword-only `filter=tuple[str, ...]` on `authorized`, `granted`, `all_match`, `instance_match`, `filter_authorized_scopes`, `TrustsRegistry.filter_authorized`.
- Outer tuple validated before any iteration/coercion. Bare `str` / list / set / generator / mapping → `TypeError`.
- Path-filter IR is in the registration fingerprint (name diagnostic only). Request tuple is query identity (validate then sort). Unused named filters appear in the catalog.
- `register_permission_condition` remains a thin unpublished forwarder onto `register_request_filter`.
- Same-PR `migrates.md` with old/new rows and the r13 §10 search checklist.

## Not in this PR
- `require_authorization` / selectors / 404–403 table (#138)
- Removal of Core `permission_required` / `P` / Zero compat import
- Consumer conversions, W1, C-final/C2, docs/release, pin changes

Do not merge. Awaiting Chat review of the C-unify surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9630d76-9fdf-4586-a80e-fe3efed654c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9630d76-9fdf-4586-a80e-fe3efed654c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

