### PR TITLE
#131 C-unify: fold register_strategy into register(..., strategy=)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -171,6 +171,10 @@ Register the model paths when the application starts:
 ``__`` relationship paths identify the user, permission, and protected
 content associated with each row.
 
+The same ``register`` verb donates an OrderedFold plan as
+``handle.register(Ace, strategy=OrderedFold(...))``. AnyPath arguments
+and ``strategy=`` are mutually exclusive.
+
 The declaration is validated when it is registered. Invalid or unsupported
 paths raise a configuration error instead of becoming an authorization rule.
 

--- a/migrates.md
+++ b/migrates.md
@@ -34,11 +34,12 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
 2. Provide `TrustsImplementationConfig` and a backend that subclasses
    `TrustModelBackendMixin`. Call `super().ready()`.
 3. Register protected models through `handle.register(root, user=...,
-   permission=..., content=...)`, ordered strategies through
-   `handle.register_strategy(source_model, OrderedFold(...))`, and
+   permission=..., content=...)` or ordered strategies through
+   `handle.register(source_model, strategy=OrderedFold(...))`, and
    named-condition **builders** through
    `handle.register_permission_condition` in `AppConfig.ready()` before
-   finalization.
+   finalization. AnyPath arguments and `strategy=` are mutually
+   exclusive.
 4. Import only the six public `trusts.conditions` names:
    `PermissionConditionBooleanError`, `PermissionConditionError`,
    `PermissionConditionNotQueryable`, `PermissionConditionUnsupported`,
@@ -58,14 +59,15 @@ The 1.x runtime requires Python 3.12–3.14 and Django 6.1.
 | Relation register | `from trusts.core import Ref` + `handle.registry.register(content=j.document, ...)` | `handle.register(DocumentGrant, user="user", permission="permission", content="document")` |
 | Along | `along=Along(j.parent, 8)` | `along=("parent", 8)` |
 | Closed condition | `Equal(t.team.organization, t.repository.organization)` | `Equal("team__organization", "repository__organization")` |
-| OrderedFold | `.registry.register_strategy(OrderedFold(...Ref...))` | `handle.register_strategy(Ace, OrderedFold(content="document", descriptor="", order="ace_order", polarity=PolarityMap("ace_type", allow_value=ALLOW, deny_value=DENY), mask="access_mask", trustee="user", token=FlatToken(principal=User, principal_user="", principal_identity=""), domain=PermissionMaskDomain(Permission, masks)))` |
+| OrderedFold | `.registry.register_strategy(OrderedFold(...Ref...))` or `handle.register_strategy(Ace, OrderedFold(...))` | `handle.register(Ace, strategy=OrderedFold(content="document", descriptor="", order="ace_order", polarity=PolarityMap("ace_type", allow_value=ALLOW, deny_value=DENY), mask="access_mask", trustee="user", token=FlatToken(principal=User, principal_user="", principal_identity=""), domain=PermissionMaskDomain(Permission, masks)))` |
 
 `handle.registry` remains temporarily so unconverted consumers still
-compile. `handle.register_strategy` is the public OrderedFold entry.
-The positional source model is required; do not call
-`register_strategy(OrderedFold(...))` without that root. A non-empty
-`descriptor` is content-relative; the derived source descriptor is the
-content path plus those segments (`content="node"`,
+compile. `handle.register(..., strategy=)` is the public OrderedFold
+entry. The positional source model is required; do not call
+`register(strategy=OrderedFold(...))` without that root. There is no
+public `register_strategy` alias. A non-empty `descriptor` is
+content-relative; the derived source descriptor is the content path
+plus those segments (`content="node"`,
 `descriptor="security_descriptor"` → internal
 `Ace.node.security_descriptor`).
 
@@ -77,6 +79,7 @@ Migration-bot search list:
 - `.registry.register_strategy(`
 - `Along(`
 - `OrderedFold(`
+- `register_strategy(`
 - `register_strategy(OrderedFold`
 
 This file is the Core 1.x router only. It does not document concrete

--- a/tests/core/test_issue122.py
+++ b/tests/core/test_issue122.py
@@ -85,9 +85,10 @@ class FinalDocumentationSurfaceTest(SimpleTestCase):
         self.assertIn('.registry.register_strategy(', text)
         self.assertIn('Along(', text)
         self.assertIn('OrderedFold(', text)
+        self.assertIn('register_strategy(', text)
         self.assertIn('register_strategy(OrderedFold', text)
         self.assertIn('handle.register(DocumentGrant', text)
-        self.assertIn('handle.register_strategy(Ace, OrderedFold(', text)
+        self.assertIn('handle.register(Ace, strategy=OrderedFold(', text)
         self.assertIn('## Archaeology', text)
         self.assertIn(
             'https://github.com/django-trusts/django-trusts-zero/blob/dev/migrates.md',

--- a/tests/core/test_issue131.py
+++ b/tests/core/test_issue131.py
@@ -1,9 +1,9 @@
-"""#131 C1 / C1-fold: BackendHandle public AnyPath and OrderedFold APIs.
+"""#131 C1 / C-unify: BackendHandle public AnyPath and OrderedFold APIs.
 
 Handle-bound Django ``__`` paths, string condition leaves,
-``along=(path, bound)``, and ``register_strategy(source_model,
-OrderedFold(...))``. ``Ref`` input is TypeError. Freeze raises before
-path resolution. Dual handles stay isolated. Internal
+``along=(path, bound)``, and ``register(source_model,
+strategy=OrderedFold(...))``. ``Ref`` input is TypeError. Freeze
+raises before path resolution. Dual handles stay isolated. Internal
 ``TrustsRegistry.register(Ref)`` and ``register_strategy(OrderedFold)``
 remain for compiler tests.
 """
@@ -51,12 +51,12 @@ def _handle(registry=None, path='tests.core.handle-a'):
 
 
 class HandleRegisterSurfaceTest(SimpleTestCase):
-    def test_register_and_register_strategy_are_handle_methods(self):
+    def test_register_is_the_public_donation_verb(self):
         handle = _handle()
         self.assertTrue(hasattr(BackendHandle, 'register'))
-        self.assertTrue(hasattr(BackendHandle, 'register_strategy'))
+        self.assertFalse(hasattr(BackendHandle, 'register_strategy'))
         self.assertTrue(hasattr(handle, 'register'))
-        self.assertTrue(hasattr(handle, 'register_strategy'))
+        self.assertFalse(hasattr(handle, 'register_strategy'))
         self.assertTrue(hasattr(handle.registry, 'register'))
         self.assertTrue(hasattr(handle.registry, 'register_strategy'))
 
@@ -340,7 +340,31 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
         handle = _handle()
         strategy = _public_direct_fold(Ace, Permission, Document)
         with self.assertRaises(TypeError):
-            handle.register_strategy(strategy)
+            handle.register(strategy=strategy)
+        self.assertEqual(handle.registry.strategies, ())
+
+    def test_anypath_and_strategy_are_mutually_exclusive(self):
+        Permission, Document, Ace = _direct_models()
+        handle = _handle()
+        strategy = _public_direct_fold(Ace, Permission, Document)
+        with self.assertRaises(TypeError):
+            handle.register(
+                Ace,
+                user='user',
+                permission='permission',
+                content='document',
+                strategy=strategy,
+            )
+        with self.assertRaises(TypeError):
+            handle.register(Ace, along=('document', 8), strategy=strategy)
+        self.assertEqual(handle.registry.strategies, ())
+        self.assertEqual(handle.registry.records, ())
+
+    def test_incomplete_anypath_is_type_error(self):
+        handle = _handle()
+        with self.assertRaises(TypeError):
+            handle.register(DocumentGrant, user='user')
+        self.assertEqual(handle.registry.records, ())
         self.assertEqual(handle.registry.strategies, ())
 
     def test_string_strategy_matches_internal_ref_record(self):
@@ -348,8 +372,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
         via_ref = TrustsRegistry()
         expected = _register_direct(via_ref, Ace, Permission, Document)
         handle = _handle()
-        compiled = handle.register_strategy(
-            Ace, _public_direct_fold(Ace, Permission, Document),
+        compiled = handle.register(Ace, strategy=_public_direct_fold(Ace, Permission, Document),
         )
         self.assertEqual(compiled, expected)
         self.assertIs(compiled.content_model, Document)
@@ -364,11 +387,10 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
         doc = Ref(Document)
         user = Ref(get_user_model())
         with self.assertRaises(TypeError):
-            handle.register_strategy(
-                ace, _public_direct_fold(Ace, Permission, Document),
+            handle.register(ace, strategy=_public_direct_fold(Ace, Permission, Document),
             )
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content=doc,
                 descriptor='',
                 order='ace_order',
@@ -383,7 +405,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
                 domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
             ))
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='document',
                 descriptor='',
                 source=ace,
@@ -400,7 +422,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
                 domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
             ))
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='document',
                 descriptor='',
                 order='ace_order',
@@ -415,7 +437,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
                 domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
             ))
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='document',
                 descriptor='',
                 order='ace_order',
@@ -446,7 +468,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
         ):
             with self.subTest(path=path):
                 with self.assertRaises(TrustsConfigurationError):
-                    handle.register_strategy(Ace, OrderedFold(
+                    handle.register(Ace, strategy=OrderedFold(
                         content=path,
                         descriptor='',
                         order='ace_order',
@@ -519,7 +541,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
             domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
         ))
         handle = _handle()
-        compiled = handle.register_strategy(Ace, OrderedFold(
+        compiled = handle.register(Ace, strategy=OrderedFold(
             content='node',
             descriptor='security_descriptor',
             order='ace_order',
@@ -546,7 +568,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
         Permission, Document, Ace = _direct_models()
         handle = _handle()
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='document',
                 descriptor='',
                 order='ace_order',
@@ -570,7 +592,7 @@ class HandleRegisterStrategySurfaceTest(SimpleTestCase):
                 app_label = 'trusts_tests'
 
         with self.assertRaises(TypeError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='document',
                 descriptor='',
                 order='ace_order',
@@ -714,7 +736,7 @@ class HandleRegisterStrategyTokenTest(SimpleTestCase):
             domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
         ))
         handle = _handle()
-        compiled = handle.register_strategy(Ace, OrderedFold(
+        compiled = handle.register(Ace, strategy=OrderedFold(
             content='wrapper__document',
             descriptor='',
             order='ace_order',
@@ -745,7 +767,7 @@ class HandleRegisterStrategyTokenTest(SimpleTestCase):
         )
         handle = _handle()
         with self.assertRaises(TrustsConfigurationError):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='wrapper__document',
                 descriptor='',
                 order='ace_order',
@@ -770,7 +792,7 @@ class HandleRegisterStrategyTokenTest(SimpleTestCase):
         )
         handle = _handle()
         with self.assertRaisesRegex(TrustsConfigurationError, r'member triad'):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='wrapper__document',
                 descriptor='',
                 order='ace_order',
@@ -786,7 +808,7 @@ class HandleRegisterStrategyTokenTest(SimpleTestCase):
                 domain=PermissionMaskDomain(Permission, (MaskEntry('read', 1),)),
             ))
         with self.assertRaisesRegex(TrustsConfigurationError, r'member triad'):
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='wrapper__document',
                 descriptor='',
                 order='ace_order',
@@ -829,9 +851,7 @@ class HandleRegisterStrategyFreezeTest(SimpleTestCase):
                         wraps=validate_ordered_fold,
                     ) as validate:
                         with self.assertRaises(TrustsConfigurationError) as ctx:
-                            handle.register_strategy(
-                                Ace,
-                                _public_direct_fold(Ace, Permission, Document),
+                            handle.register(Ace, strategy=_public_direct_fold(Ace, Permission, Document),
                             )
         self.assertIn('frozen', str(ctx.exception).lower())
         segments.assert_not_called()
@@ -846,7 +866,7 @@ class HandleRegisterStrategyFreezeTest(SimpleTestCase):
         handle = _handle(registry)
         registry.freeze()
         with self.assertRaises(TrustsConfigurationError) as ctx:
-            handle.register_strategy(Ace, OrderedFold(
+            handle.register(Ace, strategy=OrderedFold(
                 content='',
                 descriptor='',
                 order='ace_order',
@@ -870,13 +890,11 @@ class HandleRegisterStrategyIsolationTest(SimpleTestCase):
         Permission, Document, Ace = _direct_models()
         left = _handle(path='tests.core.fold-left')
         right = _handle(path='tests.core.fold-right')
-        left.register_strategy(
-            Ace, _public_direct_fold(Ace, Permission, Document),
+        left.register(Ace, strategy=_public_direct_fold(Ace, Permission, Document),
         )
         self.assertEqual(len(left.registry.strategies), 1)
         self.assertEqual(right.registry.strategies, ())
-        right.register_strategy(
-            Ace, _public_direct_fold(Ace, Permission, Document),
+        right.register(Ace, strategy=_public_direct_fold(Ace, Permission, Document),
         )
         self.assertEqual(len(left.registry.strategies), 1)
         self.assertEqual(len(right.registry.strategies), 1)

--- a/trusts/core.py
+++ b/trusts/core.py
@@ -18,10 +18,11 @@ exactly one terminal M2M membership hop after zero or more forward
 single-valued hops. Validation is registration-time ``_meta`` only
 (zero SQL).
 
-``handle.register_strategy(source_model, OrderedFold(...))`` is a
+``handle.register(source_model, strategy=OrderedFold(...))`` is the
 parallel closed family. Ordinary ``handle.register()`` stays the
-AnyPath ``EXISTS`` fast path. One content terminal may use AnyPath xor
-one OrderedFold. The first OrderedFold renderer is PostgreSQL; other
+AnyPath ``EXISTS`` fast path. AnyPath arguments and ``strategy=`` are
+mutually exclusive. One content terminal may use AnyPath xor one
+OrderedFold. The first OrderedFold renderer is PostgreSQL; other
 vendors fail closed before fold SQL. Import ``OrderedFold``,
 ``PermissionMaskDomain``, ``MaskEntry``, ``PolarityMap``, and
 ``FlatToken`` from ``trusts.core``.
@@ -2686,14 +2687,15 @@ def _bind_public_ordered_fold(source_model, strategy):
 
     if not isinstance(strategy, OrderedFold):
         raise TrustsConfigurationError(
-            'register_strategy requires OrderedFold, not %r.' % (strategy,)
+            'register(..., strategy=) requires OrderedFold, not %r.'
+            % (strategy,)
         )
     if isinstance(strategy.source, Ref) or isinstance(
         strategy.source_descriptor, Ref,
     ):
         raise TypeError(
-            'register_strategy does not accept Ref fields; pass Django '
-            'path strings.'
+            'register(..., strategy=) does not accept Ref fields; pass '
+            'Django path strings.'
         )
     if strategy.source is not None or strategy.source_descriptor is not None:
         raise TrustsConfigurationError(
@@ -2770,6 +2772,9 @@ def _bind_public_along(root, along):
     return Along(_public_ref(root, path, 'along'), bound)
 
 
+_UNSET = object()
+
+
 @dataclass(frozen=True, slots=True)
 class BackendHandle:
     """Exact configured path, exact registry identity, and class compiler."""
@@ -2778,14 +2783,26 @@ class BackendHandle:
     registry: object
     compiler: object
 
-    def register(self, root, *, user, permission, content, condition=None,
-                 along=None):
-        """Application API: register one AnyPath relation on this handle.
+    def register(self, root, *, user=_UNSET, permission=_UNSET, content=_UNSET,
+                 condition=_UNSET, along=_UNSET, strategy=_UNSET):
+        """Application API: donate one permission policy on this handle.
 
-        Public paths are Django ``__`` strings. ``condition`` leaves are
-        path strings on ``Equal`` / ``permission_in`` / ``All``. ``along``
-        is ``(path, bound)``. Passing a ``Ref`` is ``TypeError``. A frozen
-        handle raises ``TrustsConfigurationError`` before path parsing.
+        AnyPath form: Django ``__`` strings for ``user`` / ``permission``
+        / ``content``. ``condition`` leaves are path strings on
+        ``Equal`` / ``permission_in`` / ``All``. ``along`` is
+        ``(path, bound)``.
+
+        OrderedFold form: ``register(source_model, strategy=OrderedFold(...))``.
+        Public ``content``, ``order``, ``mask``, ``trustee``, and
+        ``PolarityMap.field`` are Django ``__`` paths on that source.
+        ``descriptor`` is a path on the content terminal and may be
+        ``""``. ``FlatToken.principal`` and optional ``member`` are
+        independent model classes.
+
+        AnyPath arguments and ``strategy=`` are mutually exclusive.
+        Passing a ``Ref`` is ``TypeError``. A frozen handle raises
+        ``TrustsConfigurationError`` before path parsing. Mixed or
+        incomplete forms raise before mutation.
         """
         if getattr(self.registry, 'frozen', False):
             raise TrustsConfigurationError(
@@ -2795,48 +2812,38 @@ class BackendHandle:
             raise TypeError(
                 'register root must be a Django model class, not a Ref.'
             )
+        anypath_supplied = any(
+            value is not _UNSET
+            for value in (user, permission, content, condition, along)
+        )
+        if strategy is not _UNSET and anypath_supplied:
+            raise TypeError(
+                'register() accepts AnyPath arguments or strategy=, not both.'
+            )
+        if strategy is not _UNSET:
+            if not _is_model_class(root):
+                raise TrustsConfigurationError(
+                    'register(..., strategy=) source must be a Django '
+                    'model class, not %r.' % (root,)
+                )
+            return self.registry.register_strategy(
+                _bind_public_ordered_fold(root, strategy),
+            )
+        if user is _UNSET or permission is _UNSET or content is _UNSET:
+            raise TypeError(
+                'register() requires user=, permission=, and content=, '
+                'or strategy=.'
+            )
+        if condition is _UNSET:
+            condition = None
+        if along is _UNSET:
+            along = None
         return self.registry.register(
             content=_public_ref(root, content, 'content'),
             user=_public_ref(root, user, 'user'),
             permission=_public_ref(root, permission, 'permission'),
             condition=_bind_public_condition(condition, root),
             along=_bind_public_along(root, along),
-        )
-
-    def register_strategy(self, source_model, strategy=None):
-        """Application API: register one OrderedFold plan on this handle.
-
-        The positional source model is required. Public ``content``,
-        ``order``, ``mask``, ``trustee``, and ``PolarityMap.field`` are
-        Django ``__`` paths on that source. ``content`` supplies the
-        content terminal. ``descriptor`` is a path on that terminal and
-        may be ``""``; the derived source descriptor is the content
-        path plus those segments. ``FlatToken.principal`` and optional
-        ``member`` are independent model classes. Passing a ``Ref`` is
-        ``TypeError``. A frozen handle raises
-        ``TrustsConfigurationError`` before path parsing.
-        """
-        if getattr(self.registry, 'frozen', False):
-            raise TrustsConfigurationError(
-                'Cannot register on a frozen TrustsRegistry.'
-            )
-        if strategy is None:
-            raise TypeError(
-                'register_strategy requires (source_model, OrderedFold); '
-                'the no-root form is not supported.'
-            )
-        if isinstance(source_model, Ref):
-            raise TypeError(
-                'register_strategy source must be a Django model class, '
-                'not a Ref.'
-            )
-        if not _is_model_class(source_model):
-            raise TrustsConfigurationError(
-                'register_strategy source must be a Django model class, '
-                'not %r.' % (source_model,)
-            )
-        return self.registry.register_strategy(
-            _bind_public_ordered_fold(source_model, strategy),
         )
 
     def register_permission_condition(self, model, code, builder):

--- a/trusts/ordered_fold.py
+++ b/trusts/ordered_fold.py
@@ -99,7 +99,7 @@ class FlatToken:
 class OrderedFold:
     """Closed typed remaining-bits strategy for one content terminal.
 
-    ``BackendHandle.register_strategy(source_model, OrderedFold(...))``
+    ``BackendHandle.register(source_model, strategy=OrderedFold(...))``
     derives ``source`` from the positional source model and
     ``source_descriptor`` from the public ``content`` path plus the
     content-relative ``descriptor`` segments (empty ``descriptor``


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
C-unify @chatforthomas

Implements only the one public donation verb from https://github.com/django-trusts/django-trusts/issues/131#issuecomment-5652086570 on Core `dev` `7f298153f9a9b66c8a9904bfec41b472779d9bc4`.

```python
backend.register(Grant, user="user", permission="permission", content="document", condition=..., along=...)
backend.register(WinAce, strategy=OrderedFold(...))
```

**In this PR**
- Fold public `register_strategy(source_model, strategy)` into `register(source_model, *, strategy=...)`
- AnyPath arguments and `strategy=` are mutually exclusive; mixed/incomplete forms fail before mutation
- Remove the public `register_strategy` alias; `TrustsRegistry.register_strategy` stays internal
- `register_permission_condition` unchanged
- RST/docstrings, `migrates.md`, and handle-surface regressions updated

**Not in this PR:** decorators, P/K/G/O, request filters, colon transport, registration names/manifests, consumers, README, security guide, coverage, W1, `.registry` privacy.

Local `KERNEL_SUITE` green (404 tests, 13 skipped). Head: `cfe5a2bfd6d65aab0b493dea43f166f493b27d61`.

No merge until you say so.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e645d7f-996f-45ab-b4fe-f422d7c0a6cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

