### PR TITLE
#160: drop transitional version framing from DEV.md

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -5,49 +5,44 @@ unsupported or superseded states. The user-facing package introduction
 is [README.md](README.md). `pyproject.toml` long-description metadata
 points at `README.md`, not this file.
 
-## Current pairing
+## Current architecture
 
-This tree is `django-trusts==1.0.0.dev3`, the final core-library cut
-([#112](https://github.com/django-trusts/django-trusts/pull/112)
-merge `11058641b533e0f8489598e0b1f5cbe5d42a81db`). That mark is a
-development-line identifier, not a production 1.0 release. See
-[docs/development-version.md](docs/development-version.md).
-
-The completed Zero user path is django-trusts-zero
-[#14](https://github.com/django-trusts/django-trusts-zero/pull/14)
-merge `f0b25c5562c4f9803d861503dd2acac21613119d`
-(`django-trusts-zero==1.0.0.dev0`).
+Historical django-trusts 0.x was the concrete Trust / Content / group
+implementation. Current django-trusts is the schema-neutral Core
+library. [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero)
+is the continuation and bridge for that historical concrete behavior.
+Package-version identity for this tree is recorded in
+[docs/development-version.md](docs/development-version.md), not here.
 
 Core is a Python dependency only: do **not** list `'trusts'` in
-`INSTALLED_APPS`. Final core ships no Django `AppConfig`, no
+`INSTALLED_APPS`. Current Core ships no Django `AppConfig`, no
 `kernel_config()`, and no `trusts.backends.TrustModelBackend`. The
 mixin stays at `trusts.backends.TrustModelBackendMixin`. Historical
 Trust / Content / settlor / trustee models and the concrete backend
 live only in `django-trusts-zero`.
 
-Pair CI pins the Zero #37 STAGE 1 destination
-`73b74b4213f6040f0e71c4c46d7a509804975672` so historical tests run
-from Zero `tests/legacy/`, not from core package paths.
+Pair CI runs historical tests from the pinned Zero companion
+`tests/legacy/`, not from core package paths. Exact companion pins
+are in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 ## What this package is not
 
 Earlier top-level README copy described django-trusts itself as a
 multiple-organization Trust/settlor/trustee add-on with concrete
-`Content` / `Group` models. That product description is false for this
-library after the final core cut. Readers who want that 0.x behavior
-should use [django-trusts-zero](https://github.com/django-trusts/django-trusts-zero).
+`Content` / `Group` models. That product description is false for
+current Core. Readers who want that 0.x behavior should use
+[django-trusts-zero](https://github.com/django-trusts/django-trusts-zero).
 
 ## Supported versions
 
-The `1.0.0.dev3` development line requires **Python 3.12–3.14** and
-**Django 6.1**. Sources checked on 2026-09-07 and the rationale are in
-[docs/support-matrix.md](docs/support-matrix.md).
+Supported Python, Django, and database versions are in
+[docs/support-matrix.md](docs/support-matrix.md). Exact test and
+companion pins are in CI and project metadata. User installation is
+in [README.md](README.md).
 
-This is not a published PyPI release. Install from a local checkout or
-sdist/wheel built from this tree.
+Install from a local checkout with current project metadata:
 
 ```
-python -m pip install "Django>=6.1,<6.2"
 python -m pip install .
 ```
 
@@ -63,14 +58,12 @@ AUTHENTICATION_BACKENDS = (
 )
 ```
 
-API and compatibility notes for this modernization are in
-[migrates.md](migrates.md).
+API and compatibility notes are in [migrates.md](migrates.md).
 
 ## Test
 
 ```
-python -m pip install "Django>=6.1,<6.2" coverage
-python -m pip install -e .
+python -m pip install -e ".[test]"
 python -m tests.runtests
 python -m django check --settings=tests.settings
 ```

--- a/tests/core/test_issue160.py
+++ b/tests/core/test_issue160.py
@@ -1,0 +1,62 @@
+"""#160: DEV.md must not reintroduce transitional dev-version framing."""
+
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class DevMdTransitionalFramingTest(SimpleTestCase):
+    def test_dev_md_is_0x_versus_current_without_dev_pins(self):
+        dev = (ROOT / 'DEV.md').read_text()
+        forbidden = (
+            '1.0.0.dev3',
+            '1.0.0.dev0',
+            'django-trusts==',
+            'django-trusts-zero==',
+            'STAGE 1',
+            'STAGE 2',
+            'STAGE 3',
+            'Stage I',
+            'Stage II',
+            'Stage III',
+            '11058641',
+            'f0b25c55',
+            '73b74b42',
+            'final core-library cut',
+            'final core cut',
+            'not a production 1.0',
+            'not a published PyPI release',
+            'not yet a published',
+            '1.0.0rc1',
+            'rc1',
+            'Python 3.12',
+            'Django 6.1',
+            'Django>=6.1',
+        )
+        offenders = [needle for needle in forbidden if needle in dev]
+        self.assertEqual(offenders, [])
+        self.assertNotRegex(dev, r'(?i)\b1\.0\.0\b')
+        self.assertIn('0.x', dev)
+        self.assertIn('schema-neutral Core', dev)
+        self.assertIn('django-trusts-zero', dev)
+        self.assertIn("do **not** list `'trusts'` in", dev)
+        self.assertIn('INSTALLED_APPS', dev)
+        self.assertIn('no Django `AppConfig`', dev)
+        self.assertIn('docs/support-matrix.md', dev)
+        self.assertIn('.github/workflows/ci.yml', dev)
+        self.assertIn('README.md', dev)
+        self.assertIn('migrates.md', dev)
+        self.assertIn('docs/legacy-baseline.md', dev)
+        self.assertIn('python -m pip install .', dev)
+        self.assertIn('python -m pip install -e ".[test]"', dev)
+        self.assertIn('python -m tests.runtests', dev)
+        self.assertIn('python -m django check --settings=tests.settings', dev)
+        self.assertTrue((ROOT / 'docs' / 'support-matrix.md').is_file())
+        self.assertTrue((ROOT / 'docs' / 'legacy-baseline.md').is_file())
+        self.assertTrue((ROOT / 'docs' / 'development-version.md').is_file())
+        self.assertTrue((ROOT / 'README.md').is_file())
+        self.assertTrue((ROOT / 'migrates.md').is_file())
+        self.assertTrue((ROOT / '.github' / 'workflows' / 'ci.yml').is_file())

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -42,6 +42,7 @@ KERNEL_SUITE = [
     'tests.core.test_issue129',
     'tests.core.test_issue131',
     'tests.core.test_issue151',
+    'tests.core.test_issue160',
 ]
 
 # Kernel modules that remain valid against an installed Zero owner.
@@ -72,6 +73,7 @@ PAIR_KERNEL_SUITE = [
     'tests.core.test_issue129',
     'tests.core.test_issue131',
     'tests.core.test_issue151',
+    'tests.core.test_issue160',
 ]
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#160 @chatforthomas

Bounded shallow `DEV.md` pass from Core `dev` `671c7624`.

**In this PR**
- Durable 0.x versus current Core / Zero boundary; Core remains not an `INSTALLED_APPS` Django app
- Removed `1.0.0.dev3` / `1.0.0.dev0`, pairing SHAs, Stage language, and stale “not a production 1.0” prose
- No replacement package version; pins live in `docs/support-matrix.md`, CI, and project extras
- Contributor tests use `pip install -e ".[test]"` plus the existing runner/check commands
- Focused regression in `tests/core/test_issue160.py`

**Not in this PR:** README (#159), migrates (#152), SECURITY_AUDIT (#146), API/CI/dependency changes, broader DEV rewrite.

No `migrates.md` entry (documentation-only). Head: `ae85a9fe76a401518dce61d77d20b81eeecb026a`.

No merge until you say so.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

